### PR TITLE
Handle empty item schemes in SDMX-JSON and Fusion-JSON

### DIFF
--- a/src/pysdmx/io/json/fusion/messages/category.py
+++ b/src/pysdmx/io/json/fusion/messages/category.py
@@ -94,9 +94,9 @@ class FusionCategoryScheme(Struct, frozen=True, rename={"agency": "agencyId"}):
 class FusionCategorySchemeMessage(Struct, frozen=True):
     """Fusion-JSON payload for /categoryscheme queries."""
 
-    Categorisation: Sequence[FusionCategorisation]
     CategoryScheme: Sequence[FusionCategoryScheme]
-    Dataflow: Sequence[FusionDataflow]
+    Categorisation: Sequence[FusionCategorisation] = ()
+    Dataflow: Sequence[FusionDataflow] = ()
 
     def __group_flows(self) -> defaultdict[str, list[DF]]:
         out: defaultdict[str, list[DF]] = defaultdict(list)

--- a/src/pysdmx/io/json/fusion/messages/concept.py
+++ b/src/pysdmx/io/json/fusion/messages/concept.py
@@ -80,8 +80,8 @@ class FusionConceptSchemeMessage(
 ):
     """Fusion-JSON payload for /conceptscheme queries."""
 
-    Codelist: Sequence[FusionCodelist]
     ConceptScheme: Sequence[FusionConceptScheme]
+    Codelist: Sequence[FusionCodelist] = ()
 
     def to_model(self) -> CS:
         """Returns the requested concept scheme."""

--- a/src/pysdmx/io/json/fusion/messages/org.py
+++ b/src/pysdmx/io/json/fusion/messages/org.py
@@ -89,7 +89,7 @@ class FusionAgencyScheme(Struct, frozen=True):
     """Fusion-JSON payload for an agency scheme."""
 
     agencyId: str
-    items: Sequence[FusionAgency]
+    items: Sequence[FusionAgency] = ()
 
     def to_model(self) -> Sequence[Agency]:
         """Converts a FusionAgencyScheme to a list of Organisations."""

--- a/src/pysdmx/io/json/fusion/messages/org.py
+++ b/src/pysdmx/io/json/fusion/messages/org.py
@@ -109,7 +109,7 @@ class FusionAgencyMessage(Struct, frozen=True):
 class FusionProviderScheme(Struct, frozen=True):
     """Fusion-JSON payload for a data provider scheme."""
 
-    items: Sequence[FusionProvider]
+    items: Sequence[FusionProvider] = ()
 
     def __get_df_ref(self, ref: str) -> DataflowRef:
         a = parse_urn(ref)

--- a/src/pysdmx/io/json/sdmxjson2/messages/category.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/category.py
@@ -97,9 +97,9 @@ class JsonCategoryScheme(Struct, frozen=True, rename={"agency": "agencyID"}):
 class JsonCategorySchemes(Struct, frozen=True):
     """SDMX-JSON payload for the list of category schemes."""
 
-    categorisations: Sequence[JsonCategorisation]
     categorySchemes: Sequence[JsonCategoryScheme]
-    dataflows: Sequence[JsonDataflow]
+    categorisations: Sequence[JsonCategorisation] = ()
+    dataflows: Sequence[JsonDataflow] = ()
 
 
 class JsonCategorySchemeMessage(Struct, frozen=True):

--- a/src/pysdmx/io/json/sdmxjson2/messages/concept.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/concept.py
@@ -95,8 +95,8 @@ class JsonConceptSchemes(
 ):
     """SDMX-JSON payload for the list of concept schemes."""
 
-    codelists: Sequence[JsonCodelist]
     conceptSchemes: Sequence[JsonConceptScheme]
+    codelists: Sequence[JsonCodelist] = ()
 
 
 class JsonConceptSchemeMessage(

--- a/src/pysdmx/io/json/sdmxjson2/messages/org.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/org.py
@@ -77,7 +77,7 @@ class JsonAgencyScheme(Struct, frozen=True):
     """SDMX-JSON payload for an agency scheme."""
 
     agencyID: str
-    agencies: Sequence[Agency]
+    agencies: Sequence[Agency] = ()
     description: Optional[str] = None
     isExternalReference: bool = False
     validFrom: Optional[datetime] = None

--- a/src/pysdmx/io/json/sdmxjson2/messages/org.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/org.py
@@ -16,7 +16,7 @@ class JsonDataProviderScheme(Struct, frozen=True):
     """SDMX-JSON payload for a data provider scheme."""
 
     agencyID: str
-    dataProviders: Sequence[DataProvider]
+    dataProviders: Sequence[DataProvider] = ()
     description: Optional[str] = None
     isExternalReference: bool = False
     validFrom: Optional[datetime] = None

--- a/tests/api/fmr/agency_checks.py
+++ b/tests/api/fmr/agency_checks.py
@@ -81,3 +81,17 @@ def check_org_details(mock, fmr: RegistryClient, query, body):
             assert not c2.uris
         else:
             pytest.fail(f"Unexpected agency: {agency.id}")
+
+
+def check_empty(mock, fmr: RegistryClient, query, body):
+    """get_agencies() can handle empty messages."""
+    mock.get(query).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+
+    agencies = fmr.get_agencies("BIS")
+
+    assert len(agencies) == 0

--- a/tests/api/fmr/category_checks.py
+++ b/tests/api/fmr/category_checks.py
@@ -104,3 +104,23 @@ def __check_core_info(categories: Sequence[Category]):
         assert cat.name.upper().replace(" ", "_") == cat.id
         if cat.categories:
             __check_core_info(cat.categories)
+
+
+def check_empty(mock, fmr: RegistryClient, query, body):
+    """Can handle empty messages."""
+    mock.get(query).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+
+    cs = fmr.get_categories("TEST", "TEST_CS")
+
+    assert isinstance(cs, CategoryScheme)
+    assert cs.id == "TEST_CS"
+    assert cs.name == "Test Category Scheme"
+    assert cs.agency == "TEST"
+    assert cs.description is None
+    assert cs.version == "1.0"
+    assert len(cs) == 0

--- a/tests/api/fmr/concept_checks.py
+++ b/tests/api/fmr/concept_checks.py
@@ -103,3 +103,23 @@ def check_concept_details(mock, fmr: RegistryClient, query, body):
             assert concept.facets is None
         else:
             pytest.fail(f"Unexpected concept {concept.id}")
+
+
+def check_empty(mock, fmr: RegistryClient, query, body):
+    """Can handle empty messages."""
+    mock.get(query).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+
+    cs = fmr.get_concepts("BIS.MEDIT", "MEDIT_CS")
+
+    assert isinstance(cs, ConceptScheme)
+    assert cs.id == "MEDIT_CS"
+    assert cs.name == "List of concepts used by MED IT"
+    assert cs.agency == "BIS.MEDIT"
+    assert cs.description is None
+    assert cs.version == "1.0"
+    assert len(cs) == 0

--- a/tests/api/fmr/fusion/test_agencies.py
+++ b/tests/api/fmr/fusion/test_agencies.py
@@ -33,6 +33,14 @@ def body():
         return f.read()
 
 
+@pytest.fixture
+def empty():
+    with open(
+        "tests/api/fmr/samples/orgs/empty_agencies.fusion.json", "rb"
+    ) as f:
+        return f.read()
+
+
 def test_returns_orgs(respx_mock, fmr, query, body):
     """get_agencies() should return a collection of organizations."""
     checks.check_orgs(respx_mock, fmr, query, body)
@@ -47,3 +55,8 @@ async def test_orgs_have_core_info(respx_mock, async_fmr, query, body):
 def test_detailed_orgs(respx_mock, fmr, query, body):
     """Agencies may have contact information."""
     checks.check_org_details(respx_mock, fmr, query, body)
+
+
+def test_empty_orgs(respx_mock, fmr, query, empty):
+    """get_agencies() can handle empty schemes."""
+    checks.check_orgs(respx_mock, fmr, query, empty)

--- a/tests/api/fmr/fusion/test_agencies.py
+++ b/tests/api/fmr/fusion/test_agencies.py
@@ -59,4 +59,4 @@ def test_detailed_orgs(respx_mock, fmr, query, body):
 
 def test_empty_orgs(respx_mock, fmr, query, empty):
     """get_agencies() can handle empty schemes."""
-    checks.check_orgs(respx_mock, fmr, query, empty)
+    checks.check_empty(respx_mock, fmr, query, empty)

--- a/tests/api/fmr/fusion/test_categories.py
+++ b/tests/api/fmr/fusion/test_categories.py
@@ -36,6 +36,12 @@ def body():
         return f.read()
 
 
+@pytest.fixture
+def empty():
+    with open("tests/api/fmr/samples/cat/empty_cs.fusion.json", "rb") as f:
+        return f.read()
+
+
 def test_returns_categories(respx_mock, fmr, query, body):
     """get_categories() should return a category scheme."""
     checks.check_categories(respx_mock, fmr, query, body)
@@ -50,3 +56,8 @@ async def test_categories_have_core_info(respx_mock, async_fmr, query, body):
 def test_categories_have_details(respx_mock, fmr, query, body):
     """Categories may have extended information."""
     checks.check_category_details(respx_mock, fmr, query, body)
+
+
+def test_empty(respx_mock, fmr, query, empty):
+    """Can handle empty schemes."""
+    checks.check_empty(respx_mock, fmr, query, empty)

--- a/tests/api/fmr/fusion/test_concepts.py
+++ b/tests/api/fmr/fusion/test_concepts.py
@@ -34,6 +34,12 @@ def body():
         return f.read()
 
 
+@pytest.fixture
+def empty():
+    with open("tests/api/fmr/samples/concept/empty_cs.fusion.json", "rb") as f:
+        return f.read()
+
+
 def test_returns_cs(respx_mock, fmr, query, body):
     """get_concepts() should return a concept scheme."""
     checks.check_cs(respx_mock, fmr, query, body)
@@ -48,3 +54,8 @@ async def test_concepts_have_core_info(respx_mock, async_fmr, query, body):
 def test_concepts_have_details(respx_mock, fmr, query, body):
     """Concepts may have extended information."""
     checks.check_concept_details(respx_mock, fmr, query, body)
+
+
+def test_empty(respx_mock, fmr, query, empty):
+    """Can handle empty schemes."""
+    checks.check_empty(respx_mock, fmr, query, empty)

--- a/tests/api/fmr/fusion/test_providers.py
+++ b/tests/api/fmr/fusion/test_providers.py
@@ -41,6 +41,14 @@ def body():
 
 
 @pytest.fixture
+def empty():
+    with open(
+        "tests/api/fmr/samples/orgs/empty_providers.fusion.json", "rb"
+    ) as f:
+        return f.read()
+
+
+@pytest.fixture
 def flowbody():
     with open(
         "tests/api/fmr/samples/orgs/providersflows.fusion.json", "rb"
@@ -67,3 +75,8 @@ def test_detailed_providers(respx_mock, fmr, query, body):
 def test_providers_with_flows(respx_mock, fmr, flowquery, flowbody):
     """Providers may have a list of dataflows for which they provide data."""
     checks.check_with_flows(respx_mock, fmr, flowquery, flowbody)
+
+
+def test_empty_orgs(respx_mock, fmr, query, empty):
+    """Can handle empty schemes."""
+    checks.check_empty(respx_mock, fmr, query, empty)

--- a/tests/api/fmr/provider_checks.py
+++ b/tests/api/fmr/provider_checks.py
@@ -94,3 +94,17 @@ def check_with_flows(mock, fmr, query, body):
             assert len(prv.dataflows) == 0
         else:
             pytest.fail(f"Unexepcted provider: {prv.id}")
+
+
+def check_empty(mock, fmr: RegistryClient, query, body):
+    """Can handle empty messages."""
+    mock.get(query).mock(
+        return_value=httpx.Response(
+            200,
+            content=body,
+        )
+    )
+
+    agencies = fmr.get_providers("BIS")
+
+    assert len(agencies) == 0

--- a/tests/api/fmr/samples/cat/empty_cs.fusion.json
+++ b/tests/api/fmr/samples/cat/empty_cs.fusion.json
@@ -1,0 +1,19 @@
+{
+    "CategoryScheme": [
+        {
+            "id": "TEST_CS",
+            "urn": "urn:sdmx:org.sdmx.infomodel.categoryscheme.CategoryScheme=TEST:TEST_CS(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Test Category Scheme"
+                }
+            ],
+            "agencyId": "TEST",
+            "version": "1.0",
+            "isFinal": false,
+            "isPartial": false,
+            "validityType": "standard"
+        }
+    ]
+}

--- a/tests/api/fmr/samples/cat/empty_cs.json
+++ b/tests/api/fmr/samples/cat/empty_cs.json
@@ -1,0 +1,38 @@
+{
+    "meta": {
+        "id": "IREF324476",
+        "test": false,
+        "schema": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+        "prepared": "2023-08-14T11:57:49Z",
+        "contentLanguages": [
+            "en"
+        ],
+        "sender": {
+            "id": "5B0"
+        }
+    },
+    "data": {
+        "categorySchemes": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "categoryscheme",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.categoryscheme.CategoryScheme=TEST:TEST_CATSCH(1.0)"
+                    }
+                ],
+                "id": "TEST_CS",
+                "name": "Test Category Scheme",
+                "names": {
+                    "en": "Test Category Scheme"
+                },
+                "version": "1.0",
+                "agencyID": "TEST",
+                "isExternalReference": false,
+                "isFinal": false,
+                "isPartial": false
+            }
+        ]
+    }
+}

--- a/tests/api/fmr/samples/concept/empty_cs.fusion.json
+++ b/tests/api/fmr/samples/concept/empty_cs.fusion.json
@@ -1,0 +1,19 @@
+{
+    "ConceptScheme": [
+        {
+            "id": "MEDIT_CS",
+            "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=BIS.MEDIT:MEDIT_CS(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "List of concepts used by MED IT"
+                }
+            ],
+            "agencyId": "BIS.MEDIT",
+            "version": "1.0",
+            "isFinal": false,
+            "isPartial": false,
+            "validityType": "standard"
+        }
+    ]
+}

--- a/tests/api/fmr/samples/concept/empty_cs.json
+++ b/tests/api/fmr/samples/concept/empty_cs.json
@@ -1,0 +1,38 @@
+{
+    "meta": {
+        "id": "IREF398951",
+        "test": false,
+        "schema": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+        "prepared": "2023-07-27T06:38:10Z",
+        "contentLanguages": [
+            "en"
+        ],
+        "sender": {
+            "id": "5B0"
+        }
+    },
+    "data": {
+        "conceptSchemes": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "conceptscheme",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=BIS.MEDIT:MEDIT_CS(1.0)"
+                    }
+                ],
+                "id": "MEDIT_CS",
+                "name": "List of concepts used by MED IT",
+                "names": {
+                    "en": "List of concepts used by MED IT"
+                },
+                "version": "1.0",
+                "agencyID": "BIS.MEDIT",
+                "isExternalReference": false,
+                "isFinal": false,
+                "isPartial": false
+            }
+        ]
+    }
+}

--- a/tests/api/fmr/samples/orgs/empty_agencies.fusion.json
+++ b/tests/api/fmr/samples/orgs/empty_agencies.fusion.json
@@ -1,0 +1,18 @@
+{
+    "AgencyScheme": [
+        {
+            "id": "AGENCIES",
+            "urn": "urn:sdmx:org.sdmx.infomodel.base.AgencyScheme=BIS:AGENCIES(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "AGENCIES"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isFinal": false,
+            "isPartial": false
+        }
+    ]
+}

--- a/tests/api/fmr/samples/orgs/empty_agencies.json
+++ b/tests/api/fmr/samples/orgs/empty_agencies.json
@@ -1,0 +1,38 @@
+{
+    "meta": {
+        "id": "IREF853205",
+        "test": false,
+        "schema": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+        "prepared": "2023-07-25T11:42:05Z",
+        "contentLanguages": [
+            "en"
+        ],
+        "sender": {
+            "id": "5B0"
+        }
+    },
+    "data": {
+        "agencySchemes": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "agencyscheme",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.base.AgencyScheme=BIS:AGENCIES(1.0)"
+                    }
+                ],
+                "id": "AGENCIES",
+                "name": "AGENCIES",
+                "names": {
+                    "en": "AGENCIES"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isFinal": false,
+                "isPartial": false
+            }
+        ]
+    }
+}

--- a/tests/api/fmr/samples/orgs/empty_providers.fusion.json
+++ b/tests/api/fmr/samples/orgs/empty_providers.fusion.json
@@ -1,0 +1,18 @@
+{
+    "DataProviderScheme": [
+        {
+            "id": "DATA_PROVIDERS",
+            "urn": "urn:sdmx:org.sdmx.infomodel.base.DataProviderScheme=BIS:DATA_PROVIDERS(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "DATA_PROVIDERS"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isFinal": false,
+            "isPartial": false
+        }
+    ]
+}

--- a/tests/api/fmr/samples/orgs/empty_providers.json
+++ b/tests/api/fmr/samples/orgs/empty_providers.json
@@ -1,0 +1,38 @@
+{
+    "meta": {
+        "id": "IREF050759",
+        "test": false,
+        "schema": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+        "prepared": "2023-07-24T13:24:32Z",
+        "contentLanguages": [
+            "en"
+        ],
+        "sender": {
+            "id": "5B0"
+        }
+    },
+    "data": {
+        "dataProviderSchemes": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "dataproviderscheme",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.base.DataProviderScheme=BIS:DATA_PROVIDERS(1.0)"
+                    }
+                ],
+                "id": "DATA_PROVIDERS",
+                "name": "DATA_PROVIDERS",
+                "names": {
+                    "en": "DATA_PROVIDERS"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isFinal": false,
+                "isPartial": false
+            }
+        ]
+    }
+}

--- a/tests/api/fmr/sdmx/test_agencies.py
+++ b/tests/api/fmr/sdmx/test_agencies.py
@@ -55,4 +55,4 @@ def test_detailed_orgs(respx_mock, fmr, query, body):
 
 def test_empty_orgs(respx_mock, fmr, query, empty):
     """get_agencies() can handle empty schemes."""
-    checks.check_orgs(respx_mock, fmr, query, empty)
+    checks.check_empty(respx_mock, fmr, query, empty)

--- a/tests/api/fmr/sdmx/test_agencies.py
+++ b/tests/api/fmr/sdmx/test_agencies.py
@@ -31,6 +31,12 @@ def body():
         return f.read()
 
 
+@pytest.fixture
+def empty():
+    with open("tests/api/fmr/samples/orgs/empty_agencies.json", "rb") as f:
+        return f.read()
+
+
 def test_returns_orgs(respx_mock, fmr, query, body):
     """get_agencies() should return a collection of organizations."""
     checks.check_orgs(respx_mock, fmr, query, body)
@@ -45,3 +51,8 @@ async def test_orgs_have_core_info(respx_mock, async_fmr, query, body):
 def test_detailed_orgs(respx_mock, fmr, query, body):
     """Agencies may have contact information."""
     checks.check_org_details(respx_mock, fmr, query, body)
+
+
+def test_empty_orgs(respx_mock, fmr, query, empty):
+    """get_agencies() can handle empty schemes."""
+    checks.check_orgs(respx_mock, fmr, query, empty)

--- a/tests/api/fmr/sdmx/test_categories.py
+++ b/tests/api/fmr/sdmx/test_categories.py
@@ -34,6 +34,12 @@ def body():
         return f.read()
 
 
+@pytest.fixture
+def empty():
+    with open("tests/api/fmr/samples/cat/empty_cs.json", "rb") as f:
+        return f.read()
+
+
 def test_returns_categories(respx_mock, fmr, query, body):
     """get_categories() should return a category scheme."""
     checks.check_categories(respx_mock, fmr, query, body)
@@ -48,3 +54,8 @@ async def test_categories_have_core_info(respx_mock, async_fmr, query, body):
 def test_categories_have_details(respx_mock, fmr, query, body):
     """Categories may have extended information."""
     checks.check_category_details(respx_mock, fmr, query, body)
+
+
+def test_empty(respx_mock, fmr, query, empty):
+    """Can handle empty schemes."""
+    checks.check_empty(respx_mock, fmr, query, empty)

--- a/tests/api/fmr/sdmx/test_concepts.py
+++ b/tests/api/fmr/sdmx/test_concepts.py
@@ -32,6 +32,12 @@ def body():
         return f.read()
 
 
+@pytest.fixture
+def empty():
+    with open("tests/api/fmr/samples/concept/empty_cs.json", "rb") as f:
+        return f.read()
+
+
 def test_returns_cs(respx_mock, fmr, query, body):
     """get_concepts() should return a concept scheme."""
     checks.check_cs(respx_mock, fmr, query, body)
@@ -46,3 +52,8 @@ async def test_concepts_have_core_info(respx_mock, async_fmr, query, body):
 def test_concepts_have_details(respx_mock, fmr, query, body):
     """Concepts may have extended information."""
     checks.check_concept_details(respx_mock, fmr, query, body)
+
+
+def test_empty(respx_mock, fmr, query, empty):
+    """Can handle empty schemes."""
+    checks.check_empty(respx_mock, fmr, query, empty)

--- a/tests/api/fmr/sdmx/test_providers.py
+++ b/tests/api/fmr/sdmx/test_providers.py
@@ -39,6 +39,12 @@ def body():
 
 
 @pytest.fixture
+def empty():
+    with open("tests/api/fmr/samples/orgs/empty_providers.json", "rb") as f:
+        return f.read()
+
+
+@pytest.fixture
 def flowbody():
     with open("tests/api/fmr/samples/orgs/providersflows.json", "rb") as f:
         return f.read()
@@ -63,3 +69,8 @@ def test_detailed_providers(respx_mock, fmr, query, body):
 def test_providers_with_flows(respx_mock, fmr, flowquery, flowbody):
     """Providers may have contact information."""
     checks.check_with_flows(respx_mock, fmr, flowquery, flowbody)
+
+
+def test_empty_orgs(respx_mock, fmr, query, empty):
+    """Can handle empty schemes."""
+    checks.check_empty(respx_mock, fmr, query, empty)


### PR DESCRIPTION
The SDMX-JSON and Fusion-JSON deserializers could not handle empty item schemes for certain types of item schemes. The affected types were: category schemes, concept schemes, agency schemes and data provider schemes. Codelists, value lists and hierarchies were not affected.

Close #191 