### PR TITLE
Get reference metadata reports for a structure

### DIFF
--- a/src/pysdmx/fmr/__init__.py
+++ b/src/pysdmx/fmr/__init__.py
@@ -79,6 +79,7 @@ url_templates = {
     ),
     "provider": "structure/dataproviderscheme/{0}?references={1}",
     "report": "metadata/metadataset/{0}/{1}/{2}",
+    "reports": "metadata/structure/{0}/{1}/{2}/{3}",
     "schema": "schema/{0}/{1}/{2}/{3}",
     "vl": "structure/valuelist/{0}/{1}/{2}",
 }
@@ -427,6 +428,32 @@ class RegistryClient(__BaseRegistryClient):
         out = self.__fetch(super()._url("report", provider, id, version), True)
         return super()._out(out, self.deser.report)
 
+    def get_reports(
+        self,
+        artefact_type: str,
+        agency: str,
+        id: str,
+        version: str = "+",
+    ) -> Sequence[MetadataReport]:
+        """Get the reference metadata reports for the supplied structure.
+
+        Args:
+            artefact_type: The type of the structure for which reports must
+                be returned.
+            agency: The agency maintaining the hierarchy for which reports
+                must be returned.
+            id: The ID of the structure for which reports must be returned.
+            version: The version of the structure for which reports must be
+                returned.
+
+        Returns:
+            The metadata reports about the supplied structure.
+        """
+        out = self.__fetch(
+            super()._url("reports", artefact_type, agency, id, version), True
+        )
+        return super()._out(out, self.deser.report, True)
+
     def get_mapping(
         self,
         agency: str,
@@ -735,6 +762,32 @@ class AsyncRegistryClient(__BaseRegistryClient):
             super()._url("report", provider, id, version), True
         )
         return super()._out(out, self.deser.report)
+
+    async def get_reports(
+        self,
+        artefact_type: str,
+        agency: str,
+        id: str,
+        version: str = "+",
+    ) -> Sequence[MetadataReport]:
+        """Get the reference metadata reports for the supplied structure.
+
+        Args:
+            artefact_type: The type of the structure for which reports must
+                be returned.
+            agency: The agency maintaining the hierarchy for which reports
+                must be returned.
+            id: The ID of the structure for which reports must be returned.
+            version: The version of the structure for which reports must be
+                returned.
+
+        Returns:
+            The metadata reports about the supplied structure.
+        """
+        out = await self.__fetch(
+            super()._url("reports", artefact_type, agency, id, version), True
+        )
+        return super()._out(out, self.deser.report, True)
 
     async def get_mapping(
         self,

--- a/src/pysdmx/fmr/__init__.py
+++ b/src/pysdmx/fmr/__init__.py
@@ -426,7 +426,7 @@ class RegistryClient(__BaseRegistryClient):
             The requested metadata report.
         """
         out = self.__fetch(super()._url("report", provider, id, version), True)
-        return super()._out(out, self.deser.report)
+        return super()._out(out, self.deser.report)[0]
 
     def get_reports(
         self,
@@ -761,7 +761,7 @@ class AsyncRegistryClient(__BaseRegistryClient):
         out = await self.__fetch(
             super()._url("report", provider, id, version), True
         )
-        return super()._out(out, self.deser.report)
+        return super()._out(out, self.deser.report)[0]
 
     async def get_reports(
         self,

--- a/src/pysdmx/fmr/fusion/report.py
+++ b/src/pysdmx/fmr/fusion/report.py
@@ -30,10 +30,15 @@ class FusionMetadataMessage(Struct, frozen=True):
 
     data: FusionMetadataSets
 
-    def to_model(self) -> MetadataReport:
-        """Returns the requested metadata report."""
-        r = self.data.metadatasets[0]
+    def __create_report(self, r: FusionMetadataReport) -> MetadataReport:
         attrs = _merge_attributes(r.attributes)
         return MetadataReport(
             r.id, r.names[0].value, r.metadataflow, r.targets, attrs
         )
+
+    def to_model(self, fetch_all: bool = False) -> MetadataReport:
+        """Returns the requested metadata report(s)."""
+        if fetch_all:
+            return [self.__create_report(r) for r in self.data.metadatasets]
+        else:
+            return self.__create_report(self.data.metadatasets[0])

--- a/src/pysdmx/fmr/fusion/report.py
+++ b/src/pysdmx/fmr/fusion/report.py
@@ -36,9 +36,9 @@ class FusionMetadataMessage(Struct, frozen=True):
             r.id, r.names[0].value, r.metadataflow, r.targets, attrs
         )
 
-    def to_model(self, fetch_all: bool = False) -> MetadataReport:
+    def to_model(self, fetch_all: bool = False) -> Sequence[MetadataReport]:
         """Returns the requested metadata report(s)."""
         if fetch_all:
             return [self.__create_report(r) for r in self.data.metadatasets]
         else:
-            return self.__create_report(self.data.metadatasets[0])
+            return [self.__create_report(self.data.metadatasets[0])]

--- a/src/pysdmx/fmr/sdmx/report.py
+++ b/src/pysdmx/fmr/sdmx/report.py
@@ -23,9 +23,9 @@ class JsonMetadataMessage(Struct, frozen=True):
         attrs = _merge_attributes(r.attributes)
         return MetadataReport(r.id, r.name, r.metadataflow, r.targets, attrs)
 
-    def to_model(self, fetch_all: bool = False) -> MetadataReport:
+    def to_model(self, fetch_all: bool = False) -> Sequence[MetadataReport]:
         """Returns the requested metadata report(s)."""
         if fetch_all:
             return [self.__create_report(r) for r in self.data.metadataSets]
         else:
-            return self.__create_report(self.data.metadataSets[0])
+            return [self.__create_report(self.data.metadataSets[0])]

--- a/src/pysdmx/fmr/sdmx/report.py
+++ b/src/pysdmx/fmr/sdmx/report.py
@@ -19,8 +19,13 @@ class JsonMetadataMessage(Struct, frozen=True):
 
     data: JsonMetadataSets
 
-    def to_model(self) -> MetadataReport:
-        """Returns the requested metadata report."""
-        r = self.data.metadataSets[0]
+    def __create_report(self, r: MetadataReport) -> MetadataReport:
         attrs = _merge_attributes(r.attributes)
         return MetadataReport(r.id, r.name, r.metadataflow, r.targets, attrs)
+
+    def to_model(self, fetch_all: bool = False) -> MetadataReport:
+        """Returns the requested metadata report(s)."""
+        if fetch_all:
+            return [self.__create_report(r) for r in self.data.metadataSets]
+        else:
+            return self.__create_report(self.data.metadataSets[0])

--- a/tests/fmr/fusion/test_reports.py
+++ b/tests/fmr/fusion/test_reports.py
@@ -1,0 +1,47 @@
+import pytest
+import tests.fmr.mult_reports_checks as checks
+
+from pysdmx.fmr import AsyncRegistryClient, Format, RegistryClient
+
+
+@pytest.fixture()
+def fmr():
+    return RegistryClient(
+        "https://registry.sdmx.org/sdmx/v2/",
+        Format.FUSION_JSON,
+    )
+
+
+@pytest.fixture()
+def async_fmr() -> AsyncRegistryClient:
+    return AsyncRegistryClient(
+        "https://registry.sdmx.org/sdmx/v2/",
+        Format.FUSION_JSON,
+    )
+
+
+@pytest.fixture()
+def query(fmr):
+    res = "metadata/structure/"
+    typ = "dataflow"
+    agency = "BIS.MACRO"
+    id = "BIS_MACRO"
+    version = "1.0"
+    return f"{fmr.api_endpoint}{res}{typ}/{agency}/{id}/{version}"
+
+
+@pytest.fixture()
+def body():
+    with open("tests/fmr/samples/refmeta/mult_reports.fusion.json", "rb") as f:
+        return f.read()
+
+
+def test_returns_mult_report(respx_mock, fmr, query, body):
+    """get_reports() should return multiple reports."""
+    checks.check_reports(respx_mock, fmr, query, body)
+
+
+@pytest.mark.asyncio()
+async def test_returns_mult_report_async(respx_mock, async_fmr, query, body):
+    """get_reports() should return multiple reports (async)."""
+    await checks.check_reports_async(respx_mock, async_fmr, query, body)

--- a/tests/fmr/mult_reports_checks.py
+++ b/tests/fmr/mult_reports_checks.py
@@ -1,0 +1,86 @@
+from typing import Sequence
+
+import httpx
+
+from pysdmx.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.model import MetadataAttribute
+
+
+def check_reports(mock, fmr: RegistryClient, query, body):
+    """get_reports() should return multiple metadata reports."""
+    mock.get(query).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+
+    reports = fmr.get_reports("dataflow", "BIS.MACRO", "BIS_MACRO", "1.0")
+
+    assert isinstance(reports, Sequence)
+    assert len(reports) == 2
+    for r in reports:
+        assert "Dataflow=BIS.MACRO:BIS_MACRO(1.0)" in r.targets[0]
+        if r.id == "DTI_BIS_MACRO":
+            assert r.name == "Technical metadata for BIS.MACRO:BIS_MACRO"
+            assert r.metadataflow == (
+                "urn:sdmx:org.sdmx.infomodel.metadatastructure.Metadataflow="
+                "BIS.MEDIT:DTI(1.0)"
+            )
+            assert len(r.targets) == 1
+
+            assert len(r) == 5
+            for attr in r:
+                assert isinstance(attr, MetadataAttribute)
+        else:
+            assert r.name == "Reference metadata for BIS.MACRO:BIS_MACRO"
+            assert r.metadataflow == (
+                "urn:sdmx:org.sdmx.infomodel.metadatastructure.Metadataflow="
+                "BIS:DF_META(1.0)"
+            )
+            assert len(r.targets) == 1
+
+            assert len(r) == 1
+            for attr in r:
+                assert isinstance(attr, MetadataAttribute)
+
+
+async def check_reports_async(mock, fmr: AsyncRegistryClient, query, body):
+    """get_reports() should return multiple metadata reports."""
+    mock.get(query).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+
+    reports = await fmr.get_reports(
+        "dataflow", "BIS.MACRO", "BIS_MACRO", "1.0"
+    )
+
+    assert isinstance(reports, Sequence)
+    assert len(reports) == 2
+    for r in reports:
+        assert "Dataflow=BIS.MACRO:BIS_MACRO(1.0)" in r.targets[0]
+        if r.id == "DTI_BIS_MACRO":
+            assert r.name == "Technical metadata for BIS.MACRO:BIS_MACRO"
+            assert r.metadataflow == (
+                "urn:sdmx:org.sdmx.infomodel.metadatastructure.Metadataflow="
+                "BIS.MEDIT:DTI(1.0)"
+            )
+            assert len(r.targets) == 1
+
+            assert len(r) == 5
+            for attr in r:
+                assert isinstance(attr, MetadataAttribute)
+        else:
+            assert r.name == "Reference metadata for BIS.MACRO:BIS_MACRO"
+            assert r.metadataflow == (
+                "urn:sdmx:org.sdmx.infomodel.metadatastructure.Metadataflow="
+                "BIS:DF_META(1.0)"
+            )
+            assert len(r.targets) == 1
+
+            assert len(r) == 1
+            for attr in r:
+                assert isinstance(attr, MetadataAttribute)

--- a/tests/fmr/samples/refmeta/mult_reports.fusion.json
+++ b/tests/fmr/samples/refmeta/mult_reports.fusion.json
@@ -1,0 +1,87 @@
+{
+    "meta": {
+        "id": "IREF389470",
+        "test": false,
+        "prepared": "2023-09-18T12:09:04Z",
+        "contentLanguages": [
+            "en"
+        ],
+        "sender": {
+            "id": "FusionRegistry"
+        },
+        "format": "fusionjson"
+    },
+    "data": {
+        "metadatasets": [
+            {
+                "id": "DTI_BIS_MACRO",
+                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataSet=BIS.MEDIT:DTI_BIS_MACRO(1.0)",
+                "names": [
+                    {
+                        "locale": "en",
+                        "value": "Technical metadata for BIS.MACRO:BIS_MACRO"
+                    }
+                ],
+                "agencyId": "BIS.MEDIT",
+                "version": "1.0",
+                "isFinal": false,
+                "metadataflow": "urn:sdmx:org.sdmx.infomodel.metadatastructure.Metadataflow=BIS.MEDIT:DTI(1.0)",
+                "targets": [
+                    "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS.MACRO:BIS_MACRO(1.0)"
+                ],
+                "attributes": [
+                    {
+                        "id": "idea_partition_details",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_details",
+                        "attributes": [
+                            {
+                                "id": "idea_partition_name",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_name",
+                                "value": "dt"
+                            },
+                            {
+                                "id": "idea_partition_pattern",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_pattern",
+                                "value": "\\d{4}-(0\\d|1[012])"
+                            },
+                            {
+                                "id": "idea_partition_type",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_type",
+                                "value": "string"
+                            }
+                        ]
+                    },
+                    {
+                        "id": "record_format",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).record_format",
+                        "value": "A"
+                    }
+                ]
+            },
+            {
+                "id": "BIS_MACRO",
+                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataSet=BIS.MACRO:BIS_MACRO(1.0)",
+                "names": [
+                    {
+                        "locale": "en",
+                        "value": "Reference metadata for BIS.MACRO:BIS_MACRO"
+                    }
+                ],
+                "agencyId": "BIS.MACRO",
+                "version": "1.0",
+                "isFinal": false,
+                "metadataflow": "urn:sdmx:org.sdmx.infomodel.metadatastructure.Metadataflow=BIS:DF_META(1.0)",
+                "targets": [
+                    "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS.MACRO:BIS_MACRO(1.0)"
+                ],
+                "attributes": [
+                    {
+                        "id": "methodology",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MACRO:BIS_MACRO(1.0).methodology",
+                        "value": "A methodological note"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/fmr/samples/refmeta/mult_reports.json
+++ b/tests/fmr/samples/refmeta/mult_reports.json
@@ -1,0 +1,141 @@
+{
+    "meta": {
+        "id": "IREF944364",
+        "test": false,
+        "schema": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/master/metadata-message/tools/schemas/2.0.0/sdmx-json-metadata-schema.json",
+        "prepared": "2023-08-16T14:00:39Z",
+        "contentLanguages": [
+            "en"
+        ],
+        "sender": {
+            "id": "FusionRegistry"
+        }
+    },
+    "data": {
+        "metadataSets": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "metadataset",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataSet=BIS.MEDIT:DTI_BIS_MACRO(1.0)"
+                    }
+                ],
+                "id": "DTI_BIS_MACRO",
+                "name": "Technical metadata for BIS.MACRO:BIS_MACRO",
+                "names": {
+                    "en": "Technical metadata for BIS.MACRO:BIS_MACRO"
+                },
+                "version": "1.0",
+                "agencyID": "BIS.MEDIT",
+                "isExternalReference": false,
+                "isFinal": false,
+                "metadataflow": "urn:sdmx:org.sdmx.infomodel.metadatastructure.Metadataflow=BIS.MEDIT:DTI(1.0)",
+                "targets": [
+                    "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS.MACRO:BIS_MACRO(1.0)"
+                ],
+                "attributes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "metadataattribute",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_name"
+                            }
+                        ],
+                        "id": "idea_partition_details",
+                        "attributes": [
+                            {
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "metadataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_name"
+                                    }
+                                ],
+                                "id": "idea_partition_name",
+                                "value": "dt"
+                            },
+                            {
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "metadataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_pattern"
+                                    }
+                                ],
+                                "id": "idea_partition_pattern",
+                                "value": "\\d{4}-(0\\d|1[012])"
+                            },
+                            {
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "metadataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_type"
+                                    }
+                                ],
+                                "id": "idea_partition_type",
+                                "value": "string"
+                            }
+                        ]
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "metadataattribute",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).record_format"
+                            }
+                        ],
+                        "id": "record_format",
+                        "value": "A"
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "metadataset",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataSet=BIS.MACRO:BIS_MACRO(1.0)"
+                    }
+                ],
+                "id": "BIS_MACRO",
+                "name": "Reference metadata for BIS.MACRO:BIS_MACRO",
+                "names": {
+                    "en": "Reference metadata for BIS.MACRO:BIS_MACRO"
+                },
+                "version": "1.0",
+                "agencyID": "BIS.MACRO",
+                "isExternalReference": false,
+                "isFinal": false,
+                "metadataflow": "urn:sdmx:org.sdmx.infomodel.metadatastructure.Metadataflow=BIS:DF_META(1.0)",
+                "targets": [
+                    "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS.MACRO:BIS_MACRO(1.0)"
+                ],
+                "attributes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "metadataattribute",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MACRO:BIS_MACRO(1.0).methodology"
+                            }
+                        ],
+                        "id": "methodology",
+                        "value": "A methodological note"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/fmr/sdmx/test_reports.py
+++ b/tests/fmr/sdmx/test_reports.py
@@ -1,0 +1,47 @@
+import pytest
+import tests.fmr.mult_reports_checks as checks
+
+from pysdmx.fmr import AsyncRegistryClient, Format, RegistryClient
+
+
+@pytest.fixture()
+def fmr():
+    return RegistryClient(
+        "https://registry.sdmx.org/sdmx/v2/",
+        Format.SDMX_JSON,
+    )
+
+
+@pytest.fixture()
+def async_fmr() -> AsyncRegistryClient:
+    return AsyncRegistryClient(
+        "https://registry.sdmx.org/sdmx/v2/",
+        Format.SDMX_JSON,
+    )
+
+
+@pytest.fixture()
+def query(fmr):
+    res = "metadata/structure/"
+    typ = "dataflow"
+    agency = "BIS.MACRO"
+    id = "BIS_MACRO"
+    version = "1.0"
+    return f"{fmr.api_endpoint}{res}{typ}/{agency}/{id}/{version}"
+
+
+@pytest.fixture()
+def body():
+    with open("tests/fmr/samples/refmeta/mult_reports.json", "rb") as f:
+        return f.read()
+
+
+def test_returns_mult_report(respx_mock, fmr, query, body):
+    """get_reports() should return multiple reports."""
+    checks.check_reports(respx_mock, fmr, query, body)
+
+
+@pytest.mark.asyncio()
+async def test_returns_mult_report_async(respx_mock, async_fmr, query, body):
+    """get_reports() should return multiple reports (async)."""
+    await checks.check_reports_async(respx_mock, async_fmr, query, body)


### PR DESCRIPTION
So far `pysdmx` allows retrieving reference metadata reports using the report ID.

The purpose of this PBI is to allow retrieving the reference metadata reports attached to a specific structure.