### PR TITLE
Wrong media type for mapping queries in the fmr module (SDMX-JSON only)

### DIFF
--- a/tests/api/fmr/agency_checks.py
+++ b/tests/api/fmr/agency_checks.py
@@ -2,10 +2,13 @@ import httpx
 import pytest
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import Organisation
 
 
-def check_orgs(mock, fmr: RegistryClient, query, body):
+def check_orgs(
+    mock, fmr: RegistryClient, query, body, is_fusion: bool = False
+):
     """get_agencies() should return a collection of organizations."""
     mock.get(query).mock(
         return_value=httpx.Response(
@@ -15,6 +18,17 @@ def check_orgs(mock, fmr: RegistryClient, query, body):
     )
 
     agencies = fmr.get_agencies("BIS")
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.STRUCTURE_SDMX_JSON_2_0_0.value
+        )
 
     assert len(agencies) == 2
     for agency in agencies:

--- a/tests/api/fmr/categorisation_checks.py
+++ b/tests/api/fmr/categorisation_checks.py
@@ -1,10 +1,13 @@
 import httpx
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import Categorisation
 
 
-def check_categorisations(mock, fmr: RegistryClient, query, body):
+def check_categorisations(
+    mock, fmr: RegistryClient, query, body, is_fusion: bool = False
+):
     """get_categorisation() should return a catgeorisation."""
     mock.get(query).mock(
         return_value=httpx.Response(
@@ -16,6 +19,17 @@ def check_categorisations(mock, fmr: RegistryClient, query, body):
     cat = fmr.get_categorisation(
         "TEST", "06E00965-AB55-F0C3-5CA3-9D454F3BE88F", "1.0"
     )
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.STRUCTURE_SDMX_JSON_2_0_0.value
+        )
 
     assert isinstance(cat, Categorisation)
     assert cat.id == "06E00965-AB55-F0C3-5CA3-9D454F3BE88F"

--- a/tests/api/fmr/category_checks.py
+++ b/tests/api/fmr/category_checks.py
@@ -3,10 +3,13 @@ from typing import Sequence
 import httpx
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import Category, CategoryScheme
 
 
-def check_categories(mock, fmr: RegistryClient, query, body):
+def check_categories(
+    mock, fmr: RegistryClient, query, body, is_fusion: bool = False
+):
     """get_categories() should return a category scheme."""
     mock.get(query).mock(
         return_value=httpx.Response(
@@ -16,6 +19,17 @@ def check_categories(mock, fmr: RegistryClient, query, body):
     )
 
     cs = fmr.get_categories("TEST", "TEST_CS")
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.STRUCTURE_SDMX_JSON_2_0_0.value
+        )
 
     assert isinstance(cs, CategoryScheme)
     assert len(cs) == 8

--- a/tests/api/fmr/code_checks.py
+++ b/tests/api/fmr/code_checks.py
@@ -3,10 +3,13 @@ from datetime import datetime, timezone
 import httpx
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import Code, Codelist
 
 
-def check_codelist(mock, fmr: RegistryClient, query, body):
+def check_codelist(
+    mock, fmr: RegistryClient, query, body, is_fusion: bool = False
+):
     """get_codes() should return a codelist with the expected codes."""
     mock.get(query).mock(
         return_value=httpx.Response(
@@ -16,6 +19,17 @@ def check_codelist(mock, fmr: RegistryClient, query, body):
     )
 
     codelist = fmr.get_codes("SDMX", "CL_FREQ", "2.0")
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.STRUCTURE_SDMX_JSON_2_0_0.value
+        )
 
     assert isinstance(codelist, Codelist)
     assert len(codelist) == 9

--- a/tests/api/fmr/code_map_checks.py
+++ b/tests/api/fmr/code_map_checks.py
@@ -5,6 +5,7 @@ import httpx
 import pytest
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model.concept import DataType
 from pysdmx.model.map import (
     MultiRepresentationMap,
@@ -14,7 +15,9 @@ from pysdmx.model.map import (
 )
 
 
-def check_code_mapping_core(mock, fmr: RegistryClient, query, body):
+def check_code_mapping_core(
+    mock, fmr: RegistryClient, query, body, is_fusion: bool = False
+):
     """get_code_mappings() should return a dict with mapped codes."""
     mock.get(query).mock(
         return_value=httpx.Response(
@@ -24,6 +27,17 @@ def check_code_mapping_core(mock, fmr: RegistryClient, query, body):
     )
 
     mapping = fmr.get_code_map("BIS", "ISO3166-A3_2_CTY", "1.0")
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.STRUCTURE_SDMX_JSON_2_0_0.value
+        )
 
     assert isinstance(mapping, RepresentationMap)
     assert len(mapping) == 3

--- a/tests/api/fmr/concept_checks.py
+++ b/tests/api/fmr/concept_checks.py
@@ -4,14 +4,26 @@ import httpx
 import pytest
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import Code, Codelist, Concept, ConceptScheme, DataType
 
 
-def check_cs(mock, fmr: RegistryClient, query, body):
+def check_cs(mock, fmr: RegistryClient, query, body, is_fusion: bool = False):
     """get_concepts() should return a concept scheme."""
     mock.get(query).mock(return_value=httpx.Response(200, content=body))
 
     cs = fmr.get_concepts("BIS.MEDIT", "MEDIT_CS")
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.STRUCTURE_SDMX_JSON_2_0_0.value
+        )
 
     assert isinstance(cs, ConceptScheme)
     assert len(cs) == 5

--- a/tests/api/fmr/dataflow_checks.py
+++ b/tests/api/fmr/dataflow_checks.py
@@ -1,10 +1,13 @@
 import httpx
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import Dataflow
 
 
-def check_dataflows(mock, fmr: RegistryClient, query, body):
+def check_dataflows(
+    mock, fmr: RegistryClient, query, body, is_fusion: bool = False
+):
     """get_dataflows() should return a collection of dataflows."""
     mock.get(query).mock(
         return_value=httpx.Response(
@@ -14,6 +17,17 @@ def check_dataflows(mock, fmr: RegistryClient, query, body):
     )
 
     flows = fmr.get_dataflows()
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.STRUCTURE_SDMX_JSON_2_0_0.value
+        )
 
     assert len(flows) == 5
     for df in flows:

--- a/tests/api/fmr/dataflow_infos_checks.py
+++ b/tests/api/fmr/dataflow_infos_checks.py
@@ -1,6 +1,7 @@
 import httpx
 
 from pysdmx.api.fmr import AsyncRegistryClient, DataflowDetails, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import Component, Components, DataflowInfo, Organisation
 
 
@@ -13,6 +14,7 @@ def check_dataflow_info(
     dataflow_body,
     hca_query,
     hca_body,
+    is_fusion: bool = False,
 ):
     """get_schema() should return a schema."""
     route1 = mock.get(hca_query).mock(
@@ -26,6 +28,16 @@ def check_dataflow_info(
     )
 
     dsi = fmr.get_dataflow_details("BIS.CBS", "CBS", "1.0")
+
+    assert len(mock.calls) == 3  # We also fetch the schema and its hierarchy
+    for call in mock.calls:
+        if is_fusion:
+            assert call.request.headers["Accept"] == Format.FUSION_JSON.value
+        else:
+            assert (
+                call.request.headers["Accept"]
+                == Format.STRUCTURE_SDMX_JSON_2_0_0.value
+            )
 
     assert route1.called
     assert route2.called

--- a/tests/api/fmr/fusion/test_agencies.py
+++ b/tests/api/fmr/fusion/test_agencies.py
@@ -43,7 +43,7 @@ def empty():
 
 def test_returns_orgs(respx_mock, fmr, query, body):
     """get_agencies() should return a collection of organizations."""
-    checks.check_orgs(respx_mock, fmr, query, body)
+    checks.check_orgs(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_categories.py
+++ b/tests/api/fmr/fusion/test_categories.py
@@ -44,7 +44,7 @@ def empty():
 
 def test_returns_categories(respx_mock, fmr, query, body):
     """get_categories() should return a category scheme."""
-    checks.check_categories(respx_mock, fmr, query, body)
+    checks.check_categories(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_categorisation.py
+++ b/tests/api/fmr/fusion/test_categorisation.py
@@ -38,7 +38,7 @@ def body():
 
 def test_returns_categorisation(respx_mock, fmr, query, body):
     """get_categorisation() should return a categorisation."""
-    checks.check_categorisations(respx_mock, fmr, query, body)
+    checks.check_categorisations(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_code_mapping.py
+++ b/tests/api/fmr/fusion/test_code_mapping.py
@@ -54,7 +54,7 @@ def multi_body():
 
 def test_returns_code_map(respx_mock, fmr, query, body):
     """get_code_map() should return a list of code mappings."""
-    checks.check_code_mapping_core(respx_mock, fmr, query, body)
+    checks.check_code_mapping_core(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_codes.py
+++ b/tests/api/fmr/fusion/test_codes.py
@@ -37,7 +37,7 @@ def body():
 
 def test_returns_codelist(respx_mock, fmr, query, body):
     """get_codelist() should return a codelist with the expected codes."""
-    checks.check_codelist(respx_mock, fmr, query, body)
+    checks.check_codelist(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_concepts.py
+++ b/tests/api/fmr/fusion/test_concepts.py
@@ -42,7 +42,7 @@ def empty():
 
 def test_returns_cs(respx_mock, fmr, query, body):
     """get_concepts() should return a concept scheme."""
-    checks.check_cs(respx_mock, fmr, query, body)
+    checks.check_cs(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_dataflow_infos.py
+++ b/tests/api/fmr/fusion/test_dataflow_infos.py
@@ -136,6 +136,7 @@ def test_returns_dataflow_info(
         dataflow_body,
         no_hca_query,
         no_hca_body,
+        True,
     )
 
 

--- a/tests/api/fmr/fusion/test_dataflows.py
+++ b/tests/api/fmr/fusion/test_dataflows.py
@@ -36,7 +36,7 @@ def body():
 
 def test_returns_dataflows(respx_mock, fmr, query, body):
     """get_dataflows() should return a collection of dataflows."""
-    checks.check_dataflows(respx_mock, fmr, query, body)
+    checks.check_dataflows(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_hierarchy.py
+++ b/tests/api/fmr/fusion/test_hierarchy.py
@@ -37,7 +37,7 @@ def body():
 
 def test_returns_hierarchy(respx_mock, fmr, query, body):
     """get_hierarchy() should return a hierarchy."""
-    checks.check_hierarchy(respx_mock, fmr, query, body)
+    checks.check_hierarchy(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_mapping.py
+++ b/tests/api/fmr/fusion/test_mapping.py
@@ -54,7 +54,7 @@ def body2():
 
 def test_returns_mapping_definition(respx_mock, fmr, query1, body1):
     """get_mapping() should return a mapping definition."""
-    checks.check_mapping(respx_mock, fmr, query1, body1)
+    checks.check_mapping(respx_mock, fmr, query1, body1, True)
 
 
 def test_returns_multi_mapping_definition(respx_mock, fmr, query2, body2):

--- a/tests/api/fmr/fusion/test_providers.py
+++ b/tests/api/fmr/fusion/test_providers.py
@@ -58,7 +58,7 @@ def flowbody():
 
 def test_returns_providers(respx_mock, fmr, query, body):
     """get_providers() should return a collection of organizations."""
-    checks.check_orgs(respx_mock, fmr, query, body)
+    checks.check_orgs(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_provision_agreement.py
+++ b/tests/api/fmr/fusion/test_provision_agreement.py
@@ -36,7 +36,7 @@ def body():
 
 def test_returns_provision_agreement(respx_mock, fmr, query, body):
     """get_provision_agreement() should return a provision agreement."""
-    checks.check_provision_agreements(respx_mock, fmr, query, body)
+    checks.check_provision_agreements(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_report.py
+++ b/tests/api/fmr/fusion/test_report.py
@@ -54,7 +54,7 @@ def body2():
 
 def test_returns_report(respx_mock, fmr, query, body):
     """get_hierarchy() should return a metadata report."""
-    checks.check_report(respx_mock, fmr, query, body)
+    checks.check_report(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_reports.py
+++ b/tests/api/fmr/fusion/test_reports.py
@@ -40,7 +40,7 @@ def body():
 
 def test_returns_mult_report(respx_mock, fmr, query, body):
     """get_reports() should return multiple reports."""
-    checks.check_reports(respx_mock, fmr, query, body)
+    checks.check_reports(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_schemas.py
+++ b/tests/api/fmr/fusion/test_schemas.py
@@ -198,7 +198,7 @@ def test_returns_validation_context(
 ):
     """get_validation_context() should return a schema."""
     checks.check_schema(
-        respx_mock, fmr, query, no_hca_query, body, no_hca_body
+        respx_mock, fmr, query, no_hca_query, body, no_hca_body, True
     )
 
 

--- a/tests/api/fmr/fusion/test_vl_codes.py
+++ b/tests/api/fmr/fusion/test_vl_codes.py
@@ -46,7 +46,7 @@ def body():
 
 def test_returns_codelist_from_vl(respx_mock, fmr, q1, q2, body):
     """get_codelist() should return a codelist with the expected codes."""
-    checks.check_vl_codelist(respx_mock, fmr, q1, q2, body)
+    checks.check_vl_codelist(respx_mock, fmr, q1, q2, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/fusion/test_vtl_ts.py
+++ b/tests/api/fmr/fusion/test_vtl_ts.py
@@ -50,7 +50,7 @@ def body_cs():
 
 def test_returns_transformation_scheme(respx_mock, fmr, query, body):
     """get_vtl_transformation_scheme() returns a transformation scheme."""
-    checks.check_transformation_scheme(respx_mock, fmr, query, body)
+    checks.check_transformation_scheme(respx_mock, fmr, query, body, True)
 
 
 @pytest.mark.asyncio

--- a/tests/api/fmr/hierarchy_checks.py
+++ b/tests/api/fmr/hierarchy_checks.py
@@ -4,10 +4,13 @@ from typing import Sequence
 import httpx
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import HierarchicalCode, Hierarchy
 
 
-def check_hierarchy(mock, fmr: RegistryClient, query, body):
+def check_hierarchy(
+    mock, fmr: RegistryClient, query, body, is_fusion: bool = False
+):
     """get_hierarchy() should return a hierarchy."""
     mock.get(query).mock(
         return_value=httpx.Response(
@@ -17,6 +20,17 @@ def check_hierarchy(mock, fmr: RegistryClient, query, body):
     )
 
     h = fmr.get_hierarchy("TEST", "HCL_ELEMENT")
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.STRUCTURE_SDMX_JSON_2_0_0.value
+        )
 
     assert isinstance(h, Hierarchy)
     assert len(h) == 18

--- a/tests/api/fmr/mult_reports_checks.py
+++ b/tests/api/fmr/mult_reports_checks.py
@@ -3,10 +3,13 @@ from typing import Sequence
 import httpx
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import MetadataAttribute
 
 
-def check_reports(mock, fmr: RegistryClient, query, body):
+def check_reports(
+    mock, fmr: RegistryClient, query, body, is_fusion: bool = False
+):
     """get_reports() should return multiple metadata reports."""
     mock.get(query).mock(
         return_value=httpx.Response(
@@ -16,6 +19,17 @@ def check_reports(mock, fmr: RegistryClient, query, body):
     )
 
     reports = fmr.get_reports("dataflow", "BIS.MACRO", "BIS_MACRO", "1.0")
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.REFMETA_SDMX_JSON_2_0_0.value
+        )
 
     assert isinstance(reports, Sequence)
     assert len(reports) == 2

--- a/tests/api/fmr/pa_checks.py
+++ b/tests/api/fmr/pa_checks.py
@@ -1,10 +1,13 @@
 import httpx
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import ProvisionAgreement
 
 
-def check_provision_agreements(mock, fmr: RegistryClient, query, body):
+def check_provision_agreements(
+    mock, fmr: RegistryClient, query, body, is_fusion: bool = False
+):
     """get_provision_agreement() should return a provision agreement."""
     mock.get(query).mock(
         return_value=httpx.Response(
@@ -14,6 +17,17 @@ def check_provision_agreements(mock, fmr: RegistryClient, query, body):
     )
 
     cat = fmr.get_provision_agreement("BIS.CBS", "CBS_BIS_5B0", "1.0")
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.STRUCTURE_SDMX_JSON_2_0_0.value
+        )
 
     assert isinstance(cat, ProvisionAgreement)
     assert cat.id == "CBS_BIS_5B0"

--- a/tests/api/fmr/provider_checks.py
+++ b/tests/api/fmr/provider_checks.py
@@ -2,10 +2,13 @@ import httpx
 import pytest
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import Organisation
 
 
-def check_orgs(mock, fmr: RegistryClient, query, body):
+def check_orgs(
+    mock, fmr: RegistryClient, query, body, is_fusion: bool = False
+):
     """get_providers() should return a collection of organizations."""
     mock.get(query).mock(
         return_value=httpx.Response(
@@ -15,6 +18,17 @@ def check_orgs(mock, fmr: RegistryClient, query, body):
     )
 
     prvs = fmr.get_providers("BIS")
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.STRUCTURE_SDMX_JSON_2_0_0.value
+        )
 
     assert len(prvs) == 2
     for prv in prvs:

--- a/tests/api/fmr/report_checks.py
+++ b/tests/api/fmr/report_checks.py
@@ -2,10 +2,13 @@ import httpx
 import pytest
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import MetadataAttribute, MetadataReport
 
 
-def check_report(mock, fmr: RegistryClient, query, body):
+def check_report(
+    mock, fmr: RegistryClient, query, body, is_fusion: bool = False
+):
     """get_report() should return a metadata report."""
     mock.get(query).mock(
         return_value=httpx.Response(
@@ -15,6 +18,17 @@ def check_report(mock, fmr: RegistryClient, query, body):
     )
 
     report = fmr.get_report("BIS.MEDIT", "DTI_BIS_MACRO", "1.0")
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.REFMETA_SDMX_JSON_2_0_0.value
+        )
 
     assert isinstance(report, MetadataReport)
     assert report.id == "DTI_BIS_MACRO"

--- a/tests/api/fmr/vtl_ts_checks.py
+++ b/tests/api/fmr/vtl_ts_checks.py
@@ -3,6 +3,7 @@ from typing import Any
 import httpx
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
+from pysdmx.io.format import Format
 from pysdmx.model import (
     CustomType,
     DataType,
@@ -17,11 +18,24 @@ from pysdmx.model import (
 )
 
 
-def check_transformation_scheme(mock, fmr: RegistryClient, query, body):
+def check_transformation_scheme(
+    mock, fmr: RegistryClient, query, body, is_fusion: bool = False
+):
     """get_vtl_transformation_scheme() returns a transformation scheme."""
     mock.get(query).mock(return_value=httpx.Response(200, content=body))
 
     ts = fmr.get_vtl_transformation_scheme("TEST", "TEST_TS", "1.0")
+
+    assert len(mock.calls) == 1
+    if is_fusion:
+        assert (
+            mock.calls[0].request.headers["Accept"] == Format.FUSION_JSON.value
+        )
+    else:
+        assert (
+            mock.calls[0].request.headers["Accept"]
+            == Format.STRUCTURE_SDMX_JSON_2_0_0.value
+        )
 
     __check_response(ts)
 


### PR DESCRIPTION
Close #201 

The issue highlighted by the issue #201 was fixed by PR #196. However, the extra tests aim at preventing regressions later.