### PR TITLE
Replaced ObsDimension with the Dimension At Observation on the SDMX-ML Generic Series reader

### DIFF
--- a/src/pysdmx/io/xml/sdmx21/reader/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/generic.py
@@ -119,8 +119,8 @@ def __parse_generic_data(
         # Generic Series
         df = __reading_generic_series(dataset)
         dim_at_obs = structure_info["dimensionAtObservation"]
-        # In case there are observations defined, we need to move the
-        # replace the OBS_DIM column with the dimension at observation
+        # In case there are observations defined, we need to replace the
+        # OBS_DIM column with the dimension at observation
         if OBS_DIM in df.columns:
             df[dim_at_obs] = df[OBS_DIM]
             del df[OBS_DIM]

--- a/src/pysdmx/io/xml/sdmx21/reader/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/generic.py
@@ -118,6 +118,12 @@ def __parse_generic_data(
     if SERIES in dataset:
         # Generic Series
         df = __reading_generic_series(dataset)
+        dim_at_obs = structure_info["dimensionAtObservation"]
+        # In case there are observations defined, we need to move the
+        # replace the OBS_DIM column with the dimension at observation
+        if OBS_DIM in df.columns:
+            df[dim_at_obs] = df[OBS_DIM]
+            del df[OBS_DIM]
     else:
         # Generic All Dimensions
         df = __reading_generic_all(dataset)

--- a/tests/io/xml/sdmx21/reader/test_reader.py
+++ b/tests/io/xml/sdmx21/reader/test_reader.py
@@ -197,11 +197,11 @@ def test_error_message_with_different_mode(agency_scheme_path):
 @pytest.mark.parametrize(
     "filename",
     [
-        "gen_all.xml",
+        # "gen_all.xml",
         "gen_ser.xml",
-        "str_all.xml",
-        "str_ser.xml",
-        "str_ser_group.xml",
+        # "str_all.xml",
+        # "str_ser.xml",
+        # "str_ser_group.xml",
     ],
 )
 def test_reading_validation(samples_folder, filename):
@@ -218,6 +218,7 @@ def test_reading_validation(samples_folder, filename):
     assert dataset.short_urn == "DataStructure=BIS:BIS_DER(1.0)"
     data = dataset.data
     assert data.shape == (1000, 20)
+    assert "TIME_PERIOD" in data.columns
 
 
 @pytest.mark.parametrize(

--- a/tests/io/xml/sdmx21/reader/test_reader.py
+++ b/tests/io/xml/sdmx21/reader/test_reader.py
@@ -8,6 +8,7 @@ from pysdmx.errors import Invalid, NotImplemented
 from pysdmx.io import read_sdmx
 from pysdmx.io.format import Format
 from pysdmx.io.input_processor import process_string_to_read
+from pysdmx.io.xml.sdmx21.__tokens import OBS_DIM
 from pysdmx.io.xml.sdmx21.reader.error import read as read_error
 from pysdmx.io.xml.sdmx21.reader.generic import read as read_generic
 from pysdmx.io.xml.sdmx21.reader.structure import read as read_structure
@@ -197,11 +198,11 @@ def test_error_message_with_different_mode(agency_scheme_path):
 @pytest.mark.parametrize(
     "filename",
     [
-        # "gen_all.xml",
+        "gen_all.xml",
         "gen_ser.xml",
-        # "str_all.xml",
-        # "str_ser.xml",
-        # "str_ser_group.xml",
+        "str_all.xml",
+        "str_ser.xml",
+        "str_ser_group.xml",
     ],
 )
 def test_reading_validation(samples_folder, filename):
@@ -219,6 +220,7 @@ def test_reading_validation(samples_folder, filename):
     data = dataset.data
     assert data.shape == (1000, 20)
     assert "TIME_PERIOD" in data.columns
+    assert OBS_DIM not in data.columns
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #225 

Fixed small bug on SDMX-ML 2.1 Generic Series writing and ensure we have the Dimension At Observation at the Dataframe columns.