### PR TITLE
Add post init validation checks

### DIFF
--- a/src/pysdmx/model/__base.py
+++ b/src/pysdmx/model/__base.py
@@ -29,7 +29,7 @@ class Annotation(Struct, frozen=True, omit_defaults=True):
     url: Optional[str] = None
     type: Optional[str] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Additional validation checks for Annotation."""
         if (
             not self.id
@@ -216,7 +216,7 @@ class MaintainableArtefact(
     structure_url: Optional[str] = None
     agency: Union[str, Agency] = ""
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Additional validation checks for maintainable artefacts."""
         if not self.agency:
             raise ClientError(

--- a/src/pysdmx/model/__base.py
+++ b/src/pysdmx/model/__base.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, Optional, Sequence, Union
 
 from msgspec import Struct
 
+from pysdmx.errors import ClientError
+
 
 class Annotation(Struct, frozen=True, omit_defaults=True):
     """Annotation class.
@@ -26,6 +28,23 @@ class Annotation(Struct, frozen=True, omit_defaults=True):
     text: Optional[str] = None
     url: Optional[str] = None
     type: Optional[str] = None
+
+    def __post_init__(self):
+        if (
+            not self.id
+            and not self.title
+            and not self.text
+            and not self.url
+            and not self.type
+        ):
+            raise ClientError(
+                422,
+                "Empty annotation",
+                (
+                    "All fields of the annotation have been left empty."
+                    "Please set at least one."
+                ),
+            )
 
     def __str__(self) -> str:
         """Returns a human-friendly description."""

--- a/src/pysdmx/model/__base.py
+++ b/src/pysdmx/model/__base.py
@@ -30,6 +30,7 @@ class Annotation(Struct, frozen=True, omit_defaults=True):
     type: Optional[str] = None
 
     def __post_init__(self):
+        """Additional validation checks for Annotation."""
         if (
             not self.id
             and not self.title

--- a/src/pysdmx/model/__base.py
+++ b/src/pysdmx/model/__base.py
@@ -216,6 +216,15 @@ class MaintainableArtefact(
     structure_url: Optional[str] = None
     agency: Union[str, Agency] = ""
 
+    def __post_init__(self):
+        """Additional validation checks for maintainable artefacts."""
+        if not self.agency:
+            raise ClientError(
+                422,
+                "Missing agency",
+                "Maintainable artefacts must reference an agency.",
+            )
+
 
 class ItemScheme(MaintainableArtefact, frozen=True, omit_defaults=True):
     """ItemScheme class.

--- a/tests/model/test_annotation.py
+++ b/tests/model/test_annotation.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pysdmx.errors import Error
 from pysdmx.model.__base import Annotation
 
 
@@ -60,14 +61,6 @@ def test_not_equal(id):
     assert a1 != a2
 
 
-def test_tostr_empty():
-    a = Annotation()
-
-    s = str(a)
-
-    assert s == ""
-
-
 def test_tostr_id(id):
     a = Annotation(id)
 
@@ -82,3 +75,8 @@ def test_tostr_all(id, title, text, url, type):
     s = str(a)
 
     assert s == f"id={id}, title={title}, text={text}, url={url}, type={type}"
+
+
+def test_empty_annotation_not_allowed():
+    with pytest.raises(Error, match="empty"):
+        Annotation()

--- a/tests/model/test_maintainable.py
+++ b/tests/model/test_maintainable.py
@@ -1,0 +1,9 @@
+import pytest
+
+from pysdmx.errors import Error
+from pysdmx.model.__base import MaintainableArtefact
+
+
+def test_empty_agency_not_allowed():
+    with pytest.raises(Error, match="must reference an agency"):
+        MaintainableArtefact("ID")


### PR DESCRIPTION
Post init validation checks have been added to:
- Annotations, to make sure at least one property is set
- Maintainable artefacts, to make sure the agency is set

Close #32
Close #34