### PR TITLE
Fixed bug on writing SDMX ML file with optional attributes

### DIFF
--- a/src/pysdmx/io/xml/sdmx21/writer/__write_aux.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/__write_aux.py
@@ -271,6 +271,7 @@ def get_codes(
     """This function divides the components in Series and Obs."""
     series_codes = []
     obs_codes = [dimension_code, dataset.structure.components.measures[0].id]
+    cols = dataset.data.columns
 
     # Getting the series and obs codes
     for dim in dataset.structure.components.dimensions:
@@ -279,9 +280,13 @@ def get_codes(
 
     # Adding the attributes based on the attachment level
     for att in dataset.structure.components.attributes:
-        if att.attachment_level == "O":
+        if att.attachment_level == "O" and att.id in cols:
             obs_codes.append(att.id)
-        elif att.attachment_level is not None and att.attachment_level != "D":
+        elif (
+            att.attachment_level is not None
+            and att.attachment_level != "D"
+            and att.id in cols
+        ):
             series_codes.append(att.id)
 
     return series_codes, obs_codes

--- a/src/pysdmx/io/xml/sdmx21/writer/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/generic.py
@@ -53,10 +53,16 @@ def __generate_obs_structure(
     for dim in dataset.structure.components.dimensions:
         obs_structure[0].append(dim.id)
 
+    cols = dataset.data.columns
+
     for att in dataset.structure.components.attributes:
-        if att.attachment_level == "O":
+        if att.attachment_level == "O" and att.id in cols:
             obs_structure[2].append(att.id)
-        elif att.attachment_level is not None and att.attachment_level != "D":
+        elif (
+            att.attachment_level is not None
+            and att.attachment_level != "D"
+            and att.id in cols
+        ):
             obs_structure[0].append(att.id)
 
     return obs_structure

--- a/tests/api/qb/registration/test_regctx_query_updated_before.py
+++ b/tests/api/qb/registration/test_regctx_query_updated_before.py
@@ -93,7 +93,6 @@ def test_url_updated_consistency(
     updated_after: datetime,
     api_version: ApiVersion,
 ):
-
     q = RegistrationByContextQuery(
         updated_before=updated_after, updated_after=updated_before
     )

--- a/tests/api/qb/registration/test_regprv_query_updated_before.py
+++ b/tests/api/qb/registration/test_regprv_query_updated_before.py
@@ -98,7 +98,6 @@ def test_url_updated_consistency(
     updated_after: datetime,
     api_version: ApiVersion,
 ):
-
     q = RegistrationByProviderQuery(
         updated_before=updated_after, updated_after=updated_before
     )

--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -282,3 +282,32 @@ def test_invalid_dimension_key(content):
             content,
             dimension_at_observation=dim_mapping,
         )
+
+
+def test_optional_data_attributes(content):
+    content = list(content.values())
+    # Removing optional attribute ATT2 only from data
+    content[0].data = content[0].data.drop(columns=["ATT2"])
+
+    assert "ATT2" in [c.id for c in content[0].structure.components]
+    assert not content[0].structure.components["ATT2"].required
+
+    # Writing with ATT2 removed to check issue #209
+    result_spe = write_str_spec(
+        content,
+        dimension_at_observation={content[0].structure.short_urn: "DIM1"},
+    )
+    result_spe_all = write_str_spec(content)
+    result_gen = write_gen(content)
+
+    # Reading the output to check the shape
+    msg_spe = read_sdmx(result_spe, validate=True)
+    msg_gen = read_sdmx(result_gen, validate=True)
+    msg_spe_all = read_sdmx(result_spe_all, validate=True)
+    data_spe = msg_spe.get_dataset(content[0].structure.short_urn).data
+    data_gen = msg_gen.get_dataset(content[0].structure.short_urn).data
+    data_spe_all = msg_spe_all.get_dataset(content[0].structure.short_urn).data
+
+    assert data_spe.shape == (3, 4)
+    assert data_gen.shape == (3, 4)
+    assert data_spe_all.shape == (3, 4)


### PR DESCRIPTION
Closes #209 

Added a check to ensure the optional attributes are present inside the data, if not, the attributes should not be added to series_codes and obs_codes.

The two test files are just format changes (from another branch maybe?)