### PR TITLE
Add simple web service client

### DIFF
--- a/src/pysdmx/api/qb/__init__.py
+++ b/src/pysdmx/api/qb/__init__.py
@@ -14,6 +14,7 @@ from pysdmx.api.qb.refmeta import (
     RefMetaFormat,
 )
 from pysdmx.api.qb.schema import SchemaContext, SchemaFormat, SchemaQuery
+from pysdmx.api.qb.service import RestService
 from pysdmx.api.qb.structure import (
     StructureDetail,
     StructureFormat,
@@ -36,6 +37,7 @@ __all__ = [
     "RefMetaByStructureQuery",
     "RefMetaDetail",
     "RefMetaFormat",
+    "RestService",
     "SchemaContext",
     "SchemaFormat",
     "SchemaQuery",

--- a/src/pysdmx/api/qb/service.py
+++ b/src/pysdmx/api/qb/service.py
@@ -33,8 +33,10 @@ class RestService:
         pem: Optional[str] = None,
     ):
         """Instantiate a connector to a SDMX-REST service."""
-        if api_endpoint.endswith("/"):
-            self.__api_endpoint = api_endpoint[0:-1]
+        self.__api_endpoint = (
+            api_endpoint[0:-1] if api_endpoint.endswith("/") else api_endpoint
+        )
+
         self.__api_version = api_version
         self.__data_format = data_format
         self.__structure_format = structure_format

--- a/src/pysdmx/api/qb/service.py
+++ b/src/pysdmx/api/qb/service.py
@@ -1,0 +1,134 @@
+"""Connector to SDMX-REST services."""
+
+from typing import NoReturn, Optional, Union
+
+import httpx
+
+from pysdmx import errors
+from pysdmx.api.qb.availability import AvailabilityFormat, AvailabilityQuery
+from pysdmx.api.qb.data import DataFormat, DataQuery
+from pysdmx.api.qb.refmeta import (
+    RefMetaByMetadataflowQuery,
+    RefMetaByMetadatasetQuery,
+    RefMetaByStructureQuery,
+    RefMetaFormat,
+)
+from pysdmx.api.qb.schema import SchemaFormat, SchemaQuery
+from pysdmx.api.qb.structure import StructureFormat, StructureQuery
+from pysdmx.api.qb.util import ApiVersion
+
+
+class RestService:
+    """Connector to SDMX-REST services."""
+
+    def __init__(
+        self,
+        api_endpoint: str,
+        api_version: ApiVersion,
+        data_format: DataFormat = DataFormat.SDMX_JSON_2_0_0,
+        structure_format: StructureFormat = StructureFormat.SDMX_JSON_2_0_0,
+        schema_format: SchemaFormat = SchemaFormat.SDMX_JSON_2_0_0_STRUCTURE,
+        refmeta_format: RefMetaFormat = RefMetaFormat.SDMX_JSON_2_0_0,
+        avail_format: AvailabilityFormat = AvailabilityFormat.SDMX_JSON_2_0_0,
+        pem: Optional[str] = None,
+    ):
+        """Instantiate a connector to a SDMX-REST service."""
+        if api_endpoint.endswith("/"):
+            self.__api_endpoint = api_endpoint[0:-1]
+        self.__api_version = api_version
+        self.__data_format = data_format
+        self.__structure_format = structure_format
+        self.__schema_format = schema_format
+        self.__refmeta_format = refmeta_format
+        self.__avail_format = avail_format
+        self.__ssl_context = (
+            httpx.create_ssl_context(
+                verify=pem,
+            )
+            if pem
+            else httpx.create_ssl_context()
+        )
+        self.headers = {
+            "Accept-Encoding": "gzip, deflate",
+        }
+
+    def data(self, query: DataQuery) -> bytes:
+        """Execute a data query against the service."""
+        q = query.get_url(self.__api_version, True)
+        f = self.__data_format.value
+        return self.__fetch(q, f)
+
+    def structure(self, query: StructureQuery) -> bytes:
+        """Execute a structure query against the service."""
+        q = query.get_url(self.__api_version, True)
+        f = self.__structure_format.value
+        return self.__fetch(q, f)
+
+    def schema(self, query: SchemaQuery) -> bytes:
+        """Execute a schema query against the service."""
+        q = query.get_url(self.__api_version, True)
+        f = self.__schema_format.value
+        return self.__fetch(q, f)
+
+    def availability(self, query: AvailabilityQuery) -> bytes:
+        """Execute an availability query against the service."""
+        q = query.get_url(self.__api_version, True)
+        f = self.__avail_format.value
+        return self.__fetch(q, f)
+
+    def reference_metadata(
+        self,
+        query: Union[
+            RefMetaByMetadataflowQuery,
+            RefMetaByMetadatasetQuery,
+            RefMetaByStructureQuery,
+        ],
+    ) -> bytes:
+        """Execute a reference metadata query against the service."""
+        q = query.get_url(self.__api_version, True)
+        f = self.__refmeta_format.value
+        return self.__fetch(q, f)
+
+    def __fetch(self, query: str, format: str) -> bytes:
+        with httpx.Client(verify=self.__ssl_context) as client:
+            try:
+                url = f"{self.__api_endpoint}{query}"
+                h = self.headers.copy()
+                h["Accept"] = format
+                r = client.get(url, headers=h)
+                r.raise_for_status()
+                return r.content
+            except (httpx.RequestError, httpx.HTTPStatusError) as e:
+                self.__map_error(e)
+
+    def __map_error(
+        self, e: Union[httpx.RequestError, httpx.HTTPStatusError]
+    ) -> NoReturn:
+        q = e.request.url
+        if isinstance(e, httpx.HTTPStatusError):
+            s = e.response.status_code
+            t = e.response.text
+            if s == 404:
+                msg = (
+                    "The requested resource(s) could not be found in the "
+                    f"targeted service. The query was `{q}`"
+                )
+                raise errors.NotFound("Not found", msg) from e
+            elif s < 500:
+                msg = (
+                    f"The query returned a {s} error code. The query "
+                    f"was `{q}`. The error message was: `{t}`."
+                )
+                raise errors.Invalid(f"Client error {s}", msg) from e
+            else:
+                msg = (
+                    f"The service returned a {s} error code. The query "
+                    f"was `{q}`. The error message was: `{t}`."
+                )
+                raise errors.InternalError(f"Service error {s}", msg) from e
+        else:
+            msg = (
+                f"There was an issue connecting to the targeted service. "
+                f"The query was `{q}`. The error message was: `{e}`."
+            )
+            raise errors.Unavailable("Connection error", msg) from e

--- a/tests/api/qb/service/test_service_availability.py
+++ b/tests/api/qb/service/test_service_availability.py
@@ -3,10 +3,10 @@ import pytest
 
 from pysdmx.api.qb import (
     ApiVersion,
-    DataContext,
-    RestService,
     AvailabilityFormat,
     AvailabilityQuery,
+    DataContext,
+    RestService,
 )
 from pysdmx.errors import InternalError, Invalid, NotFound, Unavailable
 

--- a/tests/api/qb/service/test_service_availability.py
+++ b/tests/api/qb/service/test_service_availability.py
@@ -1,0 +1,123 @@
+import httpx
+import pytest
+
+from pysdmx.api.qb import (
+    ApiVersion,
+    DataContext,
+    RestService,
+    AvailabilityFormat,
+    AvailabilityQuery,
+)
+from pysdmx.errors import InternalError, Invalid, NotFound, Unavailable
+
+
+@pytest.fixture()
+def version() -> ApiVersion:
+    return ApiVersion.V2_0_0
+
+
+@pytest.fixture()
+def end_point() -> str:
+    return "https://registry.sdmx.org/sdmx/v2"
+
+
+@pytest.fixture()
+def service(end_point: str, version: ApiVersion) -> RestService:
+    return RestService(end_point, version)
+
+
+@pytest.fixture()
+def query() -> AvailabilityQuery:
+    return AvailabilityQuery(DataContext.DATAFLOW, "BIS", "CBS")
+
+
+@pytest.fixture()
+def url(end_point: str, query: AvailabilityQuery, version: ApiVersion) -> str:
+    return f"{end_point}{query.get_url(version, True)}"
+
+
+@pytest.fixture()
+def body():
+    with open("tests/api/fmr/samples/orgs/agencies.fusion.json", "rb") as f:
+        return f.read()
+
+
+def test_not_found(
+    respx_mock, service: RestService, query: AvailabilityQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            404,
+            content=body,
+        )
+    )
+
+    with pytest.raises(NotFound) as e:
+        service.availability(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_client_error(
+    respx_mock, service: RestService, query: AvailabilityQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            409,
+            content=body,
+        )
+    )
+
+    with pytest.raises(Invalid) as e:
+        service.availability(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_service_error(
+    respx_mock, service: RestService, query: AvailabilityQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            501,
+            content=body,
+        )
+    )
+
+    with pytest.raises(InternalError) as e:
+        service.availability(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_service_unavailable(
+    respx_mock, service: RestService, query: AvailabilityQuery, url
+):
+    re = httpx.RequestError("Bad day")
+    respx_mock.get(url).mock(side_effect=re)
+
+    with pytest.raises(Unavailable) as e:
+        service.availability(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_called_as_expected(
+    respx_mock, service: RestService, query: AvailabilityQuery, url, body
+):
+    route = respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+    service.availability(query)
+    assert route.called
+    assert len(route.calls) == 1
+    headers = route.calls[0].request.headers
+    assert headers["Accept"] == AvailabilityFormat.SDMX_JSON_2_0_0.value
+    assert headers["Accept-Encoding"] == "gzip, deflate"

--- a/tests/api/qb/service/test_service_data.py
+++ b/tests/api/qb/service/test_service_data.py
@@ -1,0 +1,123 @@
+import httpx
+import pytest
+
+from pysdmx.api.qb import (
+    ApiVersion,
+    DataContext,
+    DataFormat,
+    DataQuery,
+    RestService,
+)
+from pysdmx.errors import InternalError, Invalid, NotFound, Unavailable
+
+
+@pytest.fixture()
+def version() -> ApiVersion:
+    return ApiVersion.V2_0_0
+
+
+@pytest.fixture()
+def end_point() -> str:
+    return "https://registry.sdmx.org/sdmx/v2"
+
+
+@pytest.fixture()
+def service(end_point: str, version: ApiVersion) -> RestService:
+    return RestService(end_point, version)
+
+
+@pytest.fixture()
+def query() -> DataQuery:
+    return DataQuery(DataContext.ALL, "BIS", "CBS")
+
+
+@pytest.fixture()
+def url(end_point: str, query: DataQuery, version: ApiVersion) -> str:
+    return f"{end_point}{query.get_url(version, True)}"
+
+
+@pytest.fixture()
+def body():
+    with open("tests/api/fmr/samples/orgs/agencies.fusion.json", "rb") as f:
+        return f.read()
+
+
+def test_not_found(
+    respx_mock, service: RestService, query: DataQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            404,
+            content=body,
+        )
+    )
+
+    with pytest.raises(NotFound) as e:
+        service.data(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_client_error(
+    respx_mock, service: RestService, query: DataQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            409,
+            content=body,
+        )
+    )
+
+    with pytest.raises(Invalid) as e:
+        service.data(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_service_error(
+    respx_mock, service: RestService, query: DataQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            501,
+            content=body,
+        )
+    )
+
+    with pytest.raises(InternalError) as e:
+        service.data(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_service_unavailable(
+    respx_mock, service: RestService, query: DataQuery, url
+):
+    re = httpx.RequestError("Bad day")
+    respx_mock.get(url).mock(side_effect=re)
+
+    with pytest.raises(Unavailable) as e:
+        service.data(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_called_as_expected(
+    respx_mock, service: RestService, query: DataQuery, url, body
+):
+    route = respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+    service.data(query)
+    assert route.called
+    assert len(route.calls) == 1
+    headers = route.calls[0].request.headers
+    assert headers["Accept"] == DataFormat.SDMX_JSON_2_0_0.value
+    assert headers["Accept-Encoding"] == "gzip, deflate"

--- a/tests/api/qb/service/test_service_refmeta.py
+++ b/tests/api/qb/service/test_service_refmeta.py
@@ -1,0 +1,140 @@
+import httpx
+import pytest
+
+from pysdmx.api.qb import (
+    ApiVersion,
+    RefMetaByMetadataflowQuery,
+    RefMetaFormat,
+    RestService,
+)
+from pysdmx.errors import InternalError, Invalid, NotFound, Unavailable
+
+
+@pytest.fixture()
+def version() -> ApiVersion:
+    return ApiVersion.V2_0_0
+
+
+@pytest.fixture()
+def end_point() -> str:
+    return "https://registry.sdmx.org/sdmx/v2"
+
+
+@pytest.fixture()
+def service(end_point: str, version: ApiVersion) -> RestService:
+    return RestService(end_point, version)
+
+
+@pytest.fixture()
+def query() -> RefMetaByMetadataflowQuery:
+    return RefMetaByMetadataflowQuery("BIS", "CBS", "1.0")
+
+
+@pytest.fixture()
+def url(
+    end_point: str, query: RefMetaByMetadataflowQuery, version: ApiVersion
+) -> str:
+    return f"{end_point}{query.get_url(version, True)}"
+
+
+@pytest.fixture()
+def body():
+    with open("tests/api/fmr/samples/orgs/agencies.fusion.json", "rb") as f:
+        return f.read()
+
+
+def test_not_found(
+    respx_mock,
+    service: RestService,
+    query: RefMetaByMetadataflowQuery,
+    body,
+    url,
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            404,
+            content=body,
+        )
+    )
+
+    with pytest.raises(NotFound) as e:
+        service.reference_metadata(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_client_error(
+    respx_mock,
+    service: RestService,
+    query: RefMetaByMetadataflowQuery,
+    body,
+    url,
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            409,
+            content=body,
+        )
+    )
+
+    with pytest.raises(Invalid) as e:
+        service.reference_metadata(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_service_error(
+    respx_mock,
+    service: RestService,
+    query: RefMetaByMetadataflowQuery,
+    body,
+    url,
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            501,
+            content=body,
+        )
+    )
+
+    with pytest.raises(InternalError) as e:
+        service.reference_metadata(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_service_unavailable(
+    respx_mock, service: RestService, query: RefMetaByMetadataflowQuery, url
+):
+    re = httpx.RequestError("Bad day")
+    respx_mock.get(url).mock(side_effect=re)
+
+    with pytest.raises(Unavailable) as e:
+        service.reference_metadata(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_called_as_expected(
+    respx_mock,
+    service: RestService,
+    query: RefMetaByMetadataflowQuery,
+    url,
+    body,
+):
+    route = respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+    service.reference_metadata(query)
+    assert route.called
+    assert len(route.calls) == 1
+    headers = route.calls[0].request.headers
+    assert headers["Accept"] == RefMetaFormat.SDMX_JSON_2_0_0.value
+    assert headers["Accept-Encoding"] == "gzip, deflate"

--- a/tests/api/qb/service/test_service_schema.py
+++ b/tests/api/qb/service/test_service_schema.py
@@ -1,0 +1,123 @@
+import httpx
+import pytest
+
+from pysdmx.api.qb import (
+    ApiVersion,
+    RestService,
+    SchemaContext,
+    SchemaFormat,
+    SchemaQuery,
+)
+from pysdmx.errors import InternalError, Invalid, NotFound, Unavailable
+
+
+@pytest.fixture()
+def version() -> ApiVersion:
+    return ApiVersion.V2_0_0
+
+
+@pytest.fixture()
+def end_point() -> str:
+    return "https://registry.sdmx.org/sdmx/v2"
+
+
+@pytest.fixture()
+def service(end_point: str, version: ApiVersion) -> RestService:
+    return RestService(end_point, version)
+
+
+@pytest.fixture()
+def query() -> SchemaQuery:
+    return SchemaQuery(SchemaContext.DATAFLOW, "BIS", "CBS", "1.0")
+
+
+@pytest.fixture()
+def url(end_point: str, query: SchemaQuery, version: ApiVersion) -> str:
+    return f"{end_point}{query.get_url(version, True)}"
+
+
+@pytest.fixture()
+def body():
+    with open("tests/api/fmr/samples/orgs/agencies.fusion.json", "rb") as f:
+        return f.read()
+
+
+def test_not_found(
+    respx_mock, service: RestService, query: SchemaQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            404,
+            content=body,
+        )
+    )
+
+    with pytest.raises(NotFound) as e:
+        service.schema(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_client_error(
+    respx_mock, service: RestService, query: SchemaQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            409,
+            content=body,
+        )
+    )
+
+    with pytest.raises(Invalid) as e:
+        service.schema(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_service_error(
+    respx_mock, service: RestService, query: SchemaQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            501,
+            content=body,
+        )
+    )
+
+    with pytest.raises(InternalError) as e:
+        service.schema(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_service_unavailable(
+    respx_mock, service: RestService, query: SchemaQuery, url
+):
+    re = httpx.RequestError("Bad day")
+    respx_mock.get(url).mock(side_effect=re)
+
+    with pytest.raises(Unavailable) as e:
+        service.schema(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_called_as_expected(
+    respx_mock, service: RestService, query: SchemaQuery, url, body
+):
+    route = respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+    service.schema(query)
+    assert route.called
+    assert len(route.calls) == 1
+    headers = route.calls[0].request.headers
+    assert headers["Accept"] == SchemaFormat.SDMX_JSON_2_0_0_STRUCTURE.value
+    assert headers["Accept-Encoding"] == "gzip, deflate"

--- a/tests/api/qb/service/test_service_structure.py
+++ b/tests/api/qb/service/test_service_structure.py
@@ -1,0 +1,123 @@
+import httpx
+import pytest
+
+from pysdmx.api.qb import (
+    ApiVersion,
+    RestService,
+    StructureFormat,
+    StructureQuery,
+    StructureType,
+)
+from pysdmx.errors import InternalError, Invalid, NotFound, Unavailable
+
+
+@pytest.fixture()
+def version() -> ApiVersion:
+    return ApiVersion.V2_0_0
+
+
+@pytest.fixture()
+def end_point() -> str:
+    return "https://registry.sdmx.org/sdmx/v2"
+
+
+@pytest.fixture()
+def service(end_point: str, version: ApiVersion) -> RestService:
+    return RestService(end_point, version)
+
+
+@pytest.fixture()
+def query() -> StructureQuery:
+    return StructureQuery(StructureType.ALL, "SDMX", "CL_FREQ")
+
+
+@pytest.fixture()
+def url(end_point: str, query: StructureQuery, version: ApiVersion) -> str:
+    return f"{end_point}{query.get_url(version, True)}"
+
+
+@pytest.fixture()
+def body():
+    with open("tests/api/fmr/samples/orgs/agencies.fusion.json", "rb") as f:
+        return f.read()
+
+
+def test_not_found(
+    respx_mock, service: RestService, query: StructureQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            404,
+            content=body,
+        )
+    )
+
+    with pytest.raises(NotFound) as e:
+        service.structure(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_client_error(
+    respx_mock, service: RestService, query: StructureQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            409,
+            content=body,
+        )
+    )
+
+    with pytest.raises(Invalid) as e:
+        service.structure(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_service_error(
+    respx_mock, service: RestService, query: StructureQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            501,
+            content=body,
+        )
+    )
+
+    with pytest.raises(InternalError) as e:
+        service.structure(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_service_unavailable(
+    respx_mock, service: RestService, query: StructureQuery, url
+):
+    re = httpx.RequestError("Bad day")
+    respx_mock.get(url).mock(side_effect=re)
+
+    with pytest.raises(Unavailable) as e:
+        service.structure(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+def test_called_as_expected(
+    respx_mock, service: RestService, query: StructureQuery, url, body
+):
+    route = respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+    service.structure(query)
+    assert route.called
+    assert len(route.calls) == 1
+    headers = route.calls[0].request.headers
+    assert headers["Accept"] == StructureFormat.SDMX_JSON_2_0_0.value
+    assert headers["Accept-Encoding"] == "gzip, deflate"


### PR DESCRIPTION
The purpose of this PR is to complete the work on the SDMX-REST query builders by adding a simple web service class that can be used to execute these queries.

Fix #113 