### PR TITLE
Distinguish between Dataflow (Maintainable) and DataflowRef

### DIFF
--- a/src/pysdmx/api/dc/_api.py
+++ b/src/pysdmx/api/dc/_api.py
@@ -85,7 +85,7 @@ class Connector(Protocol):
 
     def dataflow(
         self,
-        dataflow: Union[str, DataflowRef, DataflowInfo],
+        dataflow: Union[str, DataflowRef, Dataflow],
         metrics: bool = False,
     ) -> DataflowInfo:
         """Get information about a dataflow.

--- a/src/pysdmx/api/dc/_api.py
+++ b/src/pysdmx/api/dc/_api.py
@@ -10,7 +10,6 @@ from typing import (
     Optional,
     Protocol,
     runtime_checkable,
-    Sequence,
     Union,
 )
 
@@ -24,6 +23,7 @@ from pysdmx.api.dc.query import (
     TextFilter,
 )
 from pysdmx.model import (
+    Dataflow,
     DataflowInfo,
     DataflowRef,
     Organisation,
@@ -49,7 +49,7 @@ class Connector(Protocol):
         self,
         filter_query: Optional[str] = None,
         provider: Optional[str] = None,
-    ) -> Iterable[DataflowRef]:
+    ) -> Union[Iterable[Dataflow], Iterable[DataflowRef]]:
         """Get the dataflows provided by the Connector.
 
         Args:
@@ -84,7 +84,9 @@ class Connector(Protocol):
         """
 
     def dataflow(
-        self, dataflow: Union[str, DataflowRef], metrics: bool = False
+        self,
+        dataflow: Union[str, DataflowRef, DataflowInfo],
+        metrics: bool = False,
     ) -> DataflowInfo:
         """Get information about a dataflow.
 
@@ -111,7 +113,7 @@ class Connector(Protocol):
 
     def series(
         self,
-        dataflow: Union[str, DataflowRef, DataflowInfo],
+        dataflow: Union[str, DataflowRef, Dataflow, DataflowInfo],
         provider: Optional[Union[str, Organisation]] = None,
         filters: Optional[
             Union[
@@ -153,9 +155,9 @@ class Connector(Protocol):
 
     def data(
         self,
-        dataflow: Union[str, DataflowRef, DataflowInfo],
+        dataflow: Union[str, DataflowRef, Dataflow, DataflowInfo],
         provider: Optional[Union[str, Organisation]] = None,
-        series: Optional[Sequence[str]] = None,
+        series: Optional[Iterable[str]] = None,
         filters: Optional[
             Union[
                 BooleanFilter,
@@ -167,7 +169,7 @@ class Connector(Protocol):
                 TextFilter,
             ]
         ] = None,
-        columns: Optional[Sequence[str]] = None,
+        columns: Optional[Iterable[str]] = None,
         sort: Optional[List[SortBy]] = None,
         offset: int = 0,
         limit: Optional[int] = None,

--- a/src/pysdmx/io/json/fusion/messages/category.py
+++ b/src/pysdmx/io/json/fusion/messages/category.py
@@ -6,8 +6,8 @@ from typing import Dict, Optional, Sequence
 from msgspec import Struct
 
 from pysdmx.io.json.fusion.messages.core import FusionString
-from pysdmx.io.json.fusion.messages.dataflow import FusionDataflowRef
-from pysdmx.model import Category, CategoryScheme as CS, DataflowRef
+from pysdmx.io.json.fusion.messages.dataflow import FusionDataflow
+from pysdmx.model import Category, CategoryScheme as CS, Dataflow as DF
 from pysdmx.util import find_by_urn
 
 
@@ -65,10 +65,10 @@ class FusionCategorySchemeMessage(Struct, frozen=True):
 
     Categorisation: Sequence[FusionCategorisation]
     CategoryScheme: Sequence[FusionCategoryScheme]
-    Dataflow: Sequence[FusionDataflowRef]
+    Dataflow: Sequence[FusionDataflow]
 
-    def __group_flows(self) -> defaultdict[str, list[DataflowRef]]:
-        out: defaultdict[str, list[DataflowRef]] = defaultdict(list)
+    def __group_flows(self) -> defaultdict[str, list[DF]]:
+        out: defaultdict[str, list[DF]] = defaultdict(list)
         for c in self.Categorisation:
             d = find_by_urn(self.Dataflow, c.structureReference)
             src = c.categoryReference[c.categoryReference.find(")") + 2 :]
@@ -76,7 +76,7 @@ class FusionCategorySchemeMessage(Struct, frozen=True):
         return out
 
     def __add_flows(
-        self, cat: Category, cni: str, cf: Dict[str, list[DataflowRef]]
+        self, cat: Category, cni: str, cf: Dict[str, list[DF]]
     ) -> None:
         if cat.categories:
             for c in cat.categories:

--- a/src/pysdmx/io/json/fusion/messages/dataflow.py
+++ b/src/pysdmx/io/json/fusion/messages/dataflow.py
@@ -9,24 +9,25 @@ from pysdmx.io.json.fusion.messages.org import FusionProviderScheme
 from pysdmx.model import (
     Agency,
     Components,
+    Dataflow,
     DataflowInfo,
-    DataflowRef,
     DataProvider,
 )
 
 
-class FusionDataflowRef(Struct, frozen=True, rename={"agency": "agencyId"}):
+class FusionDataflow(Struct, frozen=True, rename={"agency": "agencyId"}):
     """Fusion-JSON payload for a dataflow."""
 
     id: str
     agency: str
     names: Sequence[FusionString]
+    dataStructureRef: str
     descriptions: Optional[Sequence[FusionString]] = None
     version: str = "1.0"
 
-    def to_model(self) -> DataflowRef:
-        """Converts a FusionDataflowRef to a standard dataflow ref."""
-        return DataflowRef(
+    def to_model(self) -> Dataflow:
+        """Converts a FusionDataflow to a standard dataflow."""
+        return Dataflow(
             id=self.id,
             agency=self.agency,
             name=self.names[0].value if self.names else None,
@@ -34,18 +35,8 @@ class FusionDataflowRef(Struct, frozen=True, rename={"agency": "agencyId"}):
                 self.descriptions[0].value if self.descriptions else None
             ),
             version=self.version,
+            structure=self.dataStructureRef,
         )
-
-
-class FusionDataflow(Struct, frozen=True, rename={"agency": "agencyId"}):
-    """Fusion-JSON payload for a dataflow."""
-
-    id: str
-    names: Sequence[FusionString]
-    agency: str
-    dataStructureRef: str
-    descriptions: Optional[Sequence[FusionString]] = None
-    version: str = "1.0"
 
 
 class FusionDataflowMessage(Struct, frozen=True):

--- a/src/pysdmx/io/json/sdmxjson2/messages/category.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/category.py
@@ -29,6 +29,8 @@ class JsonCategorisation(Struct, frozen=True, rename={"agency": "agencyID"}):
 
 
 class JsonCategory(Struct, frozen=True):
+    """SDMX-JSON payload for a category."""
+
     id: str  # type: ignore[misc, unused-ignore]
     name: Optional[str] = None
     description: Optional[str] = None

--- a/src/pysdmx/io/json/sdmxjson2/messages/category.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/category.py
@@ -7,8 +7,8 @@ from typing import Dict, Optional, Sequence
 from msgspec import Struct
 
 from pysdmx.io.json.sdmxjson2.messages.core import JsonAnnotation
-from pysdmx.io.json.sdmxjson2.messages.dataflow import JsonDataflowRef
-from pysdmx.model import Category, CategoryScheme, DataflowRef
+from pysdmx.io.json.sdmxjson2.messages.dataflow import JsonDataflow
+from pysdmx.model import Category, CategoryScheme, Dataflow
 from pysdmx.util import find_by_urn
 
 
@@ -59,7 +59,7 @@ class JsonCategorySchemes(Struct, frozen=True):
 
     categorisations: Sequence[JsonCategorisation]
     categorySchemes: Sequence[JsonCategoryScheme]
-    dataflows: Sequence[JsonDataflowRef]
+    dataflows: Sequence[JsonDataflow]
 
 
 class JsonCategorySchemeMessage(Struct, frozen=True):
@@ -67,8 +67,8 @@ class JsonCategorySchemeMessage(Struct, frozen=True):
 
     data: JsonCategorySchemes
 
-    def __group_flows(self) -> defaultdict[str, list[DataflowRef]]:
-        out: defaultdict[str, list[DataflowRef]] = defaultdict(list)
+    def __group_flows(self) -> defaultdict[str, list[Dataflow]]:
+        out: defaultdict[str, list[Dataflow]] = defaultdict(list)
         for c in self.data.categorisations:
             d = find_by_urn(self.data.dataflows, c.source)
             src = c.target[c.target.find(")") + 2 :]
@@ -76,7 +76,7 @@ class JsonCategorySchemeMessage(Struct, frozen=True):
         return out
 
     def __add_flows(
-        self, cat: Category, cni: str, cf: Dict[str, list[DataflowRef]]
+        self, cat: Category, cni: str, cf: Dict[str, list[Dataflow]]
     ) -> None:
         if cat.categories:
             for c in cat.categories:

--- a/src/pysdmx/io/json/sdmxjson2/messages/category.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/category.py
@@ -28,6 +28,22 @@ class JsonCategorisation(Struct, frozen=True, rename={"agency": "agencyID"}):
     annotations: Optional[Sequence[JsonAnnotation]] = None
 
 
+class JsonCategory(Struct, frozen=True):
+    id: str  # type: ignore[misc, unused-ignore]
+    name: Optional[str] = None
+    description: Optional[str] = None
+    categories: Sequence["JsonCategory"] = ()
+
+    def to_model(self) -> Category:
+        """Converts a FusionCode to a standard code."""
+        return Category(
+            id=self.id,
+            name=self.name,
+            description=self.description,
+            categories=[c.to_model() for c in self.categories],
+        )
+
+
 class JsonCategoryScheme(Struct, frozen=True, rename={"agency": "agencyID"}):
     """SDMX-JSON payload for a category scheme."""
 
@@ -40,7 +56,7 @@ class JsonCategoryScheme(Struct, frozen=True, rename={"agency": "agencyID"}):
     validFrom: Optional[datetime] = None
     validTo: Optional[datetime] = None
     annotations: Optional[Sequence[JsonAnnotation]] = None
-    categories: Sequence[Category] = ()
+    categories: Sequence[JsonCategory] = ()
 
     def to_model(self) -> CategoryScheme:
         """Converts a JsonCodelist to a standard codelist."""
@@ -50,7 +66,7 @@ class JsonCategoryScheme(Struct, frozen=True, rename={"agency": "agencyID"}):
             agency=self.agency,
             description=self.description,
             version=self.version,
-            items=self.categories,
+            items=[c.to_model() for c in self.categories],
         )
 
 

--- a/src/pysdmx/io/json/sdmxjson2/messages/dataflow.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/dataflow.py
@@ -7,33 +7,7 @@ from msgspec import Struct
 
 from pysdmx.io.json.sdmxjson2.messages.core import JsonAnnotation
 from pysdmx.io.json.sdmxjson2.messages.org import JsonDataProviderScheme
-from pysdmx.model import (
-    Agency,
-    Components,
-    DataflowInfo,
-    DataflowRef,
-    DataProvider,
-)
-
-
-class JsonDataflowRef(Struct, frozen=True, rename={"agency": "agencyID"}):
-    """SDMX-JSON payload for a dataflow."""
-
-    id: str
-    agency: str
-    name: Optional[str] = None
-    description: Optional[str] = None
-    version: str = "1.0"
-
-    def to_model(self) -> DataflowRef:
-        """Converts a JsonDataflowRef to a standard dataflow ref."""
-        return DataflowRef(
-            id=self.id,
-            agency=self.agency,
-            name=self.name,
-            description=self.description,
-            version=self.version,
-        )
+from pysdmx.model import Agency, Components, DataflowInfo, DataProvider
 
 
 class JsonDataflow(Struct, frozen=True, rename={"agency": "agencyID"}):

--- a/src/pysdmx/io/json/sdmxjson2/messages/dataflow.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/dataflow.py
@@ -7,7 +7,13 @@ from msgspec import Struct
 
 from pysdmx.io.json.sdmxjson2.messages.core import JsonAnnotation
 from pysdmx.io.json.sdmxjson2.messages.org import JsonDataProviderScheme
-from pysdmx.model import Agency, Components, DataflowInfo, DataProvider
+from pysdmx.model import (
+    Agency,
+    Components,
+    Dataflow,
+    DataflowInfo,
+    DataProvider,
+)
 
 
 class JsonDataflow(Struct, frozen=True, rename={"agency": "agencyID"}):
@@ -23,6 +29,17 @@ class JsonDataflow(Struct, frozen=True, rename={"agency": "agencyID"}):
     validFrom: Optional[datetime] = None
     validTo: Optional[datetime] = None
     annotations: Optional[Sequence[JsonAnnotation]] = None
+
+    def to_model(self) -> Dataflow:
+        """Converts a FusionDataflow to a standard dataflow."""
+        return Dataflow(
+            id=self.id,
+            agency=self.agency,
+            name=self.name,
+            description=self.description,
+            version=self.version,
+            structure=self.structure,
+        )
 
 
 class JsonDataflows(Struct, frozen=True):

--- a/src/pysdmx/model/__base.py
+++ b/src/pysdmx/model/__base.py
@@ -268,9 +268,9 @@ class DataflowRef(Struct, frozen=True, omit_defaults=True):
 
     def __hash__(self) -> int:
         """Returns the dataflow reference's hash."""
-        return hash(self.agency, self.id, self.version)
+        return hash((self.agency, self.id, self.version))
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         """Whether the 2 objects are equal."""
         return (
             self.__class__ == other.__class__
@@ -279,6 +279,6 @@ class DataflowRef(Struct, frozen=True, omit_defaults=True):
             and self.version == other.version
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         """A string representating the dataflow's reference."""
         return f"Dataflow={self.agency}:{self.id}({self.version})"

--- a/src/pysdmx/model/__base.py
+++ b/src/pysdmx/model/__base.py
@@ -265,3 +265,20 @@ class DataflowRef(Struct, frozen=True, omit_defaults=True):
     agency: str
     id: str
     version: str = "1.0"
+
+    def __hash__(self) -> int:
+        """Returns the dataflow reference's hash."""
+        return hash(self.agency, self.id, self.version)
+
+    def __eq__(self, other):
+        """Whether the 2 objects are equal."""
+        return (
+            self.__class__ == other.__class__
+            and self.agency == other.agency
+            and self.id == other.id
+            and self.version == other.version
+        )
+
+    def __str__(self):
+        """A string representating the dataflow's reference."""
+        return f"Dataflow={self.agency}:{self.id}({self.version})"

--- a/src/pysdmx/model/__base.py
+++ b/src/pysdmx/model/__base.py
@@ -253,13 +253,15 @@ class ItemScheme(MaintainableArtefact, frozen=True, omit_defaults=True):
     is_partial: bool = False
 
 
-class DataflowRef(MaintainableArtefact, frozen=True, omit_defaults=True):
-    """Provide core information about a dataflow.
+class DataflowRef(Struct, frozen=True, omit_defaults=True):
+    """A unique reference to a dataflow.
 
     Attributes:
         id: The dataflow identifier (e.g. BIS_MACRO).
         agency: The organisation (or unit) responsible for the dataflow.
-        name: The dataflow name (e.g. MACRO dataflow).
-        description: Additional descriptive information about the dataflow.
         version: The version of the dataflow (e.g. 1.0).
     """
+
+    agency: str
+    id: str
+    version: str = "1.0"

--- a/src/pysdmx/model/__init__.py
+++ b/src/pysdmx/model/__init__.py
@@ -29,6 +29,7 @@ from pysdmx.model.dataflow import (
     ArrayBoundaries,
     Component,
     Components,
+    Dataflow,
     DataflowInfo,
     Role,
     Schema,

--- a/src/pysdmx/model/__init__.py
+++ b/src/pysdmx/model/__init__.py
@@ -100,6 +100,7 @@ __all__ = [
     "ConceptScheme",
     "Contact",
     "DataConsumer",
+    "Dataflow",
     "DataflowInfo",
     "DataflowRef",
     "DataType",

--- a/src/pysdmx/model/category.py
+++ b/src/pysdmx/model/category.py
@@ -4,7 +4,7 @@ An example of a category scheme is one which categorises data, sometimes
 known as a subject matter domain scheme or a data category scheme.
 """
 
-from typing import Iterator, List, Optional, Sequence, Set, Union
+from typing import Iterator, Optional, Sequence, Union
 
 from pysdmx.model.__base import DataflowRef, Item, ItemScheme
 from pysdmx.model.dataflow import Dataflow

--- a/src/pysdmx/model/category.py
+++ b/src/pysdmx/model/category.py
@@ -4,9 +4,10 @@ An example of a category scheme is one which categorises data, sometimes
 known as a subject matter domain scheme or a data category scheme.
 """
 
-from typing import Iterator, List, Optional, Sequence, Set
+from typing import Iterator, List, Optional, Sequence, Set, Union
 
 from pysdmx.model.__base import DataflowRef, Item, ItemScheme
+from pysdmx.model.dataflow import Dataflow
 
 
 class Category(Item, frozen=False, omit_defaults=True):  # type: ignore[misc]
@@ -31,7 +32,7 @@ class Category(Item, frozen=False, omit_defaults=True):  # type: ignore[misc]
     """
 
     categories: Sequence["Category"] = ()
-    dataflows: Sequence[DataflowRef] = ()
+    dataflows: Union[Sequence[DataflowRef], Sequence[Dataflow]] = ()
 
     def __iter__(self) -> Iterator["Category"]:
         """Return an iterator over the list of categories."""
@@ -71,9 +72,9 @@ class CategoryScheme(ItemScheme, frozen=True, omit_defaults=True):
         return self.items  # type: ignore[return-value]
 
     @property
-    def dataflows(self) -> Sequence[DataflowRef]:
+    def dataflows(self) -> Union[Sequence[DataflowRef], Sequence[Dataflow]]:
         """Return the dataflows attached to any category in the scheme."""
-        flows: Set[DataflowRef] = set()
+        flows = set()
         for cat in self.categories:
             flows.update(self.__extract_flows(cat))
         return list(flows)
@@ -117,8 +118,10 @@ class CategoryScheme(ItemScheme, frozen=True, omit_defaults=True):
                 return out[0]
         return None
 
-    def __extract_flows(self, c: Category) -> Sequence[DataflowRef]:
-        flows: List[DataflowRef] = []
+    def __extract_flows(
+        self, c: Category
+    ) -> Union[Sequence[DataflowRef], Sequence[Dataflow]]:
+        flows = []
         if c.dataflows:
             flows.extend(c.dataflows)
         for sub in c.categories:

--- a/src/pysdmx/model/category.py
+++ b/src/pysdmx/model/category.py
@@ -74,7 +74,7 @@ class CategoryScheme(ItemScheme, frozen=True, omit_defaults=True):
     @property
     def dataflows(self) -> Union[Sequence[DataflowRef], Sequence[Dataflow]]:
         """Return the dataflows attached to any category in the scheme."""
-        flows = set()
+        flows = set()  # type: ignore[var-annotated]
         for cat in self.categories:
             flows.update(self.__extract_flows(cat))
         return list(flows)
@@ -121,7 +121,7 @@ class CategoryScheme(ItemScheme, frozen=True, omit_defaults=True):
     def __extract_flows(
         self, c: Category
     ) -> Union[Sequence[DataflowRef], Sequence[Dataflow]]:
-        flows = []
+        flows = []  # type: ignore[var-annotated]
         if c.dataflows:
             flows.extend(c.dataflows)
         for sub in c.categories:

--- a/src/pysdmx/model/dataflow.py
+++ b/src/pysdmx/model/dataflow.py
@@ -15,7 +15,7 @@ from typing import Any, Iterable, Optional, Sequence, Union
 from msgspec import Struct
 
 from pysdmx.errors import Invalid
-from pysdmx.model.__base import Agency, DataProvider
+from pysdmx.model.__base import Agency, DataProvider, MaintainableArtefact
 from pysdmx.model.code import Codelist, Hierarchy
 from pysdmx.model.concept import Concept, DataType, Facets
 
@@ -393,3 +393,9 @@ class Schema(Struct, frozen=True, omit_defaults=True):
             if v:
                 out.append(f"{k}={v}")
         return ", ".join(out)
+
+
+class Dataflow(MaintainableArtefact, frozen=True, omit_defaults=True):
+    """A flow of data that providers will provide."""
+
+    structure: Optional[str] = None

--- a/tests/model/test_dataflow_ref.py
+++ b/tests/model/test_dataflow_ref.py
@@ -9,16 +9,6 @@ def dsi():
 
 
 @pytest.fixture()
-def name():
-    return "ICP name"
-
-
-@pytest.fixture()
-def desc():
-    return "ICP description"
-
-
-@pytest.fixture()
 def agency():
     return "5B0"
 
@@ -28,26 +18,12 @@ def version():
     return "1.0"
 
 
-def test_basic_instantiation(dsi, agency):
+def test_instantiation(dsi, agency):
     ds = DataflowRef(id=dsi, agency=agency)
 
     assert ds.id == dsi
-    assert ds.name is None
-    assert ds.description is None
     assert ds.agency == agency
     assert ds.version == "1.0"
-
-
-def test_full_instantiation(dsi, name, desc, agency, version):
-    ds = DataflowRef(
-        id=dsi, agency=agency, name=name, description=desc, version=version
-    )
-
-    assert ds.id == dsi
-    assert ds.name == name
-    assert ds.description == desc
-    assert ds.agency == agency
-    assert ds.version == version
 
 
 def test_immutable(dsi, agency):
@@ -56,26 +32,18 @@ def test_immutable(dsi, agency):
         ds.name = "Not allowed"
 
 
-def test_equal(dsi, name, desc, agency, version):
-    ds1 = DataflowRef(
-        id=dsi, agency=agency, name=name, description=desc, version=version
-    )
-    ds2 = DataflowRef(
-        id=dsi, agency=agency, name=name, description=desc, version=version
-    )
+def test_equal(dsi, agency, version):
+    ds1 = DataflowRef(id=dsi, agency=agency, version=version)
+    ds2 = DataflowRef(id=dsi, agency=agency, version=version)
 
     assert ds1 == ds2
 
 
-def test_not_equal(dsi, name, desc, agency, version):
-    ds1 = DataflowRef(
-        id=dsi, agency=agency, name=name, description=desc, version=version
-    )
+def test_not_equal(dsi, agency, version):
+    ds1 = DataflowRef(id=dsi, agency=agency, version=version)
     ds2 = DataflowRef(
         id=dsi,
         agency=agency,
-        name=name,
-        description=desc,
         version=f"{version}.42",
     )
 
@@ -87,17 +55,4 @@ def test_tostr_id(dsi, agency):
 
     s = str(d)
 
-    assert s == f"id={dsi}, version={d.version}, agency={agency}"
-
-
-def test_tostr_name(dsi, name, desc, agency, version):
-    d = DataflowRef(
-        id=dsi, agency=agency, name=name, description=desc, version=version
-    )
-
-    s = str(d)
-
-    assert s == (
-        f"id={dsi}, description={desc}, name={name}, "
-        f"version={version}, agency={agency}"
-    )
+    assert s == f"Dataflow={agency}:{dsi}({d.version})"

--- a/tests/model/test_organisation.py
+++ b/tests/model/test_organisation.py
@@ -25,8 +25,8 @@ def contact():
 
 @pytest.fixture()
 def dataflows():
-    df1 = DataflowRef(id="DF1", name="TEST", agency="T1")
-    df2 = DataflowRef(id="DF2", name="Also TEST", agency="T1")
+    df1 = DataflowRef(id="DF1", agency="T1")
+    df2 = DataflowRef(id="DF2", agency="T1")
     return [df1, df2]
 
 


### PR DESCRIPTION
The purpose of this PR is to allow distinguishing between:

- A `DataflowRef`, i.e. an SDMX artefact that consists of the information necessary to identify a dataflow (agency, id and version);
- A `Dataflow`, i.e. a maintainable SDMX artefact.

Until now, the 2 were mixed in the code base, which was confusing.

Fix #117 