### PR TITLE
Implemented dataset action and dataset id on header. Added action attribute to dataset on SDMX-ML data writers

### DIFF
--- a/src/pysdmx/io/xml/sdmx21/reader/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/generic.py
@@ -25,6 +25,7 @@ from pysdmx.io.xml.sdmx21.reader.__data_aux import (
 )
 from pysdmx.io.xml.sdmx21.reader.__parse_xml import parse_xml
 from pysdmx.io.xml.utils import add_list
+from pysdmx.model.dataset import ActionType
 
 
 def __get_element_to_list(data: Dict[str, Any], mode: Any) -> Dict[str, Any]:
@@ -121,10 +122,13 @@ def __parse_generic_data(
         # Generic All Dimensions
         df = __reading_generic_all(dataset)
 
+    action = dataset.get("action", "Information")
+    action = ActionType(action)
+
     urn = f"{structure_info['structure_type']}={structure_info['unique_id']}"
 
     return PandasDataset(
-        structure=urn, attributes=attached_attributes, data=df
+        structure=urn, attributes=attached_attributes, data=df, action=action
     )
 
 

--- a/src/pysdmx/io/xml/sdmx21/reader/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/structure_specific.py
@@ -22,6 +22,7 @@ from pysdmx.io.xml.sdmx21.reader.__data_aux import (
 )
 from pysdmx.io.xml.sdmx21.reader.__parse_xml import parse_xml
 from pysdmx.io.xml.utils import add_list
+from pysdmx.model.dataset import ActionType
 
 
 def __reading_str_series(dataset: Dict[str, Any]) -> pd.DataFrame:
@@ -90,9 +91,11 @@ def __parse_structure_specific_data(
         df = pd.DataFrame(dataset[OBS]).replace(np.nan, "")
 
     urn = f"{structure_info['structure_type']}={structure_info['unique_id']}"
+    action = dataset.get("action", "Information")
+    action = ActionType(action)
 
     return PandasDataset(
-        structure=urn, attributes=attached_attributes, data=df
+        structure=urn, attributes=attached_attributes, data=df, action=action
     )
 
 

--- a/src/pysdmx/io/xml/sdmx21/writer/__write_aux.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/__write_aux.py
@@ -239,7 +239,9 @@ def __write_header(
     if header.structure is not None:
         for short_urn, dim_at_obs in header.structure.items():
             references_str += __reference(short_urn, dim_at_obs)
-    if not data_message and (header.dataset_id or header.dataset_action):
+    if not data_message and (
+        header.dataset_id or header.dataset_action or header.structure
+    ):
         raise Invalid(
             "Header must not contain DataSetID or DataSetAction "
             "when writing a Structures Message."

--- a/src/pysdmx/io/xml/sdmx21/writer/__write_aux.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/__write_aux.py
@@ -143,7 +143,10 @@ def add_indent(indent: str) -> str:
 
 
 def __write_header(
-    header: Header, prettyprint: bool, add_namespace_structure: bool = False
+    header: Header,
+    prettyprint: bool,
+    add_namespace_structure: bool = False,
+    data_message: bool = True,
 ) -> str:
     """Writes the Header part of the message.
 
@@ -151,6 +154,7 @@ def __write_header(
         header: The Header to be written
         prettyprint: Prettyprint or not
         add_namespace_structure: Add the namespace for the structure
+        data_message: If the message is a data message
 
     Returns:
         The XML string
@@ -236,6 +240,11 @@ def __write_header(
     if header.structure is not None:
         for short_urn, dim_at_obs in header.structure.items():
             references_str += __reference(short_urn, dim_at_obs)
+    if not data_message and (header.dataset_id or header.dataset_action):
+        raise Invalid(
+            "Header must not contain DataSetID or DataSetAction "
+            "when writing a Structures Message."
+        )
     return (
         f"{nl}{child1}<{ABBR_MSG}:Header>"
         f"{__value('ID', header.id)}"

--- a/src/pysdmx/io/xml/sdmx21/writer/__write_aux.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/__write_aux.py
@@ -230,6 +230,9 @@ def __write_header(
     prepared = header.prepared.strftime("%Y-%m-%dT%H:%M:%S")
     test = str(header.test).lower()
     references_str = ""
+    action_value = (
+        header.dataset_action.value if header.dataset_action else None
+    )
     if header.structure is not None:
         for short_urn, dim_at_obs in header.structure.items():
             references_str += __reference(short_urn, dim_at_obs)
@@ -242,6 +245,8 @@ def __write_header(
         f"{__item('Receiver', header.receiver)}"
         f"{__value('Source', header.source)}"
         f"{references_str}"
+        f"{__value('DataSetAction', action_value)}"
+        f"{__value('DataSetID', header.dataset_id)}"
         f"{nl}{child1}</{ABBR_MSG}:Header>"
     ).replace("'", '"')
 

--- a/src/pysdmx/io/xml/sdmx21/writer/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/generic.py
@@ -169,7 +169,7 @@ def __write_data_single_dataset(
     outfile += (
         f"{nl}{child1}<{ABBR_MSG}:DataSet "
         f"structureRef={id_structure!r} "
-        f'action="Replace">{nl}'
+        f"action={dataset.action.value!r}>{nl}"
     )
     data = ""
     # Write attached attributes

--- a/src/pysdmx/io/xml/sdmx21/writer/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/generic.py
@@ -403,7 +403,7 @@ def write(
     # Generating the initial tag with namespaces
     outfile = create_namespaces(type_, prettyprint=prettyprint)
     # Generating the header
-    outfile += __write_header(header, prettyprint)
+    outfile += __write_header(header, prettyprint, data_message=True)
     # Writing the content
     outfile += __write_data_generic(content, dim_mapping, prettyprint)
 

--- a/src/pysdmx/io/xml/sdmx21/writer/structure.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/structure.py
@@ -679,7 +679,7 @@ def write(
     # Generating the initial tag with namespaces
     outfile = create_namespaces(type_, prettyprint=prettyprint)
     # Generating the header
-    outfile += __write_header(header, prettyprint)
+    outfile += __write_header(header, prettyprint, data_message=False)
     # Writing the content
     outfile += __write_structures(content, prettyprint)
 

--- a/src/pysdmx/io/xml/sdmx21/writer/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/structure_specific.py
@@ -287,7 +287,9 @@ def write(
     # Generating the initial tag with namespaces
     outfile = create_namespaces(type_, ss_namespaces, prettyprint)
     # Generating the header
-    outfile += __write_header(header, prettyprint, add_namespace_structure)
+    outfile += __write_header(
+        header, prettyprint, add_namespace_structure, data_message=True
+    )
     # Writing the content
     outfile += __write_data_structure_specific(
         datasets=content,

--- a/src/pysdmx/io/xml/sdmx21/writer/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/structure_specific.py
@@ -111,6 +111,7 @@ def __write_data_single_dataset(
     outfile = ""
     structure_urn = get_structure(dataset)
     id_structure = parse_short_urn(structure_urn).id
+    sdmx_type = parse_short_urn(structure_urn).id
 
     nl = "\n" if prettyprint else ""
     child1 = "\t" if prettyprint else ""
@@ -124,8 +125,8 @@ def __write_data_single_dataset(
         f"{nl}{child1}<{ABBR_MSG}:DataSet {attached_attributes_str}"
         f"ss:structureRef={id_structure!r} "
         f'xsi:type="ns{count}:DataSetType" '
-        f'ss:dataScope="DataStructure" '
-        f'action="Replace">{nl}'
+        f'ss:dataScope="{sdmx_type}" '
+        f'action="{dataset.action.value}">{nl}'
     )
 
     if dim == ALL_DIM:
@@ -289,7 +290,9 @@ def write(
     outfile += __write_header(header, prettyprint, add_namespace_structure)
     # Writing the content
     outfile += __write_data_structure_specific(
-        content, dim_mapping, prettyprint
+        datasets=content,
+        dim_mapping=dim_mapping,
+        prettyprint=prettyprint,
     )
 
     outfile += get_end_message(type_, prettyprint)

--- a/src/pysdmx/model/dataset.py
+++ b/src/pysdmx/model/dataset.py
@@ -15,10 +15,10 @@ class ActionType(Enum):
     Enumeration that withholds the Action type for writing purposes.
     """
 
-    Append = "append"
-    Replace = "replace"
-    Delete = "delete"
-    Information = "information"
+    Append = "Append"
+    Replace = "Replace"
+    Delete = "Delete"
+    Information = "Information"
 
 
 class SeriesInfo(Struct, frozen=True):

--- a/src/pysdmx/model/message.py
+++ b/src/pysdmx/model/message.py
@@ -39,6 +39,7 @@ class Header(Struct, kw_only=True):
     source: Optional[str] = None
     dataset_action: Optional[ActionType] = None
     structure: Optional[Dict[str, str]] = None
+    dataset_id: Optional[str] = None
 
 
 class Message(Struct, frozen=True):

--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -292,11 +292,18 @@ def test_dataset_action_and_header_action_dataset_id(content, header):
     header.dataset_action = ActionType.Append
     header.dataset_id = "TEST_ID"
 
-    result = write_str_spec(content, header=header)
+    result_spe = write_str_spec(content, header=header)
+    result_gen = write_gen(content, header=header)
 
-    assert "DataSetAction>Append</" in result
-    assert "DataSetID>TEST_ID</" in result
+    assert "DataSetAction>Append</" in result_spe
+    assert "DataSetAction>Append</" in result_gen
+    assert "DataSetID>TEST_ID</" in result_spe
+    assert "DataSetID>TEST_ID</" in result_gen
 
     # Read the result to check for formal errors
-    result_msg = read_sdmx(result, validate=True)
-    assert result_msg.data[0].action == ActionType.Append
+    data_spe = read_sdmx(result_spe, validate=True)
+    data_gen = read_sdmx(result_gen, validate=True)
+    assert data_spe.data[0].action == ActionType.Append
+    # We cannot define action for a specific dataset in a generic message
+    # as the attribute is not defined in the XSD
+    assert data_gen.data[0].action == ActionType.Information

--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -369,7 +369,7 @@ def test_optional_data_attributes(content):
     assert data_spe_all.shape == (3, 4)
 
 
-def test_invalid_structures_header(content, header):
+def test_dataset_action_and_header_action_dataset_id(content, header):
     content = list(content.values())
     content[0].action = ActionType.Append
 

--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -373,14 +373,14 @@ def test_dataset_action_and_header_action_dataset_id(content, header):
     content = list(content.values())
     content[0].action = ActionType.Append
 
-    header.dataset_action = ActionType.Append
+    header.dataset_action = ActionType.Replace
     header.dataset_id = "TEST_ID"
 
     result_spe = write_str_spec(content, header=header)
     result_gen = write_gen(content, header=header)
 
-    assert "DataSetAction>Append</" in result_spe
-    assert "DataSetAction>Append</" in result_gen
+    assert "DataSetAction>Replace</" in result_spe
+    assert "DataSetAction>Replace</" in result_gen
     assert "DataSetID>TEST_ID</" in result_spe
     assert "DataSetID>TEST_ID</" in result_gen
 
@@ -388,6 +388,4 @@ def test_dataset_action_and_header_action_dataset_id(content, header):
     data_spe = read_sdmx(result_spe, validate=True)
     data_gen = read_sdmx(result_gen, validate=True)
     assert data_spe.data[0].action == ActionType.Append
-    # We cannot define action for a specific dataset in a generic message
-    # as the attribute is not defined in the XSD
-    assert data_gen.data[0].action == ActionType.Information
+    assert data_gen.data[0].action == ActionType.Append

--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -24,6 +24,7 @@ from pysdmx.model import (
     Role,
     Schema,
 )
+from pysdmx.model.dataset import ActionType
 from pysdmx.model.message import Header
 
 
@@ -282,3 +283,20 @@ def test_invalid_dimension_key(content):
             content,
             dimension_at_observation=dim_mapping,
         )
+
+
+def test_dataset_action_and_header_action_dataset_id(content, header):
+    content = list(content.values())
+    content[0].action = ActionType.Append
+
+    header.dataset_action = ActionType.Append
+    header.dataset_id = "TEST_ID"
+
+    result = write_str_spec(content, header=header)
+
+    assert "DataSetAction>Append</" in result
+    assert "DataSetID>TEST_ID</" in result
+
+    # Read the result to check for formal errors
+    result_msg = read_sdmx(result, validate=True)
+    assert result_msg.data[0].action == ActionType.Append

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -486,9 +486,13 @@ def test_check_escape(estat_sample):
 def test_invalid_structure_header(header):
     header_da = copy.deepcopy(header)
     header_did = copy.deepcopy(header)
+    header_structures = copy.deepcopy(header)
     header_da.dataset_action = ActionType.Append
     with pytest.raises(Invalid):
         write([], header=header_da)
     header_did.dataset_id = "ID"
     with pytest.raises(Invalid):
         write([], header=header_did)
+    header_structures.structure = {"BIS_DER": "DataStructure=BIS:BIS_DER(1.0)"}
+    with pytest.raises(Invalid):
+        write([], header=header_structures)

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -1,10 +1,11 @@
+import copy
 import os
 from datetime import datetime
 from pathlib import Path
 
 import pytest
 
-from pysdmx.errors import NotImplemented
+from pysdmx.errors import Invalid, NotImplemented
 from pysdmx.io.format import Format
 from pysdmx.io.input_processor import process_string_to_read
 from pysdmx.io.xml.sdmx21.__tokens import CON
@@ -20,6 +21,7 @@ from pysdmx.model.dataflow import (
     DataStructureDefinition,
     Role,
 )
+from pysdmx.model.dataset import ActionType
 from pysdmx.model.message import Header
 from pysdmx.util import ItemReference
 
@@ -461,3 +463,14 @@ def test_group_deletion(groups_sample, header):
     )
     assert "Groups" not in write_result
     assert any("BIS:BIS_DER(1.0)" in e.short_urn for e in read_result)
+
+
+def test_invalid_header_for_data(header):
+    header_da = copy.deepcopy(header)
+    header_did = copy.deepcopy(header)
+    header_da.dataset_action = ActionType.Append
+    with pytest.raises(Invalid):
+        write([], header=header_da)
+    header_did.dataset_id = "ID"
+    with pytest.raises(Invalid):
+        write([], header=header_did)

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -483,7 +483,7 @@ def test_check_escape(estat_sample):
     assert structures == structures_after_loop
 
 
-def test_invalid_header_for_data(header):
+def test_invalid_structure_header(header):
     header_da = copy.deepcopy(header)
     header_did = copy.deepcopy(header)
     header_da.dataset_action = ActionType.Append


### PR DESCRIPTION
Close #211 

- Added dataset action and dataset id to SDMX-ML data writers
- Added better handling of dataset qualifiers on SDMX-ML structure specific writer
- Prevent the use of dataset id and dataset action in SDMX-ML Structures writer