### PR TITLE
Add escape function to SDMX-ML writers

### DIFF
--- a/src/pysdmx/io/xml/sdmx21/writer/__write_aux.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/__write_aux.py
@@ -3,6 +3,7 @@
 
 from collections import OrderedDict
 from typing import Dict, List, Optional, Sequence, Tuple
+from xml.sax.saxutils import escape
 
 from pysdmx.errors import Invalid, NotImplemented
 from pysdmx.io.format import Format
@@ -377,3 +378,7 @@ def __to_lower_camel_case(snake_str: str) -> str:
     # with the 'capitalize' method and join them together.
     camel_string = __to_camel_case(snake_str)
     return snake_str[0].lower() + camel_string[1:]
+
+
+def __escape_xml(value: str) -> str:
+    return escape(value)

--- a/src/pysdmx/io/xml/sdmx21/writer/structure.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/structure.py
@@ -2,6 +2,7 @@
 
 from collections import OrderedDict
 from typing import Any, Dict, Optional, Sequence, Union
+from xml.sax.saxutils import escape
 
 from pysdmx.io.format import Format
 from pysdmx.io.xml.sdmx21.__tokens import (
@@ -145,7 +146,7 @@ def __write_annotable(annotable: AnnotableArtefact, indent: str) -> str:
         for attr, label in ANNOTATION_WRITER.items():
             if getattr(annotation, attr, None) is not None:
                 value = getattr(annotation, attr)
-                value = value.replace("&", "&amp;").rstrip()
+                value = escape(value)
 
                 if attr == "text":
                     head_tag = f'{ABBR_COM}:{label} xml:lang="en"'
@@ -193,11 +194,13 @@ def __write_nameable(
 
     for attr in attrs:
         if getattr(nameable, attr.lower(), None) is not None:
+            value = getattr(nameable, attr.lower())
+            value = escape(value)
             outfile[attr] = [
                 (
                     f"{indent}"
                     f'<{ABBR_COM}:{attr} xml:lang="en">'
-                    f"{getattr(nameable, attr.lower())}"
+                    f"{value}"
                     f"</{ABBR_COM}:{attr}>"
                 )
             ]
@@ -249,7 +252,7 @@ def __write_contact(contact: Contact, indent: str) -> str:
     """Writes the contact to the XML file."""
 
     def __item_to_str(item: Any, ns: str, tag: str) -> str:
-        return f"{add_indent(indent)}<{ns}:{tag}>{item}</{ns}:{tag}>"
+        return f"{add_indent(indent)}<{ns}:{tag}>{escape(item)}</{ns}:{tag}>"
 
     def __items_to_str(items: Any, ns: str, tag: str) -> str:
         return "".join([__item_to_str(item, ns, tag) for item in items])

--- a/src/pysdmx/io/xml/sdmx21/writer/structure.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/structure.py
@@ -2,7 +2,6 @@
 
 from collections import OrderedDict
 from typing import Any, Dict, Optional, Sequence, Union
-from xml.sax.saxutils import escape
 
 from pysdmx.io.format import Format
 from pysdmx.io.xml.sdmx21.__tokens import (
@@ -53,6 +52,7 @@ from pysdmx.io.xml.sdmx21.writer.__write_aux import (
     ABBR_MSG,
     ABBR_STR,
     MSG_CONTENT_PKG,
+    __escape_xml,
     __to_lower_camel_case,
     __write_header,
     add_indent,
@@ -146,7 +146,7 @@ def __write_annotable(annotable: AnnotableArtefact, indent: str) -> str:
         for attr, label in ANNOTATION_WRITER.items():
             if getattr(annotation, attr, None) is not None:
                 value = getattr(annotation, attr)
-                value = escape(value)
+                value = __escape_xml(str(value))
 
                 if attr == "text":
                     head_tag = f'{ABBR_COM}:{label} xml:lang="en"'
@@ -195,7 +195,7 @@ def __write_nameable(
     for attr in attrs:
         if getattr(nameable, attr.lower(), None) is not None:
             value = getattr(nameable, attr.lower())
-            value = escape(value)
+            value = __escape_xml(str(value))
             outfile[attr] = [
                 (
                     f"{indent}"
@@ -252,7 +252,12 @@ def __write_contact(contact: Contact, indent: str) -> str:
     """Writes the contact to the XML file."""
 
     def __item_to_str(item: Any, ns: str, tag: str) -> str:
-        return f"{add_indent(indent)}<{ns}:{tag}>{escape(item)}</{ns}:{tag}>"
+        return (
+            f"{add_indent(indent)}"
+            f"<{ns}:{tag}>"
+            f"{__escape_xml(str(item))}"
+            f"</{ns}:{tag}>"
+        )
 
     def __items_to_str(items: Any, ns: str, tag: str) -> str:
         return "".join([__item_to_str(item, ns, tag) for item in items])

--- a/src/pysdmx/io/xml/sdmx21/writer/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/structure_specific.py
@@ -10,6 +10,7 @@ from pysdmx.io.pd import PandasDataset
 from pysdmx.io.xml.sdmx21.writer.__write_aux import (
     ABBR_MSG,
     ALL_DIM,
+    __escape_xml,
     __write_header,
     check_content_dataset,
     check_dimension_at_observation,
@@ -127,14 +128,14 @@ def __write_data_single_dataset(
         f'ss:dataScope="DataStructure" '
         f'action="Replace">{nl}'
     )
-
+    data = ""
     if dim == ALL_DIM:
-        outfile += __memory_optimization_writing(dataset, prettyprint)
+        data += __memory_optimization_writing(dataset, prettyprint)
     else:
         writing_validation(dataset)
         series_codes, obs_codes = get_codes(dim, dataset)
 
-        outfile += __series_processing(
+        data += __series_processing(
             data=dataset.data,
             series_codes=series_codes,
             obs_codes=obs_codes,
@@ -142,7 +143,10 @@ def __write_data_single_dataset(
         )
 
         # Remove optional attributes empty data
-        outfile = __remove_optional_attributes_empty_data(outfile)
+        data = __remove_optional_attributes_empty_data(data)
+
+    # Adding to outfile
+    outfile += data
 
     outfile += f"{child1}</{ABBR_MSG}:DataSet>"
 
@@ -158,7 +162,7 @@ def __obs_processing(data: pd.DataFrame, prettyprint: bool = True) -> str:
         out = f"{child2}<Obs "
 
         for k, v in element.items():
-            out += f"{k}={str(v)!r} "
+            out += f"{k}={__escape_xml(str(v))!r} "
 
         out += f"/>{nl}"
 
@@ -209,7 +213,7 @@ def __series_processing(
 
         for k, v in data_info.items():
             if k != "Obs":
-                out_element += f"{k}={str(v)!r} "
+                out_element += f"{k}={__escape_xml(str(v))!r} "
 
         out_element += f">{nl}"
 
@@ -217,7 +221,7 @@ def __series_processing(
             out_element += f"{child3}<Obs "
 
             for k, v in obs.items():
-                out_element += f"{k}={str(v)!r} "
+                out_element += f"{k}={__escape_xml(str(v))!r} "
 
             out_element += f"/>{nl}"
 

--- a/tests/io/xml/sdmx21/writer/samples/bis_der.xml
+++ b/tests/io/xml/sdmx21/writer/samples/bis_der.xml
@@ -3535,7 +3535,7 @@
 					<com:Name xml:lang="en">South African Rand</com:Name>
 				</str:Code>
 				<str:Code id="ZZZ" urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_BIS_UNIT(1.0).ZZZ">
-					<com:Name xml:lang="en">Temp unit --> CODE OBSOLETE SINCE 2013.04.05</com:Name>
+					<com:Name xml:lang="en">Temp unit --&gt; CODE OBSOLETE SINCE 2013.04.05</com:Name>
 				</str:Code>
 				<str:Code id="XDC" urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_BIS_UNIT(1.0).XDC">
 					<com:Name xml:lang="en">Domestic currency (incl. conversion to current currency made using a fix

--- a/tests/io/xml/sdmx21/writer/samples/estat_sample.xml
+++ b/tests/io/xml/sdmx21/writer/samples/estat_sample.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<m:Structure xmlns:m="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+             xmlns:s="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure"
+             xmlns:c="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">
+    <m:Header>
+        <m:ID>DF1737844368</m:ID>
+        <m:Test>false</m:Test>
+        <m:Prepared>2025-01-25T23:32:48.84+01:00</m:Prepared>
+        <m:Sender id="ESTAT"/>
+    </m:Header>
+    <m:Structures>
+        <s:Dataflows>
+            <s:Dataflow id="ISOC_CI_ID_H"
+                        urn="urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=ESTAT:ISOC_CI_ID_H(1.0)"
+                        agencyID="ESTAT" version="1.0" isFinal="false">
+                <c:Annotations>
+                    <c:Annotation>
+                        <c:AnnotationTitle>2009-03-27T17:52:43+0100</c:AnnotationTitle>
+                        <c:AnnotationType>CREATED</c:AnnotationType>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationTitle>&lt;adms:identifier xmlns:adms="http://www.w3.org/ns/adms#"
+                            xmlns:skos="http://www.w3.org/2004/02/skos/core.html" xmlns:dct="http://purl.org/dc/terms/"
+                            xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">&lt;adms:Identifier
+                            rdf:about="https://doi.org/10.2908/ISOC_CI_ID_H">&lt;skos:notation
+                            rdf:datatype="http://purl.org/spar/datacite/doi">10.2908/ISOC_CI_ID_H&lt;/skos:notation>&lt;dct:creator
+                            rdf:resource="http://publications.europa.eu/resource/authority/corporate-body/ESTAT"/>&lt;dct:issued
+                            rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-01-19&lt;/dct:issued>&lt;/adms:Identifier>&lt;/adms:identifier>
+                        </c:AnnotationTitle>
+                        <c:AnnotationType>DISSEMINATION_DOI_XML</c:AnnotationType>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationTitle>DATASET</c:AnnotationTitle>
+                        <c:AnnotationType>DISSEMINATION_OBJECT_TYPE</c:AnnotationType>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationTitle>2025-01-24T23:00:00+0100</c:AnnotationTitle>
+                        <c:AnnotationType>DISSEMINATION_TIMESTAMP_DATA</c:AnnotationType>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationTitle>2025-01-24T23:00:00+0100</c:AnnotationTitle>
+                        <c:AnnotationType>DISSEMINATION &amp; TIMESTAMP_GLOBAL</c:AnnotationType>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationTitle>2025-01-24T23:00:00+0100</c:AnnotationTitle>
+                        <c:AnnotationType>DISSEMINATION_TIMESTAMP_PLANNED</c:AnnotationType>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationTitle>Explanatory texts (metadata)</c:AnnotationTitle>
+                        <c:AnnotationType>ESMS_HTML</c:AnnotationType>
+                        <c:AnnotationURL>https://ec.europa.eu/eurostat/cache/metadata/en/isoc_i_esms.htm
+                        </c:AnnotationURL>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationTitle>Explanatory texts (metadata)</c:AnnotationTitle>
+                        <c:AnnotationType>ESMS_SDMX</c:AnnotationType>
+                        <c:AnnotationURL>
+                            https://ec.europa.eu/eurostat/api/dissemination/files?file=metadata/isoc_i_esms.sdmx.zip&amp;test=false
+                        </c:AnnotationURL>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationTitle>95814</c:AnnotationTitle>
+                        <c:AnnotationType>OBS_COUNT</c:AnnotationType>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationTitle>2014</c:AnnotationTitle>
+                        <c:AnnotationType>OBS_PERIOD_OVERALL_LATEST</c:AnnotationType>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationTitle>2002</c:AnnotationTitle>
+                        <c:AnnotationType>OBS_PERIOD_OVERALL_OLDEST</c:AnnotationType>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationType>SOURCE_INSTITUTIONS</c:AnnotationType>
+                        <c:AnnotationText xml:lang="fr">Eurostat</c:AnnotationText>
+                        <c:AnnotationText xml:lang="en">Eurostat</c:AnnotationText>
+                        <c:AnnotationText xml:lang="de">Eurostat</c:AnnotationText>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationTitle>2024-06-16T23:00:00+0200</c:AnnotationTitle>
+                        <c:AnnotationType>UPDATE_DATA</c:AnnotationType>
+                    </c:Annotation>
+                    <c:Annotation>
+                        <c:AnnotationTitle>2024-01-03T23:00:00+0100</c:AnnotationTitle>
+                        <c:AnnotationType>UPDATE_STRUCTURE</c:AnnotationType>
+                    </c:Annotation>
+                </c:Annotations>
+                <c:Name xml:lang="de">Haushalte - Verfügbarkeit von Internet-Geräten</c:Name>
+                <c:Name xml:lang="en">Households - "devices" to access the internet &amp; other</c:Name>
+                <c:Name xml:lang="fr">Ménages - dispositifs pour accéder à l'internet</c:Name>
+                <s:Structure>
+                    <Ref id="ISOC_CI_ID_H" version="36.1" agencyID="ESTAT" package="datastructure"
+                         class="DataStructure"/>
+                </s:Structure>
+            </s:Dataflow>
+        </s:Dataflows>
+    </m:Structures>
+</m:Structure>

--- a/tests/io/xml/sdmx21/writer/samples/estat_sample.xml
+++ b/tests/io/xml/sdmx21/writer/samples/estat_sample.xml
@@ -88,6 +88,9 @@
                 <c:Name xml:lang="de">Haushalte - Verfügbarkeit von Internet-Geräten</c:Name>
                 <c:Name xml:lang="en">Households - "devices" to access the internet &amp; other</c:Name>
                 <c:Name xml:lang="fr">Ménages - dispositifs pour accéder à l'internet</c:Name>
+                <c:Description xml:lang="en">
+                    Test description with some special characters: &lt; &gt; &amp;
+                </c:Description>
                 <s:Structure>
                     <Ref id="ISOC_CI_ID_H" version="36.1" agencyID="ESTAT" package="datastructure"
                          class="DataStructure"/>

--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -282,3 +282,23 @@ def test_invalid_dimension_key(content):
             content,
             dimension_at_observation=dim_mapping,
         )
+
+
+def test_data_writing_escape(content):
+    content = list(content.values())
+    content[0].data["ATT1"] = ["<A", ">B", "&C"]
+    result_spe = write_str_spec(content)
+    assert "&lt;A" in result_spe
+    assert "&gt;B" in result_spe
+    assert "&amp;C" in result_spe
+    result_gen = write_gen(content)
+    assert "&lt;A" in result_spe
+    assert "&gt;B" in result_spe
+    assert "&amp;C" in result_spe
+
+    # Read the result to check for formal errors
+    data_spe = read_sdmx(result_spe, validate=True).data[0]
+    data_gen = read_sdmx(result_gen, validate=True).data[0]
+
+    assert data_spe.data["ATT1"].tolist() == ["<A", ">B", "&C"]
+    assert data_gen.data["ATT1"].tolist() == ["<A", ">B", "&C"]

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -65,6 +65,13 @@ def bis_sample():
 
 
 @pytest.fixture
+def estat_sample():
+    base_path = Path(__file__).parent / "samples" / "estat_sample.xml"
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
 def groups_sample():
     base_path = Path(__file__).parent / "samples" / "del_groups.xml"
     with open(base_path, "r") as f:
@@ -335,7 +342,7 @@ def test_concept(concept_sample, complete_header, concept):
 
 def test_file_writing(concept_sample, complete_header, concept):
     content = [concept]
-    output_path = Path(__file__).parent / "samples" / "test_output.xml"
+    output_path = str(Path(__file__).parent / "samples" / "test_output.xml")
     write(
         content,
         output_path=output_path,
@@ -461,3 +468,14 @@ def test_group_deletion(groups_sample, header):
     )
     assert "Groups" not in write_result
     assert any("BIS:BIS_DER(1.0)" in e.short_urn for e in read_result)
+
+
+def test_check_escape(estat_sample):
+    structures = read(estat_sample, validate=True)
+    result = write(structures, prettyprint=True)
+    assert result.count("&lt;") == 9
+    assert result.count("&gt;") == 9
+    assert result.count("&amp;") == 3
+
+    structures_after_loop = read(result, validate=True)
+    assert structures == structures_after_loop

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -473,9 +473,9 @@ def test_group_deletion(groups_sample, header):
 def test_check_escape(estat_sample):
     structures = read(estat_sample, validate=True)
     result = write(structures, prettyprint=True)
-    assert result.count("&lt;") == 9
-    assert result.count("&gt;") == 9
-    assert result.count("&amp;") == 3
+    assert result.count("&lt;") == 10
+    assert result.count("&gt;") == 10
+    assert result.count("&amp;") == 4
 
     structures_after_loop = read(result, validate=True)
     assert structures == structures_after_loop


### PR DESCRIPTION
Closes #215 

Added a escape function on data writing and structures writing to ensure text is escaped when necessary (&,  > and < is converted to &amp; &gt; &lt;)

Added a sample file from ESTAT as this agency normally has these kind of characters in annotations, edited to include them in Names and Descriptions.