### PR TITLE
Find codes by ID

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysdmx"
-version = "1.0.0-beta-4"
+version = "1.0.0-beta-5"
 description = "Your opinionated Python SDMX library"
 authors = [
     "Xavier Sosnovsky <xavier.sosnovsky@bis.org>",

--- a/src/pysdmx/__init__.py
+++ b/src/pysdmx/__init__.py
@@ -1,3 +1,3 @@
 """Your opinionated Python SDMX library."""
 
-__version__ = "1.0.0-beta-4"
+__version__ = "1.0.0-beta-5"

--- a/src/pysdmx/model/code.py
+++ b/src/pysdmx/model/code.py
@@ -17,7 +17,7 @@ representation of hierarchical relationships to hierarchies only.
 """
 
 from datetime import datetime
-from typing import Iterator, Optional, Sequence, FrozenSet
+from typing import FrozenSet, Iterator, Optional, Sequence
 
 from msgspec import Struct
 
@@ -211,7 +211,7 @@ class Hierarchy(Struct, frozen=True, omit_defaults=True):
         return None
 
     def __by_id(
-        self, id: str, codes: FrozenSet[HierarchicalCode]
+        self, id: str, codes: Sequence[HierarchicalCode]
     ) -> FrozenSet[HierarchicalCode]:
         out = []
         for i in codes:
@@ -231,7 +231,7 @@ class Hierarchy(Struct, frozen=True, omit_defaults=True):
         This function can be used when you just know the code ID,
         and not the ID of its parents.
 
-        Attributes:
+        Args:
             id: The ID of the code to be returned.
 
         Returns:

--- a/tests/model/test_hierarchy.py
+++ b/tests/model/test_hierarchy.py
@@ -98,3 +98,64 @@ def test_get_code(id, name, agency):
     assert resp2 == codes[1]
     assert resp3 is None
     assert resp4 is None
+
+
+def test_codes_by_id_no_parent_needed(id, name, agency):
+    grandchild = HierarchicalCode("child211", "Child 2.1.1")
+    child1 = HierarchicalCode("child21", "Child 2.1", codes=[grandchild])
+    codes = [
+        HierarchicalCode("child1", "Child 1"),
+        HierarchicalCode("child2", "Child 2", codes=[child1]),
+    ]
+    cs = Hierarchy(id, name, agency, codes=codes)
+
+    m = cs.by_id("child211")
+
+    assert isinstance(m, Iterable)
+    assert len(m) == 1
+    m = list(m)
+    assert m[0] == grandchild
+
+
+def test_codes_by_id_is_a_set(id, name, agency):
+    grandchild1 = HierarchicalCode("child211", "Child 2.1.1")
+    grandchild2 = HierarchicalCode("child212", "Child 2.1.2")
+    child1 = HierarchicalCode(
+        "child21", "Child 2.1", codes=[grandchild1, grandchild2]
+    )
+    child2 = HierarchicalCode("child22", "Child 2.2", codes=[grandchild1])
+    codes = [
+        HierarchicalCode("child1", "Child 1"),
+        HierarchicalCode("child2", "Child 2", codes=[child1, child2]),
+    ]
+    cs = Hierarchy(id, name, agency, codes=codes)
+
+    m = cs.by_id("child211")
+
+    assert isinstance(m, Iterable)
+    assert len(m) == 1
+    m = list(m)
+    assert m[0] == grandchild1
+
+
+def test_codes_by_id_dff_names(id, name, agency):
+    grandchild1 = HierarchicalCode("child211", "Child 2.1.1")
+    grandchild2 = HierarchicalCode("child212", "Child 2.1.2")
+    grandchild3 = HierarchicalCode("child211", "Child 2.1.1 - Diff name")
+    child1 = HierarchicalCode(
+        "child21", "Child 2.1", codes=[grandchild1, grandchild2]
+    )
+    child2 = HierarchicalCode("child22", "Child 2.2", codes=[grandchild3])
+    codes = [
+        HierarchicalCode("child1", "Child 1"),
+        HierarchicalCode("child2", "Child 2", codes=[child1, child2]),
+    ]
+    cs = Hierarchy(id, name, agency, codes=codes)
+
+    m = cs.by_id("child211")
+
+    assert isinstance(m, Iterable)
+    assert len(m) == 2
+    m = list(m)
+    assert grandchild1 in m
+    assert grandchild3 in m


### PR DESCRIPTION
Codes within a hierarchy can be retrieved by ID, for example:

```python
code = hierarchy["EU.ES"]
```

However, this requires knowing not only the code ID  (`ES` in the example above), but also the ID of all of its parents (`EU` in the example above).

A method has been added, so as to be able to retrieve codes, when the IDs of the parents are unknown. 

Please not that:

- The method returns a set, to avoid returning the same code more than once, in case it is attached to multiple parents;
- The set may contain more than one code. As a hierarchy can reference codes coming from multiple codelists, we cannot exclude the possibility that codes from different codelists will have the same ID.