### PR TITLE
Removed dataset attributes parsing on SDMX-CSV readers.

### DIFF
--- a/src/pysdmx/io/csv/sdmx10/reader/__init__.py
+++ b/src/pysdmx/io/csv/sdmx10/reader/__init__.py
@@ -16,20 +16,10 @@ def __generate_dataset_from_sdmx_csv(data: pd.DataFrame) -> PandasDataset:
     df_csv = data.drop(["DATAFLOW"], axis=1)
     urn = f"Dataflow={structure_id}"
 
-    # Extract dataset attributes from sdmx-csv (all values are the same)
-    attributes = {
-        col: df_csv[col].iloc[0]
-        for col in df_csv.columns
-        if df_csv[col].nunique() == 1
-    }
-    for col in attributes:
-        df_csv = df_csv.drop(col, axis=1)
-
     # Return a Dataset object with the extracted information
     return PandasDataset(
         structure=urn,
         data=df_csv,
-        attributes=attributes,
     )
 
 

--- a/src/pysdmx/io/csv/sdmx20/reader/__init__.py
+++ b/src/pysdmx/io/csv/sdmx20/reader/__init__.py
@@ -60,20 +60,11 @@ def __generate_dataset_from_sdmx_csv(data: pd.DataFrame) -> PandasDataset:
             "Invalid SDMX-CSV 2.0 file. "
             "Check the docs for the proper values on STRUCTURE column.",
         )
-    # Extract dataset attributes from sdmx-csv (all values are the same)
-    attributes = {
-        col: df_csv[col].iloc[0]
-        for col in df_csv.columns
-        if df_csv[col].nunique() == 1
-    }
-    for col in attributes:
-        df_csv = df_csv.drop(col, axis=1)
 
     # Return a Dataset object with the extracted information
     return PandasDataset(
         structure=urn,
         data=df_csv,
-        attributes=attributes,
         action=action,
     )
 

--- a/tests/io/csv/sdmx10/reader/test_reader_v1.py
+++ b/tests/io/csv/sdmx10/reader/test_reader_v1.py
@@ -41,6 +41,7 @@ def test_reading_sdmx_csv_v1(data_path):
     df = datasets[0].data
     assert len(df) == 1000
     assert "DATAFLOW" not in df.columns
+    assert len(datasets[0].attributes) == 0
 
 
 def test_reading_sdmx_csv_v1_string(data_path):
@@ -51,6 +52,7 @@ def test_reading_sdmx_csv_v1_string(data_path):
     df = datasets[0].data
     assert len(df) == 1000
     assert "DATAFLOW" not in df.columns
+    assert len(datasets[0].attributes) == 0
 
 
 def test_reading_data_v1_exception(data_path_exception):

--- a/tests/io/csv/sdmx20/reader/test_reader_v2.py
+++ b/tests/io/csv/sdmx20/reader/test_reader_v2.py
@@ -75,6 +75,7 @@ def test_reading_data_v2(data_path):
     assert "STRUCTURE" not in df.columns
     assert "STRUCTURE_ID" not in df.columns
     assert "ACTION" not in df.columns
+    assert len(datasets[0].attributes) == 0
 
 
 def test_reading_sdmx_csv_v2(data_path):
@@ -85,6 +86,7 @@ def test_reading_sdmx_csv_v2(data_path):
     assert "STRUCTURE" not in df.columns
     assert "STRUCTURE_ID" not in df.columns
     assert "ACTION" not in df.columns
+    assert len(datasets[0].attributes) == 0
 
 
 def test_reading_sdmx_csv_v2_string(data_path):
@@ -97,6 +99,7 @@ def test_reading_sdmx_csv_v2_string(data_path):
     assert "STRUCTURE" not in df.columns
     assert "STRUCTURE_ID" not in df.columns
     assert "ACTION" not in df.columns
+    assert len(datasets[0].attributes) == 0
 
 
 def test_reading_v2_exception(data_path_exception):


### PR DESCRIPTION
Close #214

# Summary of changes

- Removed dataset attribtues parsing on SDMX-CSV readers (version 1.0 and 2.0)
- Changed tests to ensure we do not read any dataset attributes in these formats