### PR TITLE
Fix issue with negative epoch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysdmx"
-version = "1.0.0-beta-2"
+version = "1.0.0-beta-3"
 description = "Your opinionated Python SDMX library"
 authors = [
     "Xavier Sosnovsky <xavier.sosnovsky@bis.org>",

--- a/src/pysdmx/__init__.py
+++ b/src/pysdmx/__init__.py
@@ -1,3 +1,3 @@
 """Your opinionated Python SDMX library."""
 
-__version__ = "1.0.0-beta-2"
+__version__ = "1.0.0-beta-3"

--- a/tests/fmr/hierarchy_checks.py
+++ b/tests/fmr/hierarchy_checks.py
@@ -84,7 +84,7 @@ def check_hcode_details(mock, fmr: RegistryClient, query, body):
                     for chld in c.codes:
                         if chld.id == "Li":
                             assert chld.rel_valid_from == datetime(
-                                2020, 1, 1, tzinfo=timezone.utc
+                                1920, 1, 1, tzinfo=timezone.utc
                             )
                             assert chld.rel_valid_to == datetime(
                                 2020, 12, 31, 23, 59, 59, tzinfo=timezone.utc

--- a/tests/fmr/samples/code/hier.fusion.json
+++ b/tests/fmr/samples/code/hier.fusion.json
@@ -272,7 +272,7 @@
                                     "id": "M0_Li",
                                     "urn": "urn:sdmx:org.sdmx.infomodel.codelist.HierarchicalCode=TEST:HCL_ELEMENT(1.0).Ze33.M1.M0_Li",
                                     "code": "urn:sdmx:org.sdmx.infomodel.codelist.Code=TEST:CL_PERIODIC_TABLE(1.0).Li",
-                                    "validFrom": 1577836800000,
+                                    "validFrom": -1577923200000,
                                     "validTo": 1609459199000
                                 },
                                 {

--- a/tests/fmr/samples/code/hier.json
+++ b/tests/fmr/samples/code/hier.json
@@ -409,7 +409,7 @@
                                             }
                                         ],
                                         "id": "M0_Li",
-                                        "validFrom": "2020-01-01T00:00:00",
+                                        "validFrom": "1920-01-01T00:00:00",
                                         "validTo": "2020-12-31T23:59:59",
                                         "code": "urn:sdmx:org.sdmx.infomodel.codelist.Code=TEST:CL_PERIODIC_TABLE(1.0).Li"
                                     },


### PR DESCRIPTION
There is a bug affecting the conversion of negative UNIX timestamps (i.e. dates before 1970-01-01) when deserializing fusion-json payloads.

The purpose of this PR is to fix this issue.