### PR TITLE
Fix Header order on Source and add compatibility for empty data on SDMX-ML Data messages

### DIFF
--- a/src/pysdmx/io/xml/sdmx21/reader/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/generic.py
@@ -76,6 +76,8 @@ def __reading_generic_series(dataset: Dict[str, Any]) -> pd.DataFrame:
 def __reading_generic_all(dataset: Dict[str, Any]) -> pd.DataFrame:
     # Generic All Dimensions
     test_list = []
+    if OBS not in dataset:
+        return pd.DataFrame()
     df = None
     dataset[OBS] = add_list(dataset[OBS])
     for data in dataset[OBS]:

--- a/src/pysdmx/io/xml/sdmx21/reader/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/structure_specific.py
@@ -74,6 +74,8 @@ def __parse_structure_specific_data(
 ) -> PandasDataset:
     attached_attributes = __get_at_att_str(dataset)
 
+    df = pd.DataFrame()
+
     # Parsing data
     if SERIES in dataset:
         # Structure Specific Series
@@ -84,7 +86,7 @@ def __parse_structure_specific_data(
                 set(df.columns).intersection(set(df_group.columns))
             )
             df = pd.merge(df, df_group, on=common_columns, how="left")
-    else:
+    elif OBS in dataset:
         dataset[OBS] = add_list(dataset[OBS])
         # Structure Specific All dimensions
         df = pd.DataFrame(dataset[OBS]).replace(np.nan, "")

--- a/src/pysdmx/io/xml/sdmx21/writer/__write_aux.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/__write_aux.py
@@ -240,8 +240,8 @@ def __write_header(
         f"{__value('Prepared', prepared)}"
         f"{__item('Sender', header.sender)}"
         f"{__item('Receiver', header.receiver)}"
-        f"{__value('Source', header.source)}"
         f"{references_str}"
+        f"{__value('Source', header.source)}"
         f"{nl}{child1}</{ABBR_MSG}:Header>"
     ).replace("'", '"')
 

--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -301,6 +301,16 @@ def test_write_empty_data(header, content):
         header=header,
         prettyprint=True,
     )
+
+    # Check the source is present and there are references to the structure
+    assert "Source" in result_spe
+    assert "Source" in result_gen
+
+    reference = (
+        '<Ref agencyID="MD" id="TEST" version="1.0" class="DataStructure"/>'
+    )
+    assert reference in result_spe
+    assert reference in result_gen
     # Checks validation against XSD
     msg_spe = read_sdmx(result_spe, validate=True)
     msg_gen = read_sdmx(result_gen, validate=True)

--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -32,6 +32,9 @@ def header():
     return Header(
         id="ID",
         prepared=datetime.strptime("2021-01-01", "%Y-%m-%d"),
+        sender="SENDER",
+        receiver="RECEIVER",
+        source="PySDMX",
     )
 
 
@@ -282,3 +285,25 @@ def test_invalid_dimension_key(content):
             content,
             dimension_at_observation=dim_mapping,
         )
+
+
+def test_write_empty_data(header, content):
+    content = list(content.values())
+    content[0].data = pd.DataFrame(columns=content[0].data.columns)
+    content[0].attributes = {}
+    result_spe = write_str_spec(
+        content,
+        header=header,
+        prettyprint=True,
+    )
+    result_gen = write_gen(
+        content,
+        header=header,
+        prettyprint=True,
+    )
+    # Checks validation against XSD
+    msg_spe = read_sdmx(result_spe, validate=True)
+    msg_gen = read_sdmx(result_gen, validate=True)
+
+    assert msg_spe.data[0].data.empty
+    assert msg_gen.data[0].data.empty


### PR DESCRIPTION
Closes #217 

- Fixed Header order and added test to write and read empty data. 
- Ensure we write a Header with Source and references that is valid against the SDMX-ML 2.1 XSD.