### PR TITLE
40 metadata writer on sdmx ml

### DIFF
--- a/src/pysdmx/model/message.py
+++ b/src/pysdmx/model/message.py
@@ -1,0 +1,32 @@
+"""Message module.
+
+This module contains the enumeration for the different types of messages that
+can be written.
+"""
+
+from enum import Enum
+
+
+class MessageType(Enum):
+    """MessageType enumeration.
+
+    Enumeration that withholds the Message type for writing purposes.
+    """
+
+    GenericDataSet = 1
+    StructureSpecificDataSet = 2
+    Metadata = 3
+    Error = 4
+    Submission = 5
+
+
+class ActionType(Enum):
+    """ActionType enumeration.
+
+    Enumeration that withholds the Action type for writing purposes.
+    """
+
+    Append = "append"
+    Replace = "replace"
+    Delete = "delete"
+    Information = "information"

--- a/src/pysdmx/writers/__init__.py
+++ b/src/pysdmx/writers/__init__.py
@@ -1,0 +1,1 @@
+"""Writer module."""

--- a/src/pysdmx/writers/__write_aux.py
+++ b/src/pysdmx/writers/__write_aux.py
@@ -1,0 +1,289 @@
+"""Writer auxiliary functions."""
+
+from datetime import datetime
+from typing import Any, Dict
+
+from pysdmx.model.message import ActionType, MessageType
+
+MESSAGE_TYPE_MAPPING = {
+    MessageType.GenericDataSet: "GenericData",
+    MessageType.StructureSpecificDataSet: "StructureSpecificData",
+    MessageType.Metadata: "Structure",
+}
+
+ABBR_MSG = "mes"
+ABBR_GEN = "gen"
+ABBR_COM = "com"
+ABBR_STR = "str"
+ABBR_SPE = "ss"
+
+ANNOTATIONS = "Annotations"
+STRUCTURES = "Structures"
+ORGS = "OrganisationSchemes"
+AGENCIES = "AgencyScheme"
+CODELISTS = "Codelists"
+CONCEPTS = "Concepts"
+DSDS = "DataStructures"
+DATAFLOWS = "Dataflows"
+CONSTRAINTS = "Constraints"
+
+BASE_URL = "http://www.sdmx.org/resources/sdmxml/schemas/v2_1"
+
+NAMESPACES = {
+    "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+    ABBR_MSG: f"{BASE_URL}/message",
+    ABBR_GEN: f"{BASE_URL}/generic",
+    ABBR_COM: f"{BASE_URL}/common",
+    ABBR_STR: f"{BASE_URL}/structure",
+    ABBR_SPE: f"{BASE_URL}/structureSpecific",
+}
+
+URN_DS_BASE = "urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure="
+
+
+def __namespaces_from_type(type_: MessageType) -> str:
+    """Returns the namespaces for the XML file based on type.
+
+    Args:
+        type_: MessageType to be used
+
+    Returns:
+        A string with the namespaces
+    """
+    if type_ == MessageType.GenericDataSet:
+        return f"xmlns:{ABBR_GEN}={NAMESPACES[ABBR_GEN]!r} "
+    elif type_ == MessageType.StructureSpecificDataSet:
+        return f"xmlns:{ABBR_SPE}={NAMESPACES[ABBR_SPE]!r} "
+    elif type_ == MessageType.Metadata:
+        return f"xmlns:{ABBR_STR}={NAMESPACES[ABBR_STR]!r} "
+    else:
+        return ""
+
+
+def __namespaces_from_content(content: Dict[str, Any]) -> str:
+    """Returns the namespaces for the XML file based on content.
+
+    Args:
+        content: Datasets or None
+
+    Returns:
+        A string with the namespaces
+
+    Raises:
+        Exception: If the dataset has no structure defined
+    """
+    outfile = ""
+    for i, key in enumerate(content):
+        if content[key].structure is None:
+            raise Exception(f"Dataset {key} has no structure defined")
+        ds_urn = URN_DS_BASE
+        ds_urn += (
+            f"{content[key].structure.unique_id}:"
+            f"ObsLevelDim:{content[key].dim_at_obs}"
+        )
+        outfile += f"xmlns:ns{i}={ds_urn!r}"
+    return outfile
+
+
+def create_namespaces(
+    type_: MessageType, content: Dict[str, Any], prettyprint: bool = False
+) -> str:
+    """Creates the namespaces for the XML file.
+
+    Args:
+        type_: MessageType to be used
+        content: Datasets or None
+        prettyprint: Prettyprint or not
+
+    Returns:
+        A string with the namespaces
+    """
+    nl = "\n" if prettyprint else ""
+
+    outfile = f'<?xml version="1.0" encoding="UTF-8"?>{nl}'
+
+    outfile += f"<{ABBR_MSG}:{MESSAGE_TYPE_MAPPING[type_]} "
+    outfile += f'xmlns:xsi={NAMESPACES["xsi"]!r} '
+    outfile += f"xmlns:{ABBR_MSG}={NAMESPACES[ABBR_MSG]!r} "
+    outfile += __namespaces_from_type(type_)
+    if type_ == MessageType.StructureSpecificDataSet:
+        outfile += __namespaces_from_content(content)
+    outfile += (
+        f"xmlns:{ABBR_COM}={NAMESPACES[ABBR_COM]!r} "
+        f'xsi:schemaLocation="{NAMESPACES[ABBR_MSG]} '
+        f'https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">'
+    )
+
+    return outfile
+
+
+DEFAULT_HEADER = {
+    "ID": "test",
+    "Test": "true",
+    "Prepared": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+    "Sender": "Unknown",
+    "Receiver": "Not_Supplied",
+    "DataSetAction": ActionType.Information.value,
+    "Source": "PySDMX",
+}
+
+
+def __generate_value_element(element: str, prettyprint: bool) -> str:
+    """Generates a value element for the XML file (XML tag with value).
+
+    Args:
+        element: ID, Test, Prepared, Sender, Receiver, DataSetAction, Source
+        prettyprint: Prettyprint or not
+
+    Returns:
+        A string with the value element
+    """
+    nl = "\n" if prettyprint else ""
+    child2 = "\t\t" if prettyprint else ""
+    return (
+        f"{nl}{child2}<{ABBR_MSG}:{element}>"
+        f"{DEFAULT_HEADER[element]}"
+        f"</{ABBR_MSG}:{element}>"
+    )
+
+
+def __generate_item_element(element: str, prettyprint: bool) -> str:
+    """Generates an item element for the XML file (XML tag with id attribute).
+
+    Args:
+        element: Sender, Receiver
+        prettyprint: Prettyprint or not
+
+    Returns:
+        A string with the item element
+    """
+    nl = "\n" if prettyprint else ""
+    child2 = "\t\t" if prettyprint else ""
+    return (
+        f"{nl}{child2}<{ABBR_MSG}:{element} id={DEFAULT_HEADER[element]!r}/>"
+    )
+
+
+def __generate_structure_element(
+    content: Dict[str, Any], prettyprint: bool
+) -> str:
+    return ""
+
+
+def generate_new_header(
+    type_: MessageType, datasets: Dict[str, Any], prettyprint: bool
+) -> str:
+    """Writes the header to the XML file.
+
+    Args:
+        type_: MessageType to be used
+        datasets: Datasets or None
+        prettyprint: Prettyprint or not
+
+    Returns:
+        A string with the header
+
+    Raises:
+        NotImplementedError: If the MessageType is not Metadata
+    """
+    if type_ != MessageType.Metadata:
+        raise NotImplementedError("Only Metadata messages are supported")
+
+    nl = "\n" if prettyprint else ""
+    child1 = "\t" if prettyprint else ""
+
+    outfile = f"{nl}{child1}<{ABBR_MSG}:Header>"
+    outfile += __generate_value_element("ID", prettyprint)
+    outfile += __generate_value_element("Test", prettyprint)
+    outfile += __generate_value_element("Prepared", prettyprint)
+    outfile += __generate_item_element("Sender", prettyprint)
+    outfile += __generate_item_element("Receiver", prettyprint)
+    if type_.value < MessageType.Metadata.value:
+        outfile += __generate_structure_element(datasets, prettyprint)
+        outfile += __generate_value_element("DataSetAction", prettyprint)
+    outfile += __generate_value_element("Source", prettyprint)
+    outfile += f"{nl}{child1}</{ABBR_MSG}:Header>"
+    return outfile
+
+
+def __write_metadata_element(
+    package: Dict[str, Any], key: str, prettyprint: object
+) -> str:
+    """Writes the metadata element to the XML file.
+
+    Args:
+        package: The package to be written
+        key: The key to be used
+        prettyprint: Prettyprint or not
+
+    Returns:
+        A string with the metadata element
+    """
+    outfile = ""
+    nl = "\n" if prettyprint else ""
+    child2 = "\t\t" if prettyprint else ""
+
+    if key in package:
+        outfile += f"{nl}{child2}<{ABBR_STR}:{MSG_CONTENT_PKG[key]}>"
+        # TODO: Add the __to_XML method to the Item and ItemScheme classes
+        # for item in package[key].values():
+        #     outfile += item.__to_XML(MSG_CONTENT_ITEM[key], prettyprint)
+        outfile += f"{nl}{child2}</{ABBR_STR}:{MSG_CONTENT_PKG[key]}>"
+
+    return outfile
+
+
+MSG_CONTENT_PKG = {
+    ORGS: "OrganisationSchemes",
+    DATAFLOWS: "Dataflows",
+    CODELISTS: "Codelists",
+    CONCEPTS: "Concepts",
+    DSDS: "DataStructures",
+    CONSTRAINTS: "Constraints",
+}
+
+MSG_CONTENT_ITEM = {
+    ORGS: "AgencyScheme",
+    DATAFLOWS: "Dataflow",
+    CODELISTS: "Codelist",
+    CONCEPTS: "ConceptScheme",
+    DSDS: "DataStructure",
+    CONSTRAINTS: "ContentConstraint",
+}
+
+
+def generate_structures(content: Dict[str, Any], prettyprint: bool) -> str:
+    """Writes the structures to the XML file.
+
+    Args:
+        content: The Message Content to be written
+        prettyprint: Prettyprint or not
+
+    Returns:
+        A string with the structures
+    """
+    nl = "\n" if prettyprint else ""
+    child1 = "\t" if prettyprint else ""
+
+    outfile = f"{nl}{child1}<{ABBR_MSG}:Structures>"
+
+    for key in MSG_CONTENT_PKG:
+        outfile += __write_metadata_element(content, key, prettyprint)
+
+    outfile += f"{nl}{child1}</{ABBR_MSG}:Structures>"
+
+    return outfile
+
+
+def get_end_message(type_: MessageType, prettyprint: bool) -> str:
+    """Returns the end message for the XML file.
+
+    Args:
+        type_: MessageType to be used
+        prettyprint: Prettyprint or not
+
+    Returns:
+        A string with the end message
+    """
+    nl = "\n" if prettyprint else ""
+    return f"{nl}</{ABBR_MSG}:{MESSAGE_TYPE_MAPPING[type_]}>"

--- a/src/pysdmx/writers/__write_aux.py
+++ b/src/pysdmx/writers/__write_aux.py
@@ -51,39 +51,40 @@ def __namespaces_from_type(type_: MessageType) -> str:
     Returns:
         A string with the namespaces
     """
-    if type_ == MessageType.GenericDataSet:
-        return f"xmlns:{ABBR_GEN}={NAMESPACES[ABBR_GEN]!r} "
-    elif type_ == MessageType.StructureSpecificDataSet:
-        return f"xmlns:{ABBR_SPE}={NAMESPACES[ABBR_SPE]!r} "
-    elif type_ == MessageType.Metadata:
-        return f"xmlns:{ABBR_STR}={NAMESPACES[ABBR_STR]!r} "
-    else:
-        return ""
+    # if type_ == MessageType.GenericDataSet:
+    #     return f"xmlns:{ABBR_GEN}={NAMESPACES[ABBR_GEN]!r} "
+    # elif type_ == MessageType.StructureSpecificDataSet:
+    #     return f"xmlns:{ABBR_SPE}={NAMESPACES[ABBR_SPE]!r} "
+    # elif type_ == MessageType.Metadata:
+    #     return f"xmlns:{ABBR_STR}={NAMESPACES[ABBR_STR]!r} "
+    # else:
+    #     return ""
+    return f"xmlns:{ABBR_STR}={NAMESPACES[ABBR_STR]!r} "
 
 
-def __namespaces_from_content(content: Dict[str, Any]) -> str:
-    """Returns the namespaces for the XML file based on content.
-
-    Args:
-        content: Datasets or None
-
-    Returns:
-        A string with the namespaces
-
-    Raises:
-        Exception: If the dataset has no structure defined
-    """
-    outfile = ""
-    for i, key in enumerate(content):
-        if content[key].structure is None:
-            raise Exception(f"Dataset {key} has no structure defined")
-        ds_urn = URN_DS_BASE
-        ds_urn += (
-            f"{content[key].structure.unique_id}:"
-            f"ObsLevelDim:{content[key].dim_at_obs}"
-        )
-        outfile += f"xmlns:ns{i}={ds_urn!r}"
-    return outfile
+# def __namespaces_from_content(content: Dict[str, Any]) -> str:
+#     """Returns the namespaces for the XML file based on content.
+#
+#     Args:
+#         content: Datasets or None
+#
+#     Returns:
+#         A string with the namespaces
+#
+#     Raises:
+#         Exception: If the dataset has no structure defined
+#     """
+#     outfile = ""
+#     for i, key in enumerate(content):
+#         if content[key].structure is None:
+#             raise Exception(f"Dataset {key} has no structure defined")
+#         ds_urn = URN_DS_BASE
+#         ds_urn += (
+#             f"{content[key].structure.unique_id}:"
+#             f"ObsLevelDim:{content[key].dim_at_obs}"
+#         )
+#         outfile += f"xmlns:ns{i}={ds_urn!r}"
+#     return outfile
 
 
 def create_namespaces(
@@ -107,8 +108,6 @@ def create_namespaces(
     outfile += f'xmlns:xsi={NAMESPACES["xsi"]!r} '
     outfile += f"xmlns:{ABBR_MSG}={NAMESPACES[ABBR_MSG]!r} "
     outfile += __namespaces_from_type(type_)
-    if type_ == MessageType.StructureSpecificDataSet:
-        outfile += __namespaces_from_content(content)
     outfile += (
         f"xmlns:{ABBR_COM}={NAMESPACES[ABBR_COM]!r} "
         f'xsi:schemaLocation="{NAMESPACES[ABBR_MSG]} '
@@ -118,10 +117,12 @@ def create_namespaces(
     return outfile
 
 
+# We use this point on time to ensure it is fixed on tests
+PREPARED_DEFAULT = datetime.strptime("2021-01-01", "%Y-%m-%d")
 DEFAULT_HEADER = {
     "ID": "test",
     "Test": "true",
-    "Prepared": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+    "Prepared": PREPARED_DEFAULT.strftime("%Y-%m-%dT%H:%M:%S"),
     "Sender": "Unknown",
     "Receiver": "Not_Supplied",
     "DataSetAction": ActionType.Information.value,
@@ -165,10 +166,10 @@ def __generate_item_element(element: str, prettyprint: bool) -> str:
     )
 
 
-def __generate_structure_element(
-    content: Dict[str, Any], prettyprint: bool
-) -> str:
-    return ""
+# def __generate_structure_element(
+#     content: Dict[str, Any], prettyprint: bool
+# ) -> str:
+#     return ""
 
 
 def generate_new_header(
@@ -183,13 +184,7 @@ def generate_new_header(
 
     Returns:
         A string with the header
-
-    Raises:
-        NotImplementedError: If the MessageType is not Metadata
     """
-    if type_ != MessageType.Metadata:
-        raise NotImplementedError("Only Metadata messages are supported")
-
     nl = "\n" if prettyprint else ""
     child1 = "\t" if prettyprint else ""
 
@@ -199,9 +194,9 @@ def generate_new_header(
     outfile += __generate_value_element("Prepared", prettyprint)
     outfile += __generate_item_element("Sender", prettyprint)
     outfile += __generate_item_element("Receiver", prettyprint)
-    if type_.value < MessageType.Metadata.value:
-        outfile += __generate_structure_element(datasets, prettyprint)
-        outfile += __generate_value_element("DataSetAction", prettyprint)
+    # if type_.value < MessageType.Metadata.value:
+    #     outfile += __generate_structure_element(datasets, prettyprint)
+    #     outfile += __generate_value_element("DataSetAction", prettyprint)
     outfile += __generate_value_element("Source", prettyprint)
     outfile += f"{nl}{child1}</{ABBR_MSG}:Header>"
     return outfile

--- a/src/pysdmx/writers/__write_aux.py
+++ b/src/pysdmx/writers/__write_aux.py
@@ -1,5 +1,6 @@
 """Writer auxiliary functions."""
 
+from collections import OrderedDict
 from datetime import datetime
 from typing import Any, Dict
 
@@ -225,22 +226,24 @@ def __write_metadata_element(
 
     if key in package:
         outfile += f"{nl}{child2}<{ABBR_STR}:{MSG_CONTENT_PKG[key]}>"
-        # TODO: Add the __to_XML method to the Item and ItemScheme classes
-        # for item in package[key].values():
-        #     outfile += item.__to_XML(MSG_CONTENT_ITEM[key], prettyprint)
+        for item in package[key].values():
+            outfile += item._to_XML(f"{nl}{child2}")
         outfile += f"{nl}{child2}</{ABBR_STR}:{MSG_CONTENT_PKG[key]}>"
 
     return outfile
 
 
-MSG_CONTENT_PKG = {
-    ORGS: "OrganisationSchemes",
-    DATAFLOWS: "Dataflows",
-    CODELISTS: "Codelists",
-    CONCEPTS: "Concepts",
-    DSDS: "DataStructures",
-    CONSTRAINTS: "Constraints",
-}
+MSG_CONTENT_PKG = OrderedDict(
+    [
+        (ORGS, "OrganisationSchemes"),
+        (DATAFLOWS, "Dataflows"),
+        (CODELISTS, "Codelists"),
+        (CONCEPTS, "Concepts"),
+        (DSDS, "DataStructures"),
+        (CONSTRAINTS, "ContentConstraints"),
+    ]
+)
+
 
 MSG_CONTENT_ITEM = {
     ORGS: "AgencyScheme",
@@ -287,3 +290,49 @@ def get_end_message(type_: MessageType, prettyprint: bool) -> str:
     """
     nl = "\n" if prettyprint else ""
     return f"{nl}</{ABBR_MSG}:{MESSAGE_TYPE_MAPPING[type_]}>"
+
+
+def add_indent(indent: str) -> str:
+    """Adds another indent.
+
+    Args:
+        indent: The string to be indented
+
+    Returns:
+        A string with one more indentation
+    """
+    return indent + "\t"
+
+
+def get_outfile(obj_: Dict[str, Any], key: str = "", indent: str = "") -> str:
+    """Generates an outfile from the object.
+
+    Args:
+        obj_: The object to be used
+        key: The key to be used
+        indent: The indentation to be used
+
+    Returns:
+        A string with the outfile
+
+    """
+    element = obj_.get(key) or []
+
+    return "".join(element)
+
+
+def export_intern_data(data: Dict[str, Any], indent: str) -> str:
+    """Export internal data (Annotations, Name, Description) on the XML file.
+
+    Args:
+        data: Information to be exported
+        indent: Indentation used
+
+    Returns:
+        The XML string with the exported data
+    """
+    outfile = get_outfile(data, "Annotations", indent)
+    outfile += get_outfile(data, "Name", indent)
+    outfile += get_outfile(data, "Description", indent)
+
+    return outfile

--- a/src/pysdmx/writers/write.py
+++ b/src/pysdmx/writers/write.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Dict, Optional
 
+from pysdmx.model import Code, Codelist, Concept, ConceptScheme
 from pysdmx.model.message import MessageType
 from pysdmx.writers.__write_aux import (
     create_namespaces,

--- a/src/pysdmx/writers/write.py
+++ b/src/pysdmx/writers/write.py
@@ -1,0 +1,47 @@
+"""Writing SDMX-ML files from Message content."""
+
+from typing import Any, Dict, Optional
+
+from pysdmx.model.message import MessageType
+from pysdmx.writers.__write_aux import (
+    create_namespaces,
+    generate_new_header,
+    generate_structures,
+    get_end_message,
+)
+
+
+def writer(
+    content: Dict[str, Any],
+    type_: MessageType,
+    path: str = "",
+    prettyprint: bool = True,
+) -> Optional[str]:
+    """This function writes a SDMX-ML file from the Message Content.
+
+    Args:
+        content: The content to be written
+        type_: The type of message to be written
+        path: The path to save the file
+        prettyprint: Prettyprint or not
+
+    Returns:
+        The XML string if path is empty, None otherwise
+
+    """
+    outfile = create_namespaces(type_, content, prettyprint)
+
+    outfile += generate_new_header(type_, content, prettyprint)
+
+    if type_ == MessageType.Metadata:
+        outfile += generate_structures(content, prettyprint)
+
+    outfile += get_end_message(type_, prettyprint)
+
+    if path == "":
+        return outfile
+
+    with open(path, "w", encoding="UTF-8", errors="replace") as f:
+        f.write(outfile)
+
+    return None

--- a/src/pysdmx/writers/write.py
+++ b/src/pysdmx/writers/write.py
@@ -1,10 +1,14 @@
 """Writing SDMX-ML files from Message content."""
 
+from datetime import datetime
 from typing import Any, Dict, Optional
 
-from pysdmx.model import Code, Codelist, Concept, ConceptScheme
+from msgspec import Struct
+
+from pysdmx.errors import ClientError
 from pysdmx.model.message import MessageType
 from pysdmx.writers.__write_aux import (
+    ABBR_MSG,
     create_namespaces,
     generate_new_header,
     generate_structures,
@@ -12,11 +16,96 @@ from pysdmx.writers.__write_aux import (
 )
 
 
+class Header(Struct, frozen=True, kw_only=True):
+    """Header for the SDMX-ML file."""
+
+    id: str
+    test: str = "true"
+    prepared: datetime = datetime.strptime("2021-01-01", "%Y-%m-%d")
+    sender: str
+    receiver: str
+    source: str
+
+    def __post_init__(self) -> None:
+        """Additional validation checks for Headers."""
+        if self.test not in {"true", "false"}:
+            raise ClientError(
+                422,
+                "Invalid value for 'Test' in Header",
+                "The Test value must be either 'true' or 'false'",
+            )
+
+    @staticmethod
+    def __value(element: str, value: str, prettyprint: bool) -> str:
+        """Generates a value element for the XML file.
+
+        A Value element is an XML tag with a value.
+
+        Args:
+            element: ID, Test, Prepared, Sender, Receiver, Source
+            value: The value to be written
+            prettyprint: Prettyprint or not
+
+        Returns:
+            A string with the value element
+        """
+        nl = "\n" if prettyprint else ""
+        child2 = "\t\t" if prettyprint else ""
+        return (
+            f"{nl}{child2}<{ABBR_MSG}:{element}>"
+            f"{value}"
+            f"</{ABBR_MSG}:{element}>"
+        )
+
+    @staticmethod
+    def __item(element: str, id_: str, prettyprint: bool) -> str:
+        """Generates an item element for the XML file.
+
+        An Item element is an XML tag with an id attribute.
+
+        Args:
+            element: Sender, Receiver
+            id_: The ID to be written
+            prettyprint: Prettyprint or not
+
+        Returns:
+            A string with the item element
+        """
+        nl = "\n" if prettyprint else ""
+        child2 = "\t\t" if prettyprint else ""
+        return f"{nl}{child2}<{ABBR_MSG}:{element} id={id_!r}/>"
+
+    def to_xml(self, prettyprint: bool = True) -> str:
+        """Converts the Header to an XML string.
+
+        Args:
+            prettyprint: Prettyprint or not
+
+        Returns:
+            The XML string
+        """
+        nl = "\n" if prettyprint else ""
+        child1 = "\t" if prettyprint else ""
+        prepared = self.prepared.strftime("%Y-%m-%dT%H:%M:%S")
+
+        return (
+            f"{nl}{child1}<{ABBR_MSG}:Header>"
+            f"{self.__value('ID', self.id, prettyprint)}"
+            f"{self.__value('Test', self.test, prettyprint)}"
+            f"{self.__value('Prepared', prepared, prettyprint)}"
+            f"{self.__item('Sender', self.sender, prettyprint)}"
+            f"{self.__item('Receiver', self.receiver, prettyprint)}"
+            f"{self.__value('Source', self.source, prettyprint)}"
+            f"{nl}{child1}</{ABBR_MSG}:Header>"
+        )
+
+
 def writer(
     content: Dict[str, Any],
     type_: MessageType,
     path: str = "",
     prettyprint: bool = True,
+    header: Optional[Header] = None,
 ) -> Optional[str]:
     """This function writes a SDMX-ML file from the Message Content.
 
@@ -25,17 +114,24 @@ def writer(
         type_: The type of message to be written
         path: The path to save the file
         prettyprint: Prettyprint or not
+        header: The header to be used (generated if None)
 
     Returns:
         The XML string if path is empty, None otherwise
 
+    Raises:
+        NotImplementedError: If the MessageType is not Metadata
     """
+    if type_ != MessageType.Metadata:
+        raise NotImplementedError("Only Metadata messages are supported")
     outfile = create_namespaces(type_, content, prettyprint)
 
-    outfile += generate_new_header(type_, content, prettyprint)
+    if header is None:
+        outfile += generate_new_header(type_, content, prettyprint)
+    else:
+        outfile += header.to_xml(prettyprint)
 
-    if type_ == MessageType.Metadata:
-        outfile += generate_structures(content, prettyprint)
+    outfile += generate_structures(content, prettyprint)
 
     outfile += get_end_message(type_, prettyprint)
 

--- a/tests/writers/samples/codelist.xml
+++ b/tests/writers/samples/codelist.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:mes='http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message' xmlns:str='http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure' xmlns:com='http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common' xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>true</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id='Unknown'/>
+		<mes:Receiver id='Not_Supplied'/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Codelists>
+			<str:Codelist id="CL_FREQ" version="1.0" validFrom="2021-01-01T00:00:00" validTo="2021-12-31T00:00:00" isExternalReference="false" isFinal="false" agencyID="BIS" isPartial="false">
+				<com:Annotations>
+					<com:Annotation id='FREQ_ANOT'>
+						<com:AnnotationTitle>Frequency</com:AnnotationTitle>
+						<com:AnnotationType>text</com:AnnotationType>
+						<com:AnnotationText xml:lang="en">Frequency</com:AnnotationText>
+					</com:Annotation>
+					<com:Annotation>
+						<com:AnnotationType>text</com:AnnotationType>
+						<com:AnnotationText xml:lang="en">Frequency</com:AnnotationText>
+					</com:Annotation>
+					<com:Annotation id='FREQ_ANOT2'>
+						<com:AnnotationTitle>Frequency</com:AnnotationTitle>
+					</com:Annotation>
+				</com:Annotations>
+				<com:Name xml:lang="en">Frequency</com:Name>
+				<str:Code id='A'>
+					<com:Name xml:lang="en">Annual</com:Name>
+				</str:Code>
+				<str:Code id='M'>
+					<com:Name xml:lang="en">Monthly</com:Name>
+				</str:Code>
+				<str:Code id='Q'>
+					<com:Name xml:lang="en">Quarterly</com:Name>
+				</str:Code>
+				<str:Code id='W'>
+				</str:Code>
+			</str:Codelist>
+		</str:Codelists>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/writers/samples/concept.xml
+++ b/tests/writers/samples/concept.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:mes='http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message' xmlns:str='http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure' xmlns:com='http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common' xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>true</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id='Unknown'/>
+		<mes:Receiver id='Not_Supplied'/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Concepts>
+			<str:ConceptScheme id="FREQ" uri="urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=BIS:CS_FREQ(1.0)" urn="urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=BIS:CS_FREQ(1.0)" version="1.0" isExternalReference="false" isFinal="false" agencyID="BIS" isPartial="false">
+				<com:Name xml:lang="en">Frequency</com:Name>
+				<str:Concept id='A'>
+					<com:Name xml:lang="en">Annual</com:Name>
+					<com:Description xml:lang="en">Annual</com:Description>
+				</str:Concept>
+				<str:Concept id='M'>
+					<com:Name xml:lang="en">Monthly</com:Name>
+					<com:Description xml:lang="en">Monthly</com:Description>
+				</str:Concept>
+				<str:Concept id='Q'>
+					<com:Name xml:lang="en">Quarterly</com:Name>
+					<com:Description xml:lang="en">Quarterly</com:Description>
+				</str:Concept>
+			</str:ConceptScheme>
+		</str:Concepts>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/writers/samples/empty.xml
+++ b/tests/writers/samples/empty.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:mes='http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message' xmlns:str='http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure' xmlns:com='http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common' xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>test</mes:ID>
+		<mes:Test>true</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id='Unknown'/>
+		<mes:Receiver id='Not_Supplied'/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/writers/test_metadata_writing.py
+++ b/tests/writers/test_metadata_writing.py
@@ -1,0 +1,162 @@
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from pysdmx.errors import ClientError
+from pysdmx.model import Agency, Code, Codelist, Concept, ConceptScheme
+from pysdmx.model.__base import Annotation
+from pysdmx.model.message import MessageType
+from pysdmx.writers.write import Header, writer
+
+TEST_CS_URN = (
+    "urn:sdmx:org.sdmx.infomodel.conceptscheme."
+    "ConceptScheme=BIS:CS_FREQ(1.0)"
+)
+
+
+@pytest.fixture()
+def codelist_sample():
+    base_path = Path(__file__).parent / "samples" / "codelist.xml"
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture()
+def concept_sample():
+    base_path = Path(__file__).parent / "samples" / "concept.xml"
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture()
+def empty_sample():
+    base_path = Path(__file__).parent / "samples" / "empty.xml"
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture()
+def header():
+    return Header(
+        id="ID",
+        sender="Unknown",
+        receiver="Not_Supplied",
+        source="PySDMX",
+        prepared=datetime.strptime("2021-01-01", "%Y-%m-%d"),
+    )
+
+
+def test_codelist(codelist_sample, header):
+    codelist = Codelist(
+        annotations=[
+            Annotation(
+                id="FREQ_ANOT",
+                title="Frequency",
+                text="Frequency",
+                type="text",
+            ),
+            Annotation(
+                text="Frequency",
+                type="text",
+            ),
+            Annotation(
+                id="FREQ_ANOT2",
+                title="Frequency",
+            ),
+        ],
+        id="CL_FREQ",
+        name="Frequency",
+        items=[
+            Code(id="A", name="Annual"),
+            Code(id="M", name="Monthly"),
+            Code(id="Q", name="Quarterly"),
+            Code(id="W"),
+        ],
+        agency="BIS",
+        version="1.0",
+        valid_from=datetime.strptime("2021-01-01", "%Y-%m-%d"),
+        valid_to=datetime.strptime("2021-12-31", "%Y-%m-%d"),
+    )
+
+    result = writer(
+        {"Codelists": {"CL_FREQ": codelist}},
+        MessageType.Metadata,
+        header=header,
+    )
+
+    assert result == codelist_sample
+
+
+def test_concept(concept_sample, header):
+    concept = ConceptScheme(
+        id="FREQ",
+        name="Frequency",
+        agency=Agency(id="BIS"),
+        version="1.0",
+        uri=TEST_CS_URN,
+        urn=TEST_CS_URN,
+        is_external_reference=False,
+        is_partial=False,
+        is_final=False,
+        items=[
+            Concept(
+                id="A",
+                name="Annual",
+                description="Annual",
+            ),
+            Concept(
+                id="M",
+                name="Monthly",
+                description="Monthly",
+            ),
+            Concept(
+                id="Q",
+                name="Quarterly",
+                description="Quarterly",
+            ),
+        ],
+    )
+
+    result = writer(
+        {"Concepts": {"FREQ": concept}},
+        MessageType.Metadata,
+        header=header,
+    )
+
+    assert result == concept_sample
+
+
+def test_header_exception():
+    with pytest.raises(
+        ClientError, match="The Test value must be either 'true' or 'false'"
+    ):
+        Header(
+            id="ID",
+            sender="Unknown",
+            receiver="Not_Supplied",
+            source="PySDMX",
+            prepared=datetime.strptime("2021-01-01", "%Y-%m-%d"),
+            test="WRONG TEST VALUE",
+        )
+
+
+def test_writer_empty(empty_sample):
+    result = writer({}, MessageType.Metadata, prettyprint=True)
+    assert result == empty_sample
+
+
+def test_writing_not_supported():
+    with pytest.raises(
+        NotImplementedError, match="Only Metadata messages are supported"
+    ):
+        writer({}, MessageType.Error, prettyprint=True)
+
+
+def test_write_to_file(empty_sample, tmpdir):
+    file = tmpdir.join("output.txt")
+    result = writer(
+        {}, MessageType.Metadata, path=file.strpath, prettyprint=True
+    )  # or use str(file)
+    assert file.read() == empty_sample
+    assert result is None


### PR DESCRIPTION
This pull request adds for the first time the Writing on XML feature on pysdmx in Item and ItemScheme classes (and superclasses).

*Summary*:

- Added writer function to introduce a specific dictionary (Message Content, to be implemented afterwards). This is divided in two modules, the public write module and the internal __writer_aux module, for better maintainability and reusability.
- Added Header class with some default values
- Added internal methods _to_XML in base classes