### PR TITLE
Prepare release of v1.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,9 @@
 Changelog
 =========
 
-All notable changes to this project are listed in the *release notes* published
-with the `project documentation <https://bis-med-it.github.io/pysdmx>`_ .
+All notable changes to this project are listed in the 
+`releases section <https://github.com/bis-med-it/pysdmx/releases>`_ .
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to 
-`Semantic Versioning <https://semver.org/spec/v2.0.0.html)>`_.
+`Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,38 +1,6 @@
 Release notes
 =============
 
-1.1.0 (2025-02-06)
-------------------
-
-Added
-^^^^^
-
-- Support SDMX-REST v2.1.0 (and registration queries).
-- Asynchronous client for SDMX-REST services.
-- Option to set a timeout to SDMX-REST services client.
-
-Fixed
-^^^^^
-
-- Handling of empty item schemes in SDMX-JSON and Fusion-JSON.
-- Wrong URN returned by Schema objects.
-- Wrong media type for mapping queries in the fmr module (SDMX-JSON only).
-
-
-1.0.0 (2025-01-20)
-------------------
-
-Added
-^^^^^
-
-- Core domain classes for the SDMX information model.
-- Sync and async clients to retrieve metadata
-  from an SDMX Registry or SDMX-REST service, and use them to
-  drive statistical business processes.
-- Data readers and writers for SDMX-ML 2.1, SDMX-CSV 2.0 and
-  SDMX-CSV 1.0
-- Structures readers and writers SDMX-ML 2.1, SDMX-JSON 2.0 and
-  Fusion-JSON
-- SDMX-REST query builders and a service client to execute
-  queries against SDMX-REST services.
-- Utility functions to handle SDMX URNs.
+Please go to the project's **Releases** section on 
+`GitHub <https://github.com/bis-med-it/pysdmx/releases>`_ to get more
+information about the various releases of the library.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -1,6 +1,24 @@
 Release notes
 =============
 
+1.1.0 (2025-02-06)
+------------------
+
+Added
+^^^^^
+
+- Support SDMX-REST v2.1.0 (and registration queries).
+- Asynchronous client for SDMX-REST services.
+- Option to set a timeout to SDMX-REST services client.
+
+Fixed
+^^^^^
+
+- Handling of empty item schemes in SDMX-JSON and Fusion-JSON.
+- Wrong URN returned by Schema objects.
+- Wrong media type for mapping queries in the fmr module (SDMX-JSON only).
+
+
 1.0.0 (2025-01-20)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = ["sdmx", "data discovery", "data retrieval", "metadata", "fmr"]
 repository = "https://github.com/bis-med-it/pysdmx"
 license = "Apache-2.0"
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysdmx"
-version = "1.0.0"
+version = "1.1.0"
 description = "Your opinionated Python SDMX library"
 authors = [
     "Xavier Sosnovsky <xavier.sosnovsky@bis.org>",

--- a/src/pysdmx/__init__.py
+++ b/src/pysdmx/__init__.py
@@ -1,3 +1,3 @@
 """Your opinionated Python SDMX library."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"


### PR DESCRIPTION
This PR:

- Bumps the version number
- Adds a release note for 1.1.0
- Sets the development status to Production/Stable