### PR TITLE
Use latest version of action because old one will be removed

### DIFF
--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -41,7 +41,7 @@ jobs:
           poetry run sphinx-build docs _site
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:


### PR DESCRIPTION
Artifact actions v3 (a dependency of actions/upload-pages-artifact) will be closing down by January 30, 2025. The purpose of this PR is to avoid issues later by switching to the latest version now.