### PR TITLE
Handle multiple agency and data provider schemes

### DIFF
--- a/src/pysdmx/api/fmr/__init__.py
+++ b/src/pysdmx/api/fmr/__init__.py
@@ -379,10 +379,7 @@ class RegistryClient(__BaseRegistryClient):
         query = super()._providers_q(agency, with_flows)
         out = self.__fetch(query)
         schemes = super()._out(out, self.deser.providers)
-        if schemes:
-            return schemes[0].items
-        else:
-            return ()
+        return schemes[0].items
 
     def get_categories(
         self,
@@ -833,10 +830,7 @@ class AsyncRegistryClient(__BaseRegistryClient):
         query = super()._providers_q(agency, with_flows)
         out = await self.__fetch(query)
         schemes = super()._out(out, self.deser.providers)
-        if schemes:
-            return schemes[0].items
-        else:
-            return ()
+        return schemes[0].items
 
     async def get_categories(
         self,

--- a/src/pysdmx/api/fmr/__init__.py
+++ b/src/pysdmx/api/fmr/__init__.py
@@ -358,7 +358,8 @@ class RegistryClient(__BaseRegistryClient):
         """
         query = super()._agencies_q(agency)
         out = self.__fetch(query)
-        return super()._out(out, self.deser.agencies)
+        schemes = super()._out(out, self.deser.agencies)
+        return schemes[0].items
 
     def get_providers(
         self,
@@ -811,7 +812,8 @@ class AsyncRegistryClient(__BaseRegistryClient):
         """
         query = super()._agencies_q(agency)
         out = await self.__fetch(query)
-        return super()._out(out, self.deser.agencies)
+        schemes = super()._out(out, self.deser.agencies)
+        return schemes[0].items
 
     async def get_providers(
         self, agency: str, with_flows: bool = False

--- a/src/pysdmx/api/fmr/__init__.py
+++ b/src/pysdmx/api/fmr/__init__.py
@@ -378,7 +378,11 @@ class RegistryClient(__BaseRegistryClient):
         """
         query = super()._providers_q(agency, with_flows)
         out = self.__fetch(query)
-        return super()._out(out, self.deser.providers)
+        schemes = super()._out(out, self.deser.providers)
+        if schemes:
+            return schemes[0].items
+        else:
+            return ()
 
     def get_categories(
         self,
@@ -828,7 +832,11 @@ class AsyncRegistryClient(__BaseRegistryClient):
         """
         query = super()._providers_q(agency, with_flows)
         out = await self.__fetch(query)
-        return super()._out(out, self.deser.providers)
+        schemes = super()._out(out, self.deser.providers)
+        if schemes:
+            return schemes[0].items
+        else:
+            return ()
 
     async def get_categories(
         self,

--- a/src/pysdmx/io/json/fusion/messages/org.py
+++ b/src/pysdmx/io/json/fusion/messages/org.py
@@ -14,6 +14,9 @@ from pysdmx.model import (
     DataProvider,
 )
 from pysdmx.model import (
+    AgencyScheme as AS,
+)
+from pysdmx.model import (
     DataProviderScheme as DPS,
 )
 from pysdmx.util import parse_item_urn, parse_urn
@@ -97,11 +100,19 @@ class FusionAgencyScheme(Struct, frozen=True):
     """Fusion-JSON payload for an agency scheme."""
 
     agencyId: str
+    descriptions: Sequence[FusionString] = ()
     items: Sequence[FusionAgency] = ()
 
-    def to_model(self) -> Sequence[Agency]:
+    def to_model(self) -> AS:
         """Converts a FusionAgencyScheme to a list of Organisations."""
-        return [o.to_model(self.agencyId) for o in self.items]
+        agencies = [o.to_model(self.agencyId) for o in self.items]
+        return AS(
+            description=(
+                self.descriptions[0].value if self.descriptions else None
+            ),
+            agency=self.agencyId,
+            items=agencies,
+        )
 
 
 class FusionAgencyMessage(Struct, frozen=True):
@@ -109,9 +120,9 @@ class FusionAgencyMessage(Struct, frozen=True):
 
     AgencyScheme: Sequence[FusionAgencyScheme]
 
-    def to_model(self) -> Sequence[Agency]:
-        """Returns the requested list of agencies."""
-        return self.AgencyScheme[0].to_model()
+    def to_model(self) -> Sequence[AS]:
+        """Returns the requested agency schemes."""
+        return [a.to_model() for a in self.AgencyScheme]
 
 
 class FusionProviderScheme(Struct, frozen=True):

--- a/src/pysdmx/io/json/fusion/messages/org.py
+++ b/src/pysdmx/io/json/fusion/messages/org.py
@@ -12,6 +12,8 @@ from pysdmx.model import (
     Contact,
     DataflowRef,
     DataProvider,
+)
+from pysdmx.model import (
     DataProviderScheme as DPS,
 )
 from pysdmx.util import parse_item_urn, parse_urn

--- a/src/pysdmx/io/json/sdmxjson2/messages/org.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/org.py
@@ -31,7 +31,7 @@ class JsonDataProviderScheme(Struct, frozen=True):
 
     def to_model(
         self, pas: Sequence[JsonProvisionAgreement]
-    ) -> Sequence[DataProvider]:
+    ) -> DataProviderScheme:
         """Converts a JsonDataProviderScheme to a list of Organisations."""
         if pas:
             paprs: Dict[str, Set[DataflowRef]] = defaultdict(set)

--- a/src/pysdmx/model/organisation.py
+++ b/src/pysdmx/model/organisation.py
@@ -19,6 +19,31 @@ class AgencyScheme(ItemScheme, frozen=True, omit_defaults=True):
     version: str = "1.0"
     items: Sequence[Agency] = ()
 
+    @property
+    def agencies(self) -> Sequence[Agency]:
+        """Extract the items in the scheme."""
+        return self.items
+
+    def __iter__(self) -> Iterator[Agency]:
+        """Return an iterator over the list of agencies."""
+        yield from self.items
+
+    def __len__(self) -> int:
+        """Return the number of agencies in the scheme."""
+        return len(self.items)
+
+    def __getitem__(self, id_: str) -> Optional[Agency]:
+        """Return the agency identified by the supplied ID."""
+        out = list(filter(lambda p: p.id == id_, self.items))
+        if len(out) == 0:
+            return None
+        else:
+            return out[0]
+
+    def __contains__(self, id_: str) -> bool:
+        """Whether an agency with the supplied ID is present in the scheme."""
+        return bool(self.__getitem__(id_))
+
 
 class DataProviderScheme(ItemScheme, frozen=True, omit_defaults=True):
     """An immutable collection of data providers."""

--- a/src/pysdmx/model/organisation.py
+++ b/src/pysdmx/model/organisation.py
@@ -95,3 +95,28 @@ class DataConsumerScheme(ItemScheme, frozen=True, omit_defaults=True):
     name: str = "DATA_CONSUMERS"
     version: str = "1.0"
     items: Sequence[DataConsumer] = ()
+
+    @property
+    def consumers(self) -> Sequence[DataConsumer]:
+        """Extract the items in the scheme."""
+        return self.items
+
+    def __iter__(self) -> Iterator[DataConsumer]:
+        """Return an iterator over the list of data consumers."""
+        yield from self.items
+
+    def __len__(self) -> int:
+        """Return the number of data consumers in the scheme."""
+        return len(self.items)
+
+    def __getitem__(self, id_: str) -> Optional[DataConsumer]:
+        """Return the data consumer identified by the supplied ID."""
+        out = list(filter(lambda p: p.id == id_, self.items))
+        if len(out) == 0:
+            return None
+        else:
+            return out[0]
+
+    def __contains__(self, id_: str) -> bool:
+        """Whether a consumer with the supplied ID is present in the scheme."""
+        return bool(self.__getitem__(id_))

--- a/src/pysdmx/model/organisation.py
+++ b/src/pysdmx/model/organisation.py
@@ -1,6 +1,6 @@
 """Model for SDMX agency schemes and data provider schemes."""
 
-from typing import Sequence
+from typing import Iterator, Optional, Sequence
 
 from pysdmx.model.__base import (
     Agency,
@@ -27,6 +27,31 @@ class DataProviderScheme(ItemScheme, frozen=True, omit_defaults=True):
     name: str = "DATA_PROVIDERS"
     version: str = "1.0"
     items: Sequence[DataProvider] = ()
+
+    @property
+    def providers(self) -> Sequence[DataProvider]:
+        """Extract the items in the scheme."""
+        return self.items
+
+    def __iter__(self) -> Iterator[DataProvider]:
+        """Return an iterator over the list of data providers."""
+        yield from self.items
+
+    def __len__(self) -> int:
+        """Return the number of data providers in the scheme."""
+        return len(self.items)
+
+    def __getitem__(self, id_: str) -> Optional[DataProvider]:
+        """Return the data provider identified by the supplied ID."""
+        out = list(filter(lambda p: p.id == id_, self.items))
+        if len(out) == 0:
+            return None
+        else:
+            return out[0]
+
+    def __contains__(self, id_: str) -> bool:
+        """Whether a provider with the supplied ID is present in the scheme."""
+        return bool(self.__getitem__(id_))
 
 
 class MetadataProviderScheme(ItemScheme, frozen=True, omit_defaults=True):

--- a/src/pysdmx/model/organisation.py
+++ b/src/pysdmx/model/organisation.py
@@ -62,6 +62,31 @@ class MetadataProviderScheme(ItemScheme, frozen=True, omit_defaults=True):
     version: str = "1.0"
     items: Sequence[MetadataProvider] = ()
 
+    @property
+    def providers(self) -> Sequence[MetadataProvider]:
+        """Extract the items in the scheme."""
+        return self.items
+
+    def __iter__(self) -> Iterator[MetadataProvider]:
+        """Return an iterator over the list of metadata providers."""
+        yield from self.items
+
+    def __len__(self) -> int:
+        """Return the number of metadata providers in the scheme."""
+        return len(self.items)
+
+    def __getitem__(self, id_: str) -> Optional[MetadataProvider]:
+        """Return the metadata provider identified by the supplied ID."""
+        out = list(filter(lambda p: p.id == id_, self.items))
+        if len(out) == 0:
+            return None
+        else:
+            return out[0]
+
+    def __contains__(self, id_: str) -> bool:
+        """Whether a provider with the supplied ID is present in the scheme."""
+        return bool(self.__getitem__(id_))
+
 
 class DataConsumerScheme(ItemScheme, frozen=True, omit_defaults=True):
     """An immutable collection of data consumers."""

--- a/tests/api/fmr/provider_checks.py
+++ b/tests/api/fmr/provider_checks.py
@@ -111,7 +111,7 @@ def check_with_flows(mock, fmr, query, body):
 
 
 def check_empty(mock, fmr: RegistryClient, query, body):
-    """Can handle empty messages."""
+    """Can handle scheme with no providers."""
     mock.get(query).mock(
         return_value=httpx.Response(
             200,
@@ -119,6 +119,6 @@ def check_empty(mock, fmr: RegistryClient, query, body):
         )
     )
 
-    agencies = fmr.get_providers("BIS")
+    prvs = fmr.get_providers("BIS")
 
-    assert len(agencies) == 0
+    assert len(prvs) == 0

--- a/tests/api/fmr/provider_checks.py
+++ b/tests/api/fmr/provider_checks.py
@@ -3,7 +3,7 @@ import pytest
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
 from pysdmx.io.format import Format
-from pysdmx.model import Organisation
+from pysdmx.model import DataProvider, DataProviderScheme
 
 
 def check_orgs(
@@ -17,7 +17,7 @@ def check_orgs(
         )
     )
 
-    prvs = fmr.get_providers("BIS")
+    schemes = fmr.get_providers("BIS")
 
     assert len(mock.calls) == 1
     if is_fusion:
@@ -30,9 +30,12 @@ def check_orgs(
             == Format.STRUCTURE_SDMX_JSON_2_0_0.value
         )
 
-    assert len(prvs) == 2
-    for prv in prvs:
-        assert isinstance(prv, Organisation)
+    assert len(schemes) == 1
+    for s in schemes:
+        assert isinstance(s, DataProviderScheme)
+        assert len(s) == 2
+        for p in s:
+            assert isinstance(p, DataProvider)
 
 
 async def check_org_core_info(mock, fmr: AsyncRegistryClient, query, body):
@@ -44,15 +47,16 @@ async def check_org_core_info(mock, fmr: AsyncRegistryClient, query, body):
         )
     )
 
-    prvs = await fmr.get_providers("BIS")
+    schemes = await fmr.get_providers("BIS")
 
-    for prv in prvs:
-        if prv.id == "CH2":
-            assert prv.name == "Swiss National Bank"
-        elif prv.id == "TST":
-            assert prv.name == "Test data provider"
-        else:
-            pytest.fail(f"Unexepcted provider: {prv.id}")
+    for s in schemes:
+        for prv in s:
+            if prv.id == "CH2":
+                assert prv.name == "Swiss National Bank"
+            elif prv.id == "TST":
+                assert prv.name == "Test data provider"
+            else:
+                pytest.fail(f"Unexepcted provider: {prv.id}")
 
 
 def check_org_details(mock, fmr: RegistryClient, query, body):
@@ -64,28 +68,29 @@ def check_org_details(mock, fmr: RegistryClient, query, body):
         )
     )
 
-    prvs = fmr.get_providers("BIS")
+    schemes = fmr.get_providers("BIS")
 
-    for prv in prvs:
-        if prv.id == "CH2":
-            assert prv.description is None
-            assert not prv.contacts
-        elif prv.id == "TST":
-            assert prv.description == "Description for the test provider."
-            assert len(prv.contacts) == 1
-            c = prv.contacts[0]
-            assert c.id is None
-            assert c.name == "Support"
-            assert c.department == "Client Support"
-            assert c.role == "Head of Support"
-            assert len(c.emails) == 1
-            assert c.emails[0] == "support@test.com"
-            assert len(c.telephones) == 1
-            assert c.telephones[0] == "+42.(0)42.4242.4242"
-            assert not c.faxes
-            assert not c.uris
-        else:
-            pytest.fail(f"Unexepcted provider: {prv.id}")
+    for s in schemes:
+        for prv in s:
+            if prv.id == "CH2":
+                assert prv.description is None
+                assert not prv.contacts
+            elif prv.id == "TST":
+                assert prv.description == "Description for the test provider."
+                assert len(prv.contacts) == 1
+                c = prv.contacts[0]
+                assert c.id is None
+                assert c.name == "Support"
+                assert c.department == "Client Support"
+                assert c.role == "Head of Support"
+                assert len(c.emails) == 1
+                assert c.emails[0] == "support@test.com"
+                assert len(c.telephones) == 1
+                assert c.telephones[0] == "+42.(0)42.4242.4242"
+                assert not c.faxes
+                assert not c.uris
+            else:
+                pytest.fail(f"Unexepcted provider: {prv.id}")
 
 
 def check_with_flows(mock, fmr, query, body):
@@ -97,17 +102,18 @@ def check_with_flows(mock, fmr, query, body):
         )
     )
 
-    prvs = fmr.get_providers("BIS", True)
+    schemes = fmr.get_providers("BIS", True)
 
-    for prv in prvs:
-        if prv.id == "TEST":
-            assert len(prv.dataflows) == 2
-            for df in prv.dataflows:
-                assert df.id in ["DF1", "DF2"]
-        elif prv.id == "TEST2":
-            assert len(prv.dataflows) == 0
-        else:
-            pytest.fail(f"Unexepcted provider: {prv.id}")
+    for s in schemes:
+        for prv in s:
+            if prv.id == "TEST":
+                assert len(prv.dataflows) == 2
+                for df in prv.dataflows:
+                    assert df.id in ["DF1", "DF2"]
+            elif prv.id == "TEST2":
+                assert len(prv.dataflows) == 0
+            else:
+                pytest.fail(f"Unexepcted provider: {prv.id}")
 
 
 def check_empty(mock, fmr: RegistryClient, query, body):
@@ -119,6 +125,7 @@ def check_empty(mock, fmr: RegistryClient, query, body):
         )
     )
 
-    agencies = fmr.get_providers("BIS")
+    schemes = fmr.get_providers("BIS")
 
-    assert len(agencies) == 0
+    for s in schemes:
+        assert len(s) == 0

--- a/tests/api/fmr/provider_checks.py
+++ b/tests/api/fmr/provider_checks.py
@@ -3,7 +3,7 @@ import pytest
 
 from pysdmx.api.fmr import AsyncRegistryClient, RegistryClient
 from pysdmx.io.format import Format
-from pysdmx.model import DataProvider, DataProviderScheme
+from pysdmx.model import Organisation
 
 
 def check_orgs(
@@ -17,7 +17,7 @@ def check_orgs(
         )
     )
 
-    schemes = fmr.get_providers("BIS")
+    prvs = fmr.get_providers("BIS")
 
     assert len(mock.calls) == 1
     if is_fusion:
@@ -30,12 +30,9 @@ def check_orgs(
             == Format.STRUCTURE_SDMX_JSON_2_0_0.value
         )
 
-    assert len(schemes) == 1
-    for s in schemes:
-        assert isinstance(s, DataProviderScheme)
-        assert len(s) == 2
-        for p in s:
-            assert isinstance(p, DataProvider)
+    assert len(prvs) == 2
+    for prv in prvs:
+        assert isinstance(prv, Organisation)
 
 
 async def check_org_core_info(mock, fmr: AsyncRegistryClient, query, body):
@@ -47,16 +44,15 @@ async def check_org_core_info(mock, fmr: AsyncRegistryClient, query, body):
         )
     )
 
-    schemes = await fmr.get_providers("BIS")
+    prvs = await fmr.get_providers("BIS")
 
-    for s in schemes:
-        for prv in s:
-            if prv.id == "CH2":
-                assert prv.name == "Swiss National Bank"
-            elif prv.id == "TST":
-                assert prv.name == "Test data provider"
-            else:
-                pytest.fail(f"Unexepcted provider: {prv.id}")
+    for prv in prvs:
+        if prv.id == "CH2":
+            assert prv.name == "Swiss National Bank"
+        elif prv.id == "TST":
+            assert prv.name == "Test data provider"
+        else:
+            pytest.fail(f"Unexepcted provider: {prv.id}")
 
 
 def check_org_details(mock, fmr: RegistryClient, query, body):
@@ -68,29 +64,28 @@ def check_org_details(mock, fmr: RegistryClient, query, body):
         )
     )
 
-    schemes = fmr.get_providers("BIS")
+    prvs = fmr.get_providers("BIS")
 
-    for s in schemes:
-        for prv in s:
-            if prv.id == "CH2":
-                assert prv.description is None
-                assert not prv.contacts
-            elif prv.id == "TST":
-                assert prv.description == "Description for the test provider."
-                assert len(prv.contacts) == 1
-                c = prv.contacts[0]
-                assert c.id is None
-                assert c.name == "Support"
-                assert c.department == "Client Support"
-                assert c.role == "Head of Support"
-                assert len(c.emails) == 1
-                assert c.emails[0] == "support@test.com"
-                assert len(c.telephones) == 1
-                assert c.telephones[0] == "+42.(0)42.4242.4242"
-                assert not c.faxes
-                assert not c.uris
-            else:
-                pytest.fail(f"Unexepcted provider: {prv.id}")
+    for prv in prvs:
+        if prv.id == "CH2":
+            assert prv.description is None
+            assert not prv.contacts
+        elif prv.id == "TST":
+            assert prv.description == "Description for the test provider."
+            assert len(prv.contacts) == 1
+            c = prv.contacts[0]
+            assert c.id is None
+            assert c.name == "Support"
+            assert c.department == "Client Support"
+            assert c.role == "Head of Support"
+            assert len(c.emails) == 1
+            assert c.emails[0] == "support@test.com"
+            assert len(c.telephones) == 1
+            assert c.telephones[0] == "+42.(0)42.4242.4242"
+            assert not c.faxes
+            assert not c.uris
+        else:
+            pytest.fail(f"Unexepcted provider: {prv.id}")
 
 
 def check_with_flows(mock, fmr, query, body):
@@ -102,16 +97,17 @@ def check_with_flows(mock, fmr, query, body):
         )
     )
 
-    schemes = fmr.get_providers("BIS", True)
+    prvs = fmr.get_providers("BIS", True)
 
-    for s in schemes:
-        p1 = s["TEST"]
-        assert len(p1.dataflows) == 2
-        for df in p1.dataflows:
-            assert df.id in ["DF1", "DF2"]
-
-        p2 = s["TEST2"]
-        assert len(p2.dataflows) == 0
+    for prv in prvs:
+        if prv.id == "TEST":
+            assert len(prv.dataflows) == 2
+            for df in prv.dataflows:
+                assert df.id in ["DF1", "DF2"]
+        elif prv.id == "TEST2":
+            assert len(prv.dataflows) == 0
+        else:
+            pytest.fail(f"Unexepcted provider: {prv.id}")
 
 
 def check_empty(mock, fmr: RegistryClient, query, body):
@@ -123,7 +119,6 @@ def check_empty(mock, fmr: RegistryClient, query, body):
         )
     )
 
-    schemes = fmr.get_providers("BIS")
+    agencies = fmr.get_providers("BIS")
 
-    for s in schemes:
-        assert len(s) == 0
+    assert len(agencies) == 0

--- a/tests/api/fmr/provider_checks.py
+++ b/tests/api/fmr/provider_checks.py
@@ -105,15 +105,13 @@ def check_with_flows(mock, fmr, query, body):
     schemes = fmr.get_providers("BIS", True)
 
     for s in schemes:
-        for prv in s:
-            if prv.id == "TEST":
-                assert len(prv.dataflows) == 2
-                for df in prv.dataflows:
-                    assert df.id in ["DF1", "DF2"]
-            elif prv.id == "TEST2":
-                assert len(prv.dataflows) == 0
-            else:
-                pytest.fail(f"Unexepcted provider: {prv.id}")
+        p1 = s["TEST"]
+        assert len(p1.dataflows) == 2
+        for df in p1.dataflows:
+            assert df.id in ["DF1", "DF2"]
+
+        p2 = s["TEST2"]
+        assert len(p2.dataflows) == 0
 
 
 def check_empty(mock, fmr: RegistryClient, query, body):

--- a/tests/model/test_organisation_schemes.py
+++ b/tests/model/test_organisation_schemes.py
@@ -196,3 +196,22 @@ def test_dcs_get_consumer(data_consumers):
         assert p.id in data_consumers
 
     assert data_consumers["NOT_IN_THE_SCHEME"] is None
+
+
+def test_as_iterable(agencies):
+    assert isinstance(agencies, Iterable)
+    out = list(agencies)
+    assert len(out) == len(agencies.agencies)
+    assert out == agencies.agencies
+
+
+def test_as_sized(agencies):
+    assert isinstance(agencies, Sized)
+
+
+def test_as_get_agency(agencies):
+    for p in agencies.items:
+        assert agencies[p.id] == p
+        assert p.id in agencies
+
+    assert agencies["NOT_IN_THE_SCHEME"] is None

--- a/tests/model/test_organisation_schemes.py
+++ b/tests/model/test_organisation_schemes.py
@@ -177,3 +177,22 @@ def test_mps_get_provider(metadata_providers):
         assert p.id in metadata_providers
 
     assert metadata_providers["NOT_IN_THE_SCHEME"] is None
+
+
+def test_dcs_iterable(data_consumers):
+    assert isinstance(data_consumers, Iterable)
+    out = list(data_consumers)
+    assert len(out) == len(data_consumers.consumers)
+    assert out == data_consumers.consumers
+
+
+def test_dcs_sized(data_consumers):
+    assert isinstance(data_consumers, Sized)
+
+
+def test_dcs_get_consumer(data_consumers):
+    for p in data_consumers.items:
+        assert data_consumers[p.id] == p
+        assert p.id in data_consumers
+
+    assert data_consumers["NOT_IN_THE_SCHEME"] is None

--- a/tests/model/test_organisation_schemes.py
+++ b/tests/model/test_organisation_schemes.py
@@ -1,3 +1,5 @@
+from typing import Iterable, Sized
+
 import msgspec
 import pytest
 
@@ -137,3 +139,22 @@ def test_metadata_provider_scheme_serde(metadata_providers):
     deser = msgspec.msgpack.Decoder(MetadataProviderScheme).decode(ser)
 
     assert deser == metadata_providers
+
+
+def test_dps_iterable(data_providers):
+    assert isinstance(data_providers, Iterable)
+    out = [p for p in data_providers]
+    assert len(out) == len(data_providers.providers)
+    assert out == data_providers.providers
+
+
+def test_dps_sized(data_providers):
+    assert isinstance(data_providers, Sized)
+
+
+def test_dps_get_provider(data_providers):
+    for p in data_providers.items:
+        assert data_providers[p.id] == p
+        assert p.id in data_providers
+
+    assert data_providers["NOT_IN_THE_SCHEME"] is None

--- a/tests/model/test_organisation_schemes.py
+++ b/tests/model/test_organisation_schemes.py
@@ -158,3 +158,22 @@ def test_dps_get_provider(data_providers):
         assert p.id in data_providers
 
     assert data_providers["NOT_IN_THE_SCHEME"] is None
+
+
+def test_mps_iterable(metadata_providers):
+    assert isinstance(metadata_providers, Iterable)
+    out = list(metadata_providers)
+    assert len(out) == len(metadata_providers.providers)
+    assert out == metadata_providers.providers
+
+
+def test_mps_sized(metadata_providers):
+    assert isinstance(metadata_providers, Sized)
+
+
+def test_mps_get_provider(metadata_providers):
+    for p in metadata_providers.items:
+        assert metadata_providers[p.id] == p
+        assert p.id in metadata_providers
+
+    assert metadata_providers["NOT_IN_THE_SCHEME"] is None

--- a/tests/model/test_organisation_schemes.py
+++ b/tests/model/test_organisation_schemes.py
@@ -143,7 +143,7 @@ def test_metadata_provider_scheme_serde(metadata_providers):
 
 def test_dps_iterable(data_providers):
     assert isinstance(data_providers, Iterable)
-    out = [p for p in data_providers]
+    out = list(data_providers)
     assert len(out) == len(data_providers.providers)
     assert out == data_providers.providers
 

--- a/tests/model/test_organisation_schemes.py
+++ b/tests/model/test_organisation_schemes.py
@@ -109,7 +109,7 @@ def metadata_providers(contacts, dataflows, annotations):
     return MetadataProviderScheme(agency="TEST", items=[dp1, dp2])
 
 
-def test_agency_scheme_serde(agencies):
+def test_as_serde(agencies):
     ser = ENCODER.encode(agencies)
 
     deser = msgspec.msgpack.Decoder(AgencyScheme).decode(ser)
@@ -117,7 +117,7 @@ def test_agency_scheme_serde(agencies):
     assert deser == agencies
 
 
-def test_data_provider_scheme_serde(data_providers):
+def test_dps_serde(data_providers):
     ser = ENCODER.encode(data_providers)
 
     deser = msgspec.msgpack.Decoder(DataProviderScheme).decode(ser)
@@ -125,7 +125,7 @@ def test_data_provider_scheme_serde(data_providers):
     assert deser == data_providers
 
 
-def test_data_consumer_scheme_serde(data_consumers):
+def test_dcs_serde(data_consumers):
     ser = ENCODER.encode(data_consumers)
 
     deser = msgspec.msgpack.Decoder(DataConsumerScheme).decode(ser)
@@ -133,7 +133,7 @@ def test_data_consumer_scheme_serde(data_consumers):
     assert deser == data_consumers
 
 
-def test_metadata_provider_scheme_serde(metadata_providers):
+def test_mps_serde(metadata_providers):
     ser = ENCODER.encode(metadata_providers)
 
     deser = msgspec.msgpack.Decoder(MetadataProviderScheme).decode(ser)


### PR DESCRIPTION
This PR adds support for handling JSON responses with multiple agency or data provider schemes. 

The support has been added in a backward-compatible way, i.e. the `fmr` module is not affected.

In addition, utility methods have been added to the organisation schemes (e.g. `__len__` etc), thereby aligning them with the other item schemes.

Close #224 