### PR TITLE
Add asynchronous client for SDMX-REST services

### DIFF
--- a/src/pysdmx/api/fmr/__init__.py
+++ b/src/pysdmx/api/fmr/__init__.py
@@ -10,7 +10,6 @@ from typing import (
     Union,
 )
 
-import httpx
 from msgspec.json import decode
 
 from pysdmx.api.qb import (
@@ -95,17 +94,6 @@ class __BaseRegistryClient:
             self.deser = fusion_readers
         else:
             self.deser = sdmx_readers
-        self.ssl_context = (
-            httpx.create_ssl_context(
-                verify=pem,
-            )
-            if pem
-            else httpx.create_ssl_context()
-        )
-        self.headers = {
-            "Accept": self.format.value,
-            "Accept-Encoding": "gzip, deflate",
-        }
 
     def _out(self, response: bytes, typ: Deserializer, *params: Any) -> Any:
         return decode(response, type=typ).to_model(*params)

--- a/src/pysdmx/api/qb/__init__.py
+++ b/src/pysdmx/api/qb/__init__.py
@@ -14,7 +14,7 @@ from pysdmx.api.qb.refmeta import (
     RefMetaFormat,
 )
 from pysdmx.api.qb.schema import SchemaContext, SchemaFormat, SchemaQuery
-from pysdmx.api.qb.service import RestService
+from pysdmx.api.qb.service import AsyncRestService, RestService
 from pysdmx.api.qb.structure import (
     StructureDetail,
     StructureFormat,
@@ -26,6 +26,7 @@ from pysdmx.api.qb.util import ApiVersion
 
 __all__ = [
     "ApiVersion",
+    "AsyncRestService",
     "AvailabilityFormat",
     "AvailabilityMode",
     "AvailabilityQuery",

--- a/src/pysdmx/api/qb/service.py
+++ b/src/pysdmx/api/qb/service.py
@@ -18,24 +18,8 @@ from pysdmx.api.qb.structure import StructureFormat, StructureQuery
 from pysdmx.api.qb.util import ApiVersion
 
 
-class RestService:
-    """Connector to SDMX-REST services.
-
-    Attributes:
-        api_endpoint: The entry point (URL) of the SDMX-REST service.
-        api_version: The most recent version of the SDMX-REST specification
-            supported by the service.
-        data_format: The default format for data queries.
-        structure_format: The default format for structure queries.
-        schema_format: The default format for schema queries.
-        refmeta_format: The default format for reference metadata queries.
-        avail_format: The default format for availability queries.
-        pem: In case the service uses SSL/TLS with self-signed certificate,
-            this attribute should be used to pass the pem file with the
-            list of trusted certicate authorities.
-        timeout: The maximum number of seconds to wait before considering
-            that a request timed out. Defaults to 5 seconds.
-    """
+class _CoreRestService:
+    """Abstract connector."""
 
     def __init__(
         self,
@@ -50,78 +34,29 @@ class RestService:
         timeout: Optional[float] = 5.0,
     ):
         """Instantiate a connector to a SDMX-REST service."""
-        self.__api_endpoint = (
+        self._api_endpoint = (
             api_endpoint[0:-1] if api_endpoint.endswith("/") else api_endpoint
         )
 
-        self.__api_version = api_version
-        self.__data_format = data_format
-        self.__structure_format = structure_format
-        self.__schema_format = schema_format
-        self.__refmeta_format = refmeta_format
-        self.__avail_format = avail_format
-        self.__ssl_context = (
+        self._api_version = api_version
+        self._data_format = data_format
+        self._structure_format = structure_format
+        self._schema_format = schema_format
+        self._refmeta_format = refmeta_format
+        self._avail_format = avail_format
+        self._ssl_context = (
             httpx.create_ssl_context(
                 verify=pem,
             )
             if pem
             else httpx.create_ssl_context()
         )
-        self.__headers = {
+        self._headers = {
             "Accept-Encoding": "gzip, deflate",
         }
-        self.__timeout = timeout
+        self._timeout = timeout
 
-    def data(self, query: DataQuery) -> bytes:
-        """Execute a data query against the service."""
-        q = query.get_url(self.__api_version, True)
-        f = self.__data_format.value
-        return self.__fetch(q, f)
-
-    def structure(self, query: StructureQuery) -> bytes:
-        """Execute a structure query against the service."""
-        q = query.get_url(self.__api_version, True)
-        f = self.__structure_format.value
-        return self.__fetch(q, f)
-
-    def schema(self, query: SchemaQuery) -> bytes:
-        """Execute a schema query against the service."""
-        q = query.get_url(self.__api_version, True)
-        f = self.__schema_format.value
-        return self.__fetch(q, f)
-
-    def availability(self, query: AvailabilityQuery) -> bytes:
-        """Execute an availability query against the service."""
-        q = query.get_url(self.__api_version, True)
-        f = self.__avail_format.value
-        return self.__fetch(q, f)
-
-    def reference_metadata(
-        self,
-        query: Union[
-            RefMetaByMetadataflowQuery,
-            RefMetaByMetadatasetQuery,
-            RefMetaByStructureQuery,
-        ],
-    ) -> bytes:
-        """Execute a reference metadata query against the service."""
-        q = query.get_url(self.__api_version, True)
-        f = self.__refmeta_format.value
-        return self.__fetch(q, f)
-
-    def __fetch(self, query: str, format: str) -> bytes:
-        with httpx.Client(verify=self.__ssl_context) as client:
-            try:
-                url = f"{self.__api_endpoint}{query}"
-                h = self.__headers.copy()
-                h["Accept"] = format
-                r = client.get(url, headers=h, timeout=self.__timeout)
-                r.raise_for_status()
-                return r.content
-            except (httpx.RequestError, httpx.HTTPStatusError) as e:
-                self.__map_error(e)
-
-    def __map_error(
+    def _map_error(
         self, e: Union[httpx.RequestError, httpx.HTTPStatusError]
     ) -> NoReturn:
         q = e.request.url
@@ -152,3 +87,97 @@ class RestService:
                 f"The query was `{q}`. The error message was: `{e}`."
             )
             raise errors.Unavailable("Connection error", msg) from e
+
+
+class RestService(_CoreRestService):
+    """Synchronous connector to SDMX-REST services.
+
+    Attributes:
+        api_endpoint: The entry point (URL) of the SDMX-REST service.
+        api_version: The most recent version of the SDMX-REST specification
+            supported by the service.
+        data_format: The default format for data queries.
+        structure_format: The default format for structure queries.
+        schema_format: The default format for schema queries.
+        refmeta_format: The default format for reference metadata queries.
+        avail_format: The default format for availability queries.
+        pem: In case the service uses SSL/TLS with self-signed certificate,
+            this attribute should be used to pass the pem file with the
+            list of trusted certicate authorities.
+        timeout: The maximum number of seconds to wait before considering
+            that a request timed out. Defaults to 5 seconds.
+    """
+
+    def __init__(
+        self,
+        api_endpoint: str,
+        api_version: ApiVersion,
+        data_format: DataFormat = DataFormat.SDMX_JSON_2_0_0,
+        structure_format: StructureFormat = StructureFormat.SDMX_JSON_2_0_0,
+        schema_format: SchemaFormat = SchemaFormat.SDMX_JSON_2_0_0_STRUCTURE,
+        refmeta_format: RefMetaFormat = RefMetaFormat.SDMX_JSON_2_0_0,
+        avail_format: AvailabilityFormat = AvailabilityFormat.SDMX_JSON_2_0_0,
+        pem: Optional[str] = None,
+        timeout: Optional[float] = 5.0,
+    ):
+        """Instantiate a connector to a SDMX-REST service."""
+        super().__init__(
+            api_endpoint,
+            api_version,
+            data_format,
+            structure_format,
+            schema_format,
+            refmeta_format,
+            avail_format,
+            pem,
+            timeout,
+        )
+
+    def data(self, query: DataQuery) -> bytes:
+        """Execute a data query against the service."""
+        q = query.get_url(self._api_version, True)
+        f = self._data_format.value
+        return self.__fetch(q, f)
+
+    def structure(self, query: StructureQuery) -> bytes:
+        """Execute a structure query against the service."""
+        q = query.get_url(self._api_version, True)
+        f = self._structure_format.value
+        return self.__fetch(q, f)
+
+    def schema(self, query: SchemaQuery) -> bytes:
+        """Execute a schema query against the service."""
+        q = query.get_url(self._api_version, True)
+        f = self._schema_format.value
+        return self.__fetch(q, f)
+
+    def availability(self, query: AvailabilityQuery) -> bytes:
+        """Execute an availability query against the service."""
+        q = query.get_url(self._api_version, True)
+        f = self._avail_format.value
+        return self.__fetch(q, f)
+
+    def reference_metadata(
+        self,
+        query: Union[
+            RefMetaByMetadataflowQuery,
+            RefMetaByMetadatasetQuery,
+            RefMetaByStructureQuery,
+        ],
+    ) -> bytes:
+        """Execute a reference metadata query against the service."""
+        q = query.get_url(self._api_version, True)
+        f = self._refmeta_format.value
+        return self.__fetch(q, f)
+
+    def __fetch(self, query: str, format: str) -> bytes:
+        with httpx.Client(verify=self._ssl_context) as client:
+            try:
+                url = f"{self._api_endpoint}{query}"
+                h = self._headers.copy()
+                h["Accept"] = format
+                r = client.get(url, headers=h, timeout=self._timeout)
+                r.raise_for_status()
+                return r.content
+            except (httpx.RequestError, httpx.HTTPStatusError) as e:
+                self._map_error(e)

--- a/src/pysdmx/io/format.py
+++ b/src/pysdmx/io/format.py
@@ -64,6 +64,7 @@ class RefMetaFormat(Enum):
     SDMX_CSV_2_0_0 = Format.REFMETA_SDMX_CSV_2_0_0.value
     SDMX_JSON_2_0_0 = Format.REFMETA_SDMX_JSON_2_0_0.value
     SDMX_ML_3_0 = Format.REFMETA_SDMX_ML_3_0.value
+    FUSION_JSON = Format.FUSION_JSON.value
 
 
 class SchemaFormat(Enum):
@@ -77,6 +78,7 @@ class SchemaFormat(Enum):
     SDMX_ML_3_0_SCHEMA = Format.SCHEMA_SDMX_ML_3_0.value
     SDMX_ML_2_1_STRUCTURE = Format.STRUCTURE_SDMX_ML_2_1.value
     SDMX_ML_3_0_STRUCTURE = Format.STRUCTURE_SDMX_ML_3_0.value
+    FUSION_JSON = Format.FUSION_JSON.value
 
 
 class StructureFormat(Enum):

--- a/tests/api/qb/refmeta/test_refmeta_format.py
+++ b/tests/api/qb/refmeta/test_refmeta_format.py
@@ -6,6 +6,7 @@ def test_expected_formats():
         "application/vnd.sdmx.metadata+xml;version=3.0.0",
         "application/vnd.sdmx.metadata+json;version=2.0.0",
         "application/vnd.sdmx.metadata+csv;version=2.0.0",
+        "application/vnd.fusion.json",
     ]
 
     assert len(RefMetaFormat) == len(expected)

--- a/tests/api/qb/schema/test_schema_format.py
+++ b/tests/api/qb/schema/test_schema_format.py
@@ -11,6 +11,7 @@ def test_expected_formats():
         "application/vnd.sdmx.structure+json;version=1.0.0",
         "application/vnd.sdmx.structure+xml;version=3.0.0",
         "application/vnd.sdmx.structure+json;version=2.0.0",
+        "application/vnd.fusion.json",
     ]
 
     assert len(SchemaFormat) == len(expected)

--- a/tests/api/qb/service/test_service_availability_async.py
+++ b/tests/api/qb/service/test_service_availability_async.py
@@ -1,0 +1,128 @@
+import httpx
+import pytest
+
+from pysdmx.api.qb import (
+    ApiVersion,
+    AsyncRestService,
+    AvailabilityFormat,
+    AvailabilityQuery,
+    DataContext,
+)
+from pysdmx.errors import InternalError, Invalid, NotFound, Unavailable
+
+
+@pytest.fixture
+def version() -> ApiVersion:
+    return ApiVersion.V2_0_0
+
+
+@pytest.fixture
+def end_point() -> str:
+    return "https://registry.sdmx.org/sdmx/v2"
+
+
+@pytest.fixture
+def service(end_point: str, version: ApiVersion) -> AsyncRestService:
+    return AsyncRestService(end_point, version)
+
+
+@pytest.fixture
+def query() -> AvailabilityQuery:
+    return AvailabilityQuery(DataContext.DATAFLOW, "BIS", "CBS")
+
+
+@pytest.fixture
+def url(end_point: str, query: AvailabilityQuery, version: ApiVersion) -> str:
+    return f"{end_point}{query.get_url(version, True)}"
+
+
+@pytest.fixture
+def body():
+    with open("tests/api/fmr/samples/orgs/agencies.fusion.json", "rb") as f:
+        return f.read()
+
+
+@pytest.mark.asyncio
+async def test_not_found(
+    respx_mock, service: AsyncRestService, query: AvailabilityQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            404,
+            content=body,
+        )
+    )
+
+    with pytest.raises(NotFound) as e:
+        await service.availability(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_client_error(
+    respx_mock, service: AsyncRestService, query: AvailabilityQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            409,
+            content=body,
+        )
+    )
+
+    with pytest.raises(Invalid) as e:
+        await service.availability(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_service_error(
+    respx_mock, service: AsyncRestService, query: AvailabilityQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            501,
+            content=body,
+        )
+    )
+
+    with pytest.raises(InternalError) as e:
+        await service.availability(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_service_unavailable(
+    respx_mock, service: AsyncRestService, query: AvailabilityQuery, url
+):
+    re = httpx.RequestError("Bad day")
+    respx_mock.get(url).mock(side_effect=re)
+
+    with pytest.raises(Unavailable) as e:
+        await service.availability(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_called_as_expected(
+    respx_mock, service: AsyncRestService, query: AvailabilityQuery, url, body
+):
+    route = respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+    await service.availability(query)
+    assert route.called
+    assert len(route.calls) == 1
+    headers = route.calls[0].request.headers
+    assert headers["Accept"] == AvailabilityFormat.SDMX_JSON_2_0_0.value
+    assert headers["Accept-Encoding"] == "gzip, deflate"

--- a/tests/api/qb/service/test_service_data_async.py
+++ b/tests/api/qb/service/test_service_data_async.py
@@ -1,0 +1,128 @@
+import httpx
+import pytest
+
+from pysdmx.api.qb import (
+    ApiVersion,
+    AsyncRestService,
+    DataContext,
+    DataFormat,
+    DataQuery,
+)
+from pysdmx.errors import InternalError, Invalid, NotFound, Unavailable
+
+
+@pytest.fixture
+def version() -> ApiVersion:
+    return ApiVersion.V2_0_0
+
+
+@pytest.fixture
+def end_point() -> str:
+    return "https://registry.sdmx.org/sdmx/v2"
+
+
+@pytest.fixture
+def service(end_point: str, version: ApiVersion) -> AsyncRestService:
+    return AsyncRestService(end_point, version)
+
+
+@pytest.fixture
+def query() -> DataQuery:
+    return DataQuery(DataContext.ALL, "BIS", "CBS")
+
+
+@pytest.fixture
+def url(end_point: str, query: DataQuery, version: ApiVersion) -> str:
+    return f"{end_point}{query.get_url(version, True)}"
+
+
+@pytest.fixture
+def body():
+    with open("tests/api/fmr/samples/orgs/agencies.fusion.json", "rb") as f:
+        return f.read()
+
+
+@pytest.mark.asyncio
+async def test_not_found(
+    respx_mock, service: AsyncRestService, query: DataQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            404,
+            content=body,
+        )
+    )
+
+    with pytest.raises(NotFound) as e:
+        await service.data(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_client_error(
+    respx_mock, service: AsyncRestService, query: DataQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            409,
+            content=body,
+        )
+    )
+
+    with pytest.raises(Invalid) as e:
+        await service.data(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_service_error(
+    respx_mock, service: AsyncRestService, query: DataQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            501,
+            content=body,
+        )
+    )
+
+    with pytest.raises(InternalError) as e:
+        await service.data(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_service_unavailable(
+    respx_mock, service: AsyncRestService, query: DataQuery, url
+):
+    re = httpx.RequestError("Bad day")
+    respx_mock.get(url).mock(side_effect=re)
+
+    with pytest.raises(Unavailable) as e:
+        await service.data(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_called_as_expected(
+    respx_mock, service: AsyncRestService, query: DataQuery, url, body
+):
+    route = respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+    await service.data(query)
+    assert route.called
+    assert len(route.calls) == 1
+    headers = route.calls[0].request.headers
+    assert headers["Accept"] == DataFormat.SDMX_JSON_2_0_0.value
+    assert headers["Accept-Encoding"] == "gzip, deflate"

--- a/tests/api/qb/service/test_service_refmeta_async.py
+++ b/tests/api/qb/service/test_service_refmeta_async.py
@@ -1,0 +1,148 @@
+import httpx
+import pytest
+
+from pysdmx.api.qb import (
+    ApiVersion,
+    AsyncRestService,
+    RefMetaByMetadataflowQuery,
+    RefMetaFormat,
+)
+from pysdmx.errors import InternalError, Invalid, NotFound, Unavailable
+
+
+@pytest.fixture
+def version() -> ApiVersion:
+    return ApiVersion.V2_0_0
+
+
+@pytest.fixture
+def end_point() -> str:
+    return "https://registry.sdmx.org/sdmx/v2"
+
+
+@pytest.fixture
+def service(end_point: str, version: ApiVersion) -> AsyncRestService:
+    return AsyncRestService(end_point, version)
+
+
+@pytest.fixture
+def query() -> RefMetaByMetadataflowQuery:
+    return RefMetaByMetadataflowQuery("BIS", "CBS", "1.0")
+
+
+@pytest.fixture
+def url(
+    end_point: str, query: RefMetaByMetadataflowQuery, version: ApiVersion
+) -> str:
+    return f"{end_point}{query.get_url(version, True)}"
+
+
+@pytest.fixture
+def body():
+    with open("tests/api/fmr/samples/orgs/agencies.fusion.json", "rb") as f:
+        return f.read()
+
+
+@pytest.mark.asyncio
+async def test_not_found(
+    respx_mock,
+    service: AsyncRestService,
+    query: RefMetaByMetadataflowQuery,
+    body,
+    url,
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            404,
+            content=body,
+        )
+    )
+
+    with pytest.raises(NotFound) as e:
+        await service.reference_metadata(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_client_error(
+    respx_mock,
+    service: AsyncRestService,
+    query: RefMetaByMetadataflowQuery,
+    body,
+    url,
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            409,
+            content=body,
+        )
+    )
+
+    with pytest.raises(Invalid) as e:
+        await service.reference_metadata(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_service_error(
+    respx_mock,
+    service: AsyncRestService,
+    query: RefMetaByMetadataflowQuery,
+    body,
+    url,
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            501,
+            content=body,
+        )
+    )
+
+    with pytest.raises(InternalError) as e:
+        await service.reference_metadata(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_service_unavailable(
+    respx_mock,
+    service: AsyncRestService,
+    query: RefMetaByMetadataflowQuery,
+    url,
+):
+    re = httpx.RequestError("Bad day")
+    respx_mock.get(url).mock(side_effect=re)
+
+    with pytest.raises(Unavailable) as e:
+        await service.reference_metadata(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_called_as_expected(
+    respx_mock,
+    service: AsyncRestService,
+    query: RefMetaByMetadataflowQuery,
+    url,
+    body,
+):
+    route = respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+    await service.reference_metadata(query)
+    assert route.called
+    assert len(route.calls) == 1
+    headers = route.calls[0].request.headers
+    assert headers["Accept"] == RefMetaFormat.SDMX_JSON_2_0_0.value
+    assert headers["Accept-Encoding"] == "gzip, deflate"

--- a/tests/api/qb/service/test_service_schema_async.py
+++ b/tests/api/qb/service/test_service_schema_async.py
@@ -1,0 +1,128 @@
+import httpx
+import pytest
+
+from pysdmx.api.qb import (
+    ApiVersion,
+    AsyncRestService,
+    SchemaContext,
+    SchemaFormat,
+    SchemaQuery,
+)
+from pysdmx.errors import InternalError, Invalid, NotFound, Unavailable
+
+
+@pytest.fixture
+def version() -> ApiVersion:
+    return ApiVersion.V2_0_0
+
+
+@pytest.fixture
+def end_point() -> str:
+    return "https://registry.sdmx.org/sdmx/v2"
+
+
+@pytest.fixture
+def service(end_point: str, version: ApiVersion) -> AsyncRestService:
+    return AsyncRestService(end_point, version)
+
+
+@pytest.fixture
+def query() -> SchemaQuery:
+    return SchemaQuery(SchemaContext.DATAFLOW, "BIS", "CBS", "1.0")
+
+
+@pytest.fixture
+def url(end_point: str, query: SchemaQuery, version: ApiVersion) -> str:
+    return f"{end_point}{query.get_url(version, True)}"
+
+
+@pytest.fixture
+def body():
+    with open("tests/api/fmr/samples/orgs/agencies.fusion.json", "rb") as f:
+        return f.read()
+
+
+@pytest.mark.asyncio
+async def test_not_found(
+    respx_mock, service: AsyncRestService, query: SchemaQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            404,
+            content=body,
+        )
+    )
+
+    with pytest.raises(NotFound) as e:
+        await service.schema(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_client_error(
+    respx_mock, service: AsyncRestService, query: SchemaQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            409,
+            content=body,
+        )
+    )
+
+    with pytest.raises(Invalid) as e:
+        await service.schema(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_service_error(
+    respx_mock, service: AsyncRestService, query: SchemaQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            501,
+            content=body,
+        )
+    )
+
+    with pytest.raises(InternalError) as e:
+        await service.schema(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_service_unavailable(
+    respx_mock, service: AsyncRestService, query: SchemaQuery, url
+):
+    re = httpx.RequestError("Bad day")
+    respx_mock.get(url).mock(side_effect=re)
+
+    with pytest.raises(Unavailable) as e:
+        await service.schema(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_called_as_expected(
+    respx_mock, service: AsyncRestService, query: SchemaQuery, url, body
+):
+    route = respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+    await service.schema(query)
+    assert route.called
+    assert len(route.calls) == 1
+    headers = route.calls[0].request.headers
+    assert headers["Accept"] == SchemaFormat.SDMX_JSON_2_0_0_STRUCTURE.value
+    assert headers["Accept-Encoding"] == "gzip, deflate"

--- a/tests/api/qb/service/test_service_structure_async.py
+++ b/tests/api/qb/service/test_service_structure_async.py
@@ -1,0 +1,128 @@
+import httpx
+import pytest
+
+from pysdmx.api.qb import (
+    ApiVersion,
+    AsyncRestService,
+    StructureFormat,
+    StructureQuery,
+    StructureType,
+)
+from pysdmx.errors import InternalError, Invalid, NotFound, Unavailable
+
+
+@pytest.fixture
+def version() -> ApiVersion:
+    return ApiVersion.V2_0_0
+
+
+@pytest.fixture
+def end_point() -> str:
+    return "https://registry.sdmx.org/sdmx/v2"
+
+
+@pytest.fixture
+def service(end_point: str, version: ApiVersion) -> AsyncRestService:
+    return AsyncRestService(end_point, version)
+
+
+@pytest.fixture
+def query() -> StructureQuery:
+    return StructureQuery(StructureType.ALL, "SDMX", "CL_FREQ")
+
+
+@pytest.fixture
+def url(end_point: str, query: StructureQuery, version: ApiVersion) -> str:
+    return f"{end_point}{query.get_url(version, True)}"
+
+
+@pytest.fixture
+def body():
+    with open("tests/api/fmr/samples/orgs/agencies.fusion.json", "rb") as f:
+        return f.read()
+
+
+@pytest.mark.asyncio
+async def test_not_found(
+    respx_mock, service: AsyncRestService, query: StructureQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            404,
+            content=body,
+        )
+    )
+
+    with pytest.raises(NotFound) as e:
+        await service.structure(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_client_error(
+    respx_mock, service: AsyncRestService, query: StructureQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            409,
+            content=body,
+        )
+    )
+
+    with pytest.raises(Invalid) as e:
+        await service.structure(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_service_error(
+    respx_mock, service: AsyncRestService, query: StructureQuery, body, url
+):
+    respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            501,
+            content=body,
+        )
+    )
+
+    with pytest.raises(InternalError) as e:
+        await service.structure(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_service_unavailable(
+    respx_mock, service: AsyncRestService, query: StructureQuery, url
+):
+    re = httpx.RequestError("Bad day")
+    respx_mock.get(url).mock(side_effect=re)
+
+    with pytest.raises(Unavailable) as e:
+        await service.structure(query)
+    assert e.value.title is not None
+    assert e.value.description is not None
+    assert url in e.value.description
+
+
+@pytest.mark.asyncio
+async def test_called_as_expected(
+    respx_mock, service: AsyncRestService, query: StructureQuery, url, body
+):
+    route = respx_mock.get(url).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+    await service.structure(query)
+    assert route.called
+    assert len(route.calls) == 1
+    headers = route.calls[0].request.headers
+    assert headers["Accept"] == StructureFormat.SDMX_JSON_2_0_0.value
+    assert headers["Accept-Encoding"] == "gzip, deflate"


### PR DESCRIPTION
The purpose of this pull request is to:

- Add an aynchronous client for SDMX-REST services
- Replace the httpx code in the `pysdmx.api.fmr` module with the SDMX-REST synchronous and asynchronous clients

Close #194 