### PR TITLE
Add support for core and local representations

### DIFF
--- a/src/pysdmx/fmr/fusion/dsd.py
+++ b/src/pysdmx/fmr/fusion/dsd.py
@@ -36,33 +36,19 @@ def _find_concept(
 
 def _get_representation(
     id_: str,
-    repr_: Optional[FusionRepresentation],
+    r: Optional[FusionRepresentation],
     cls: Sequence[FusionCodelist],
     cons: Dict[str, Sequence[str]],
-    c: Optional[FusionConcept],
 ) -> Tuple[
     DataType,
     Optional[Facets],
     Optional[Codelist],
     Optional[ArrayBoundaries],
 ]:
-    valid = cons.get(id_, [])
-    ab = None
-    dt = DataType.STRING
-    facets = None
-    codes = None
-    if repr_:
-        r = repr_
-    elif c and c.representation:
-        r = c.representation
-    else:
-        r = None
-    if r:
-        if r.textFormat:
-            dt = DataType(r.textFormat.textType)
-        facets = r.to_facets()
-        codes = r.to_enumeration(cls, valid)
-        ab = r.to_array_def()
+    ab = r.to_array_def() if r else None
+    dt = DataType(r.textFormat.textType) if r and r.textFormat else None
+    facets = r.to_facets() if r else None
+    codes = r.to_enumeration(cls, cons.get(id_, [])) if r else None
     return (dt, facets, codes, ab)
 
 
@@ -115,7 +101,7 @@ class FusionAttribute(Struct, frozen=True):
         """Returns an attribute."""
         c = _find_concept(cs, self.concept)
         dt, facets, codes, ab = _get_representation(
-            self.id, self.representation, cls, cons, c
+            self.id, self.representation, cls, cons
         )
         lvl = self.__derive_level(groups)
         if c.descriptions:
@@ -127,11 +113,11 @@ class FusionAttribute(Struct, frozen=True):
             required=self.mandatory,
             role=Role.ATTRIBUTE,
             concept=c.to_model(cls),
-            dtype=dt,
-            facets=facets,
+            local_dtype=dt,
+            local_facets=facets,
             name=c.names[0].value,
             description=desc,
-            codes=codes,
+            local_codes=codes,
             attachment_level=lvl,
             array_def=ab,
         )
@@ -169,7 +155,7 @@ class FusionDimension(Struct, frozen=True):
         """Returns a dimension."""
         c = _find_concept(cs, self.concept)
         dt, facets, codes, ab = _get_representation(
-            self.id, self.representation, cls, cons, c
+            self.id, self.representation, cls, cons
         )
         if c.descriptions:
             desc = c.descriptions[0].value
@@ -180,11 +166,11 @@ class FusionDimension(Struct, frozen=True):
             required=True,
             role=Role.DIMENSION,
             concept=c.to_model(cls),
-            dtype=dt,
-            facets=facets,
+            local_dtype=dt,
+            local_facets=facets,
             name=c.names[0].value,
             description=desc,
-            codes=codes,
+            local_codes=codes,
             array_def=ab,
         )
 
@@ -221,7 +207,7 @@ class FusionMeasure(Struct, frozen=True):
         """Returns a measure."""
         c = _find_concept(cs, self.concept)
         dt, facets, codes, ab = _get_representation(
-            self.id, self.representation, cls, cons, c
+            self.id, self.representation, cls, cons
         )
         if c.descriptions:
             desc = c.descriptions[0].value
@@ -232,11 +218,11 @@ class FusionMeasure(Struct, frozen=True):
             required=self.mandatory,
             role=Role.MEASURE,
             concept=c.to_model(cls),
-            dtype=dt,
-            facets=facets,
+            local_dtype=dt,
+            local_facets=facets,
             name=c.names[0].value,
             description=desc,
-            codes=codes,
+            local_codes=codes,
             array_def=ab,
         )
 

--- a/src/pysdmx/fmr/fusion/dsd.py
+++ b/src/pysdmx/fmr/fusion/dsd.py
@@ -123,13 +123,14 @@ class FusionAttribute(Struct, frozen=True):
         else:
             desc = None
         return Component(
-            self.id,
-            self.mandatory,
-            Role.ATTRIBUTE,
-            dt,
-            facets,
-            c.names[0].value,
-            desc,
+            id=self.id,
+            required=self.mandatory,
+            role=Role.ATTRIBUTE,
+            concept=c.to_model(cls),
+            dtype=dt,
+            facets=facets,
+            name=c.names[0].value,
+            description=desc,
             codes=codes,
             attachment_level=lvl,
             array_def=ab,
@@ -175,13 +176,14 @@ class FusionDimension(Struct, frozen=True):
         else:
             desc = None
         return Component(
-            self.id,
-            True,
-            Role.DIMENSION,
-            dt,
-            facets,
-            c.names[0].value,
-            desc,
+            id=self.id,
+            required=True,
+            role=Role.DIMENSION,
+            concept=c.to_model(cls),
+            dtype=dt,
+            facets=facets,
+            name=c.names[0].value,
+            description=desc,
             codes=codes,
             array_def=ab,
         )
@@ -226,13 +228,14 @@ class FusionMeasure(Struct, frozen=True):
         else:
             desc = None
         return Component(
-            self.id,
-            self.mandatory,
-            Role.MEASURE,
-            dt,
-            facets,
-            c.names[0].value,
-            desc,
+            id=self.id,
+            required=self.mandatory,
+            role=Role.MEASURE,
+            concept=c.to_model(cls),
+            dtype=dt,
+            facets=facets,
+            name=c.names[0].value,
+            description=desc,
             codes=codes,
             array_def=ab,
         )

--- a/src/pysdmx/fmr/fusion/dsd.py
+++ b/src/pysdmx/fmr/fusion/dsd.py
@@ -40,7 +40,7 @@ def _get_representation(
     cls: Sequence[FusionCodelist],
     cons: Dict[str, Sequence[str]],
 ) -> Tuple[
-    DataType,
+    Optional[DataType],
     Optional[Facets],
     Optional[Codelist],
     Optional[ArrayBoundaries],

--- a/src/pysdmx/fmr/fusion/schema.py
+++ b/src/pysdmx/fmr/fusion/schema.py
@@ -50,7 +50,7 @@ class FusionSchemaMessage(msgspec.Struct, frozen=True):
             comp_id = parse_item_urn(ha.component_ref).item_id
             h = msgspec.structs.replace(ha.hierarchy, operator=ha.operator)
             comp_dict[comp_id] = msgspec.structs.replace(
-                components[comp_id], codes=h
+                components[comp_id], local_codes=h
             )
             urns.append(
                 "urn:sdmx:org.sdmx.infomodel.codelist.Hierarchy="

--- a/src/pysdmx/fmr/sdmx/concept.py
+++ b/src/pysdmx/fmr/sdmx/concept.py
@@ -6,7 +6,7 @@ from msgspec import Struct
 
 from pysdmx.fmr.sdmx.code import JsonCodelist
 from pysdmx.fmr.sdmx.core import JsonRepresentation
-from pysdmx.model import Concept, ConceptScheme, DataType
+from pysdmx.model import Codelist, Concept, ConceptScheme, DataType
 
 
 class JsonConcept(Struct, frozen=True):
@@ -17,7 +17,7 @@ class JsonConcept(Struct, frozen=True):
     name: Optional[str] = None
     description: Optional[str] = None
 
-    def to_model(self, codelists: Sequence[JsonCodelist]) -> Concept:
+    def to_model(self, codelists: Sequence[Codelist]) -> Concept:
         """Converts a JsonConcept to a standard concept."""
         repr_ = self.coreRepresentation
         if repr_:
@@ -30,9 +30,7 @@ class JsonConcept(Struct, frozen=True):
                     repr_.format.textType,  # type: ignore[union-attr]
                 )
             facets = repr_.to_facets()
-            codes = repr_.to_enumeration(
-                [cl.to_model() for cl in codelists], []
-            )
+            codes = repr_.to_enumeration(codelists, [])
             cl_ref = repr_.enumeration
         else:
             dt = DataType.STRING
@@ -62,13 +60,14 @@ class JsonConceptScheme(Struct, frozen=True, rename={"agency": "agencyID"}):
 
     def to_model(self, codelists: Sequence[JsonCodelist]) -> ConceptScheme:
         """Converts a JsonConceptScheme to a standard concept scheme."""
+        cls = [c.to_model() for c in codelists]
         return ConceptScheme(
             id=self.id,
             name=self.name,
             agency=self.agency,
             description=self.description,
             version=self.version,
-            items=[c.to_model(codelists) for c in self.concepts],
+            items=[c.to_model(cls) for c in self.concepts],
         )
 
 

--- a/src/pysdmx/fmr/sdmx/dsd.py
+++ b/src/pysdmx/fmr/sdmx/dsd.py
@@ -45,7 +45,7 @@ def _get_representation(
     cls: Sequence[Codelist],
     cons: Dict[str, Sequence[str]],
 ) -> Tuple[
-    DataType,
+    Optional[DataType],
     Optional[Facets],
     Optional[Codelist],
     Optional[ArrayBoundaries],

--- a/src/pysdmx/fmr/sdmx/dsd.py
+++ b/src/pysdmx/fmr/sdmx/dsd.py
@@ -116,13 +116,14 @@ class JsonDimension(Struct, frozen=True):
             self.id, self.localRepresentation, c.coreRepresentation, cls, cons
         )
         return Component(
-            self.id,
-            True,
-            Role.DIMENSION,
-            dt,
-            facets,
-            c.name,
-            c.description,
+            id=self.id,
+            required=True,
+            role=Role.DIMENSION,
+            concept=c.to_model(cls),
+            dtype=dt,
+            facets=facets,
+            name=c.name,
+            description=c.description,
             codes=codes,
             array_def=ab,
         )
@@ -156,13 +157,14 @@ class JsonAttribute(Struct, frozen=True):
             self.measureRelationship,
         )
         return Component(
-            self.id,
-            req,
-            Role.ATTRIBUTE,
-            dt,
-            facets,
-            c.name,
-            c.description,
+            id=self.id,
+            required=req,
+            role=Role.ATTRIBUTE,
+            concept=c.to_model(cls),
+            dtype=dt,
+            facets=facets,
+            name=c.name,
+            description=c.description,
             codes=codes,
             attachment_level=lvl,
             array_def=ab,
@@ -190,13 +192,14 @@ class JsonMeasure(Struct, frozen=True):
         )
         req = self.usage != "optional"
         return Component(
-            self.id,
-            req,
-            Role.MEASURE,
-            dt,
-            facets,
-            c.name,
-            c.description,
+            id=self.id,
+            required=req,
+            role=Role.MEASURE,
+            concept=c.to_model(cls),
+            dtype=dt,
+            facets=facets,
+            name=c.name,
+            description=c.description,
             codes=codes,
             array_def=ab,
         )

--- a/src/pysdmx/fmr/sdmx/schema.py
+++ b/src/pysdmx/fmr/sdmx/schema.py
@@ -59,7 +59,7 @@ class JsonSchemaMessage(
             comp_id = parse_item_urn(ha.component_ref).item_id
             h = msgspec.structs.replace(ha.hierarchy, operator=ha.operator)
             comp_dict[comp_id] = msgspec.structs.replace(
-                components[comp_id], codes=h
+                components[comp_id], local_codes=h
             )
             urns.append(
                 "urn:sdmx:org.sdmx.infomodel.codelist.Hierarchy="

--- a/src/pysdmx/model/concept.py
+++ b/src/pysdmx/model/concept.py
@@ -145,7 +145,7 @@ class Concept(Item, frozen=True, omit_defaults=True):
             which the codes are taken.
     """
 
-    dtype: DataType = DataType.STRING
+    dtype: Optional[DataType] = None
     facets: Optional[Facets] = None
     codes: Optional[Codelist] = None
     enum_ref: Optional[str] = None

--- a/src/pysdmx/model/dataflow.py
+++ b/src/pysdmx/model/dataflow.py
@@ -85,11 +85,13 @@ class Component(Struct, frozen=True, omit_defaults=True):
         id: A unique identifier for the component (e.g. FREQ).
         required: Whether the component must have a value.
         role: The role played by the component.
-        dtype: The component's data type (string, number, etc.).
-        facets: Additional details such as the component's minimum length.
+        local_dtype: The component's local data type (string, number, etc.).
+        local_facets: Additional local details such as the component's minimum
+            length.
         name: The component's name.
         description: Additional descriptive information about the component.
-        codes: The expected values for the component (e.g. currency codes).
+        local_codes: The expected local values for the component (e.g. currency
+            codes).
         attachment_level: The attachement level (if role = A only).
             Attributes can be attached at different levels such as
             D (for dataset-level attributes), O (for observation-level
@@ -102,13 +104,59 @@ class Component(Struct, frozen=True, omit_defaults=True):
     required: bool
     role: Role
     concept: Concept
-    dtype: DataType = DataType.STRING
-    facets: Optional[Facets] = None
+    local_dtype: Optional[DataType] = None
+    local_facets: Optional[Facets] = None
     name: Optional[str] = None
     description: Optional[str] = None
-    codes: Union[Codelist, Hierarchy, None] = None
+    local_codes: Union[Codelist, Hierarchy, None] = None
     attachment_level: Optional[str] = None
     array_def: Optional[ArrayBoundaries] = None
+
+    @property
+    def dtype(self) -> DataType:
+        """Returns the component data type.
+
+        This will return the local data type (if any) or
+        the data type of the referenced concept (if any).
+        In case neither are set, the data type will default
+        to string.
+        """
+        if self.local_dtype:
+            return self.local_dtype
+        elif self.concept.dtype:
+            return self.concept.dtype
+        else:
+            return DataType.STRING
+
+    @property
+    def facets(self) -> Optional[Facets]:
+        """Returns the component facets.
+
+        This will return the local facets (if any) or
+        the facets of the referenced concept (if any), or
+        None in case neither are set.
+        """
+        if self.local_facets:
+            return self.local_facets
+        elif self.concept.facets:
+            return self.concept.facets
+        else:
+            return None
+
+    @property
+    def codes(self) -> Union[Codelist, Hierarchy, None]:
+        """Returns the component codes.
+
+        This will return the local codes (if any) or
+        the codes of the referenced concept (if any), or
+        None in case neither are set.
+        """
+        if self.local_codes:
+            return self.local_codes
+        elif self.concept.codes:
+            return self.concept.codes
+        else:
+            return None
 
     def __str__(self) -> str:
         """Returns a human-friendly description."""

--- a/src/pysdmx/model/dataflow.py
+++ b/src/pysdmx/model/dataflow.py
@@ -16,7 +16,7 @@ from msgspec import Struct
 
 from pysdmx.model.__base import Agency, DataProvider
 from pysdmx.model.code import Codelist, Hierarchy
-from pysdmx.model.concept import DataType, Facets
+from pysdmx.model.concept import Concept, DataType, Facets
 
 
 class Role(str, Enum):
@@ -101,6 +101,7 @@ class Component(Struct, frozen=True, omit_defaults=True):
     id: str
     required: bool
     role: Role
+    concept: Concept
     dtype: DataType = DataType.STRING
     facets: Optional[Facets] = None
     name: Optional[str] = None
@@ -115,7 +116,10 @@ class Component(Struct, frozen=True, omit_defaults=True):
         for k in self.__annotations__.keys():
             v = self.__getattribute__(k)
             if v:
-                out.append(f"{k}={str(v)}")
+                if k == "concept":
+                    out.append(f"{k}=({str(v)})")
+                else:
+                    out.append(f"{k}={str(v)}")
         return ", ".join(out)
 
 

--- a/src/pysdmx/model/dataflow.py
+++ b/src/pysdmx/model/dataflow.py
@@ -120,6 +120,9 @@ class Component(Struct, frozen=True, omit_defaults=True):
         the data type of the referenced concept (if any).
         In case neither are set, the data type will default
         to string.
+
+        Returns:
+            The component data type (local, core or default).
         """
         if self.local_dtype:
             return self.local_dtype
@@ -135,6 +138,9 @@ class Component(Struct, frozen=True, omit_defaults=True):
         This will return the local facets (if any) or
         the facets of the referenced concept (if any), or
         None in case neither are set.
+
+        Returns:
+            The component facets (local or core).
         """
         if self.local_facets:
             return self.local_facets
@@ -150,6 +156,9 @@ class Component(Struct, frozen=True, omit_defaults=True):
         This will return the local codes (if any) or
         the codes of the referenced concept (if any), or
         None in case neither are set.
+
+        Returns:
+            The component codes (local or core).
         """
         if self.local_codes:
             return self.local_codes

--- a/tests/fmr/samples/df/hierarchy_schema.fusion.json
+++ b/tests/fmr/samples/df/hierarchy_schema.fusion.json
@@ -228,7 +228,7 @@
                         "textFormat": {
                             "textType": "String"
                         },
-                        "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:OPTION_TYPE(1.0)"
+                        "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_OPTION_TYPE(1.0)"
                     }
                 }
             ]

--- a/tests/fmr/samples/df/hierarchy_schema.json
+++ b/tests/fmr/samples/df/hierarchy_schema.json
@@ -298,7 +298,7 @@
                             "enumerationFormat": {
                                 "textType": "String"
                             },
-                            "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL)OPTION_TYPE(1.0)"
+                            "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_OPTION_TYPE(1.0)"
                         }
                     }
                 ]

--- a/tests/fmr/schema_checks.py
+++ b/tests/fmr/schema_checks.py
@@ -36,6 +36,12 @@ def check_schema(mock, fmr: RegistryClient, query, hca_query, body, hca_body):
         assert isinstance(comp, Component)
         assert comp.id is not None
         assert comp.name is not None
+        assert comp.concept is not None
+        assert comp.concept.id is not None
+        assert comp.id == comp.concept.id
+        assert comp.required is not None
+        assert comp.role is not None
+        assert comp.dtype is not None
 
 
 def check_schema_from_pra(

--- a/tests/model/test_component.py
+++ b/tests/model/test_component.py
@@ -1,6 +1,13 @@
 import pytest
 
-from pysdmx.model import ArrayBoundaries, Component, DataType, Facets, Role
+from pysdmx.model import (
+    ArrayBoundaries,
+    Component,
+    Concept,
+    DataType,
+    Facets,
+    Role,
+)
 
 
 @pytest.fixture()
@@ -33,12 +40,18 @@ def array_def():
     return ArrayBoundaries(1, 10)
 
 
-def test_defaults(fid, req, role):
-    f = Component(fid, req, role)
+@pytest.fixture()
+def concept():
+    return Concept("TEST", name="A test concept")
+
+
+def test_defaults(fid, req, role, concept):
+    f = Component(fid, req, role, concept)
 
     assert f.id == fid
     assert f.required == req
     assert f.role == role
+    assert f.concept == concept
     assert f.dtype == DataType.STRING
     assert f.facets is None
     assert f.name is None
@@ -47,7 +60,7 @@ def test_defaults(fid, req, role):
     assert f.attachment_level is None
 
 
-def test_full_initialization(fid, req, role, typ, array_def):
+def test_full_initialization(fid, req, role, concept, typ, array_def):
     facets = Facets(min_value=0, max_value="100")
     name = "Signal quality"
     desc = "The quality of the GPS signal"
@@ -57,6 +70,7 @@ def test_full_initialization(fid, req, role, typ, array_def):
         fid,
         req,
         role,
+        concept,
         typ,
         facets,
         name,
@@ -68,6 +82,7 @@ def test_full_initialization(fid, req, role, typ, array_def):
     assert f.id == fid
     assert f.required == req
     assert f.role == role
+    assert f.concept == concept
     assert f.dtype == typ
     assert f.facets == facets
     assert f.name == name
@@ -77,32 +92,33 @@ def test_full_initialization(fid, req, role, typ, array_def):
     assert f.array_def == array_def
 
 
-def test_immutable(fid, req, role, typ):
-    f = Component(fid, req, role, typ)
+def test_immutable(fid, req, role, concept, typ):
+    f = Component(fid, req, role, concept, typ)
     with pytest.raises(AttributeError):
         f.name = fid
 
 
-def test_equal(fid, req, role, typ):
-    f1 = Component(fid, req, role, typ)
-    f2 = Component(fid, req, role, typ)
+def test_equal(fid, req, role, concept, typ):
+    f1 = Component(fid, req, role, concept, typ)
+    f2 = Component(fid, req, role, concept, typ)
 
     assert f1 == f2
 
 
-def test_not_equal(fid, req, role, typ):
-    f1 = Component(fid, req, role, typ)
-    f2 = Component(fid, req, role, typ, name=fid)
+def test_not_equal(fid, req, role, concept, typ):
+    f1 = Component(fid, req, role, concept, typ)
+    f2 = Component(fid, req, role, concept, typ, name=fid)
 
     assert f1 != f2
 
 
-def test_tostr(fid, req, role, typ):
-    f1 = Component(fid, req, role, typ)
+def test_tostr(fid, req, role, concept, typ):
+    f1 = Component(fid, req, role, concept, typ)
 
     s = str(f1)
 
     assert s == (
-        f"id={fid}, required=True, role=Role.DIMENSION, "
+        f"id={fid}, required=True, role=Role.DIMENSION, concept="
+        f"(id={concept.id}, name={concept.name}, dtype=DataType.STRING), "
         "dtype=DataType.STRING"
     )

--- a/tests/model/test_component.py
+++ b/tests/model/test_component.py
@@ -2,6 +2,8 @@ import pytest
 
 from pysdmx.model import (
     ArrayBoundaries,
+    Code,
+    Codelist,
     Component,
     Concept,
     DataType,
@@ -45,6 +47,20 @@ def concept():
     return Concept("TEST", name="A test concept")
 
 
+@pytest.fixture()
+def codes():
+    c1 = Code("A", "Annual")
+    c2 = Code("D", "Daily")
+    return Codelist(
+        "CL_FREQ", name="Frequency codelist", agency="BIS", items=[c1, c2]
+    )
+
+
+@pytest.fixture()
+def facets():
+    return Facets(min_length=2)
+
+
 def test_defaults(fid, req, role, concept):
     f = Component(fid, req, role, concept)
 
@@ -60,8 +76,9 @@ def test_defaults(fid, req, role, concept):
     assert f.attachment_level is None
 
 
-def test_full_initialization(fid, req, role, concept, typ, array_def):
-    facets = Facets(min_value=0, max_value="100")
+def test_full_initialization(
+    fid, req, role, concept, typ, array_def, facets, codes
+):
     name = "Signal quality"
     desc = "The quality of the GPS signal"
     lvl = "O"
@@ -75,8 +92,9 @@ def test_full_initialization(fid, req, role, concept, typ, array_def):
         facets,
         name,
         desc,
-        attachment_level=lvl,
-        array_def=array_def,
+        codes,
+        lvl,
+        array_def,
     )
 
     assert f.id == fid
@@ -87,7 +105,7 @@ def test_full_initialization(fid, req, role, concept, typ, array_def):
     assert f.facets == facets
     assert f.name == name
     assert f.description == desc
-    assert not f.codes
+    assert f.codes == codes
     assert f.attachment_level == lvl
     assert f.array_def == array_def
 
@@ -119,6 +137,102 @@ def test_tostr(fid, req, role, concept, typ):
 
     assert s == (
         f"id={fid}, required=True, role=Role.DIMENSION, concept="
-        f"(id={concept.id}, name={concept.name}, dtype=DataType.STRING), "
-        "dtype=DataType.STRING"
+        f"(id={concept.id}, name={concept.name}), "
+        "local_dtype=DataType.STRING"
     )
+
+
+def test_dtype_property_local():
+    concept = Concept("FREQ")
+
+    component = Component(
+        "FREQ", True, Role.DIMENSION, concept, DataType.ALPHA
+    )
+
+    assert component.concept.dtype is None
+    assert component.local_dtype == DataType.ALPHA
+    assert component.dtype == DataType.ALPHA
+
+
+def test_dtype_property_core():
+    concept = Concept("FREQ", dtype=DataType.ALPHA)
+
+    component = Component("FREQ", True, Role.DIMENSION, concept)
+
+    assert component.concept.dtype == DataType.ALPHA
+    assert component.local_dtype is None
+    assert component.dtype == DataType.ALPHA
+
+
+def test_dtype_property_none():
+    concept = Concept("FREQ")
+
+    component = Component("FREQ", True, Role.DIMENSION, concept)
+
+    assert component.concept.dtype is None
+    assert component.local_dtype is None
+    assert component.dtype == DataType.STRING
+
+
+def test_facets_property_local(facets):
+    concept = Concept("FREQ")
+
+    component = Component(
+        "FREQ", True, Role.DIMENSION, concept, local_facets=facets
+    )
+
+    assert component.concept.facets is None
+    assert component.local_facets == facets
+    assert component.facets == facets
+
+
+def test_facets_property_core(facets):
+    concept = Concept("FREQ", facets=facets)
+
+    component = Component("FREQ", True, Role.DIMENSION, concept)
+
+    assert component.concept.facets == facets
+    assert component.local_facets is None
+    assert component.facets == facets
+
+
+def test_facets_property_none():
+    concept = Concept("FREQ")
+
+    component = Component("FREQ", True, Role.DIMENSION, concept)
+
+    assert component.concept.facets is None
+    assert component.local_facets is None
+    assert component.facets is None
+
+
+def test_codes_property_local(codes):
+    concept = Concept("FREQ")
+
+    component = Component(
+        "FREQ", True, Role.DIMENSION, concept, local_codes=codes
+    )
+
+    assert component.concept.codes is None
+    assert component.local_codes == codes
+    assert component.codes == codes
+
+
+def test_codes_property_core(codes):
+    concept = Concept("FREQ", codes=codes)
+
+    component = Component("FREQ", True, Role.DIMENSION, concept)
+
+    assert component.concept.codes == codes
+    assert component.local_codes is None
+    assert component.codes == codes
+
+
+def test_codes_property_none():
+    concept = Concept("FREQ")
+
+    component = Component("FREQ", True, Role.DIMENSION, concept)
+
+    assert component.concept.codes is None
+    assert component.local_codes is None
+    assert component.codes is None

--- a/tests/model/test_concept.py
+++ b/tests/model/test_concept.py
@@ -17,7 +17,7 @@ def test_defaults(fid):
     f = Concept(id=fid)
 
     assert f.id == fid
-    assert f.dtype == DataType.STRING
+    assert f.dtype is None
     assert f.facets is None
     assert f.name is None
     assert f.description is None

--- a/tests/model/test_encoders.py
+++ b/tests/model/test_encoders.py
@@ -3,7 +3,7 @@ from typing import List
 
 import pytest
 
-from pysdmx.model import Component, Components, encoders, Role
+from pysdmx.model import Concept, Component, Components, encoders, Role
 
 
 def test_pattern():
@@ -16,8 +16,8 @@ def test_pattern():
 
 
 def test_components():
-    c1 = Component("IND", True, Role.DIMENSION)
-    c2 = Component("VAL", True, Role.MEASURE)
+    c1 = Component("IND", True, Role.DIMENSION, Concept("IND"))
+    c2 = Component("VAL", True, Role.MEASURE, Concept("VAL"))
     comps = Components([c1, c2])
 
     out = encoders(comps)

--- a/tests/model/test_encoders.py
+++ b/tests/model/test_encoders.py
@@ -3,7 +3,7 @@ from typing import List
 
 import pytest
 
-from pysdmx.model import Concept, Component, Components, encoders, Role
+from pysdmx.model import Component, Components, Concept, encoders, Role
 
 
 def test_pattern():


### PR DESCRIPTION
As [discussed](https://github.com/bis-med-it/pysdmx/discussions/31), I have added support for local and core representations. This includes data type, facets and enumeration.

In order to keep the API simple, properties have been added to return the local representation (if set), or the core representation (if set), or the default value in case both are unset. Default value is `None` for facets and enumeration, and `DataType.STRING` for the data type. 

Close #38 
