### PR TITLE
Deser minval

### DIFF
--- a/src/pysdmx/io/json/fusion/messages/core.py
+++ b/src/pysdmx/io/json/fusion/messages/core.py
@@ -1,7 +1,7 @@
 """Collection of Fusion-JSON schemas for common artefacts."""
 
 from datetime import datetime
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, Union
 
 import msgspec
 
@@ -55,6 +55,12 @@ class FusionRepresentation(msgspec.Struct, frozen=True):
     minOccurs: Optional[int] = None
     maxOccurs: Optional[int] = None
 
+    def __to_number(self, input: str) -> Union[int, float]:
+        try:
+            return int(input)
+        except ValueError:
+            return float(input)
+
     def to_facets(self) -> Optional[Facets]:
         """Return a Facets domain object."""
         if self.textFormat and (
@@ -70,14 +76,35 @@ class FusionRepresentation(msgspec.Struct, frozen=True):
             or self.textFormat.startTime
             or self.textFormat.endTime
         ):
+            min = (
+                self.__to_number(self.textFormat.minValue)
+                if self.textFormat.minValue
+                else None
+            )
+            max = (
+                self.__to_number(self.textFormat.maxValue)
+                if self.textFormat.maxValue
+                else None
+            )
+            sta = (
+                self.__to_number(self.textFormat.startValue)
+                if self.textFormat.startValue
+                else None
+            )
+            end = (
+                self.__to_number(self.textFormat.endValue)
+                if self.textFormat.endValue
+                else None
+            )
+
             return Facets(
                 min_length=self.textFormat.minLength,
                 max_length=self.textFormat.maxLength,
                 is_sequence=self.textFormat.isSequence,
-                min_value=self.textFormat.minValue,  # type: ignore[arg-type]
-                max_value=self.textFormat.maxValue,  # type: ignore[arg-type]
-                start_value=self.textFormat.startValue,  # type: ignore
-                end_value=self.textFormat.endValue,  # type: ignore[arg-type]
+                min_value=min,
+                max_value=max,
+                start_value=sta,
+                end_value=end,
                 decimals=self.textFormat.decimals,
                 pattern=self.textFormat.pattern,
                 start_time=self.textFormat.startTime,

--- a/tests/api/fmr/samples/df/no_const.fusion.json
+++ b/tests/api/fmr/samples/df/no_const.fusion.json
@@ -10619,9 +10619,11 @@
                         "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).UNIT_MULT",
                         "representation": {
                             "textFormat": {
-                                "textType": "String",
+                                "textType": "Integer",
                                 "minLength": 1,
-                                "maxLength": 2
+                                "maxLength": 2,
+                                "minValue": "-15",
+                                "maxValue": "15"
                             },
                             "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_UNIT_MULT(1.0)"
                         },

--- a/tests/api/fmr/samples/df/no_const.fusion.json
+++ b/tests/api/fmr/samples/df/no_const.fusion.json
@@ -10639,9 +10639,11 @@
                     "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Measure=BIS:BIS_CBS(1.0).OBS_VALUE",
                     "representation": {
                         "textFormat": {
-                            "textType": "String",
+                            "textType": "Double",
                             "minLength": 1,
-                            "maxLength": 15
+                            "maxLength": 15,
+                            "startValue": "0.00",
+                            "endValue": "42.99"
                         }
                     },
                     "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_VALUE",

--- a/tests/api/fmr/samples/df/no_const.json
+++ b/tests/api/fmr/samples/df/no_const.json
@@ -15474,7 +15474,9 @@
                                     "enumerationFormat": {
                                         "maxLength": 2,
                                         "minLength": 1,
-                                        "dataType": "String"
+                                        "minValue": -15,
+                                        "maxValue": 15,
+                                        "dataType": "Integer"
                                     },
                                     "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_UNIT_MULT(1.0)"
                                 },

--- a/tests/api/fmr/samples/df/no_const.json
+++ b/tests/api/fmr/samples/df/no_const.json
@@ -15805,9 +15805,9 @@
                                 "id": "OBS_VALUE",
                                 "localRepresentation": {
                                     "format": {
-                                        "maxLength": 15,
-                                        "minLength": 1,
-                                        "dataType": "String"
+                                        "dataType": "Double",
+                                        "startValue": 0.0,
+                                        "endValue": 42.99
                                     }
                                 },
                                 "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_VALUE"

--- a/tests/api/fmr/samples/df/schema.fusion.json
+++ b/tests/api/fmr/samples/df/schema.fusion.json
@@ -4693,7 +4693,7 @@
                         "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).UNIT_MULT",
                         "representation": {
                             "textFormat": {
-                                "textType": "String",
+                                "textType": "Integer",
                                 "minLength": 1,
                                 "maxLength": 2,
                                 "minValue": "-15",

--- a/tests/api/fmr/samples/df/schema.json
+++ b/tests/api/fmr/samples/df/schema.json
@@ -6680,7 +6680,7 @@
                                         "minLength": 1,
                                         "minValue": -15,
                                         "maxValue": 15,
-                                        "dataType": "String"
+                                        "dataType": "Integer"
                                     },
                                     "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_UNIT_MULT(1.0)"
                                 },

--- a/tests/api/fmr/schema_checks.py
+++ b/tests/api/fmr/schema_checks.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 import httpx
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient

--- a/tests/api/fmr/schema_checks.py
+++ b/tests/api/fmr/schema_checks.py
@@ -293,6 +293,7 @@ def check_core_local_repr(
     ).components
     freq = schema["FREQ"]
     title = schema["TITLE_GRP"]
+    unit_mult = schema["UNIT_MULT"]
 
     assert isinstance(freq, Component)
     assert len(freq.enumeration) == 8
@@ -304,6 +305,14 @@ def check_core_local_repr(
     assert not title.enumeration
     assert title.dtype == DataType.STRING
     assert title.facets is None
+
+    assert isinstance(unit_mult, Component)
+    # assert unit_mult.dtype == DataType.INTEGER
+    assert len(unit_mult.enumeration) == 10
+    assert unit_mult.facets.min_length == 1
+    assert unit_mult.facets.max_length == 2
+    assert unit_mult.facets.min_value == -15
+    assert unit_mult.facets.max_value == 15
 
 
 def check_roles(mock, fmr: RegistryClient, query, hca_query, body, hca_body):
@@ -338,6 +347,8 @@ def check_types(mock, fmr: RegistryClient, query, hca_query, body, hca_body):
             assert comp.dtype == DataType.PERIOD
         elif comp.id == "DECIMALS":
             assert comp.dtype == DataType.BIG_INTEGER
+        elif comp.id == "UNIT_MULT":
+            assert comp.dtype == DataType.INTEGER
         else:
             assert comp.dtype == DataType.STRING
 

--- a/tests/api/fmr/schema_checks.py
+++ b/tests/api/fmr/schema_checks.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-
 import httpx
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
@@ -294,6 +293,7 @@ def check_core_local_repr(
     freq = schema["FREQ"]
     title = schema["TITLE_GRP"]
     unit_mult = schema["UNIT_MULT"]
+    obs_value = schema["OBS_VALUE"]
 
     assert isinstance(freq, Component)
     assert len(freq.enumeration) == 8
@@ -307,12 +307,18 @@ def check_core_local_repr(
     assert title.facets is None
 
     assert isinstance(unit_mult, Component)
-    # assert unit_mult.dtype == DataType.INTEGER
+    assert unit_mult.dtype == DataType.INTEGER
     assert len(unit_mult.enumeration) == 10
     assert unit_mult.facets.min_length == 1
     assert unit_mult.facets.max_length == 2
     assert unit_mult.facets.min_value == -15
     assert unit_mult.facets.max_value == 15
+
+    assert isinstance(obs_value, Component)
+    assert obs_value.dtype == DataType.DOUBLE
+    assert obs_value.enumeration is None
+    assert obs_value.facets.start_value == 0.0
+    assert obs_value.facets.end_value == 42.99
 
 
 def check_roles(mock, fmr: RegistryClient, query, hca_query, body, hca_body):


### PR DESCRIPTION
The type for minValue, maxValue, startValue and endValue is different between SDMX-JSON and Fusion-JSON (number vs. string). This was causing problems when deserializing objects, when using Fusion-JSON to download the data, as the model class expects an int or a float, but not a string.