### PR TITLE
Align pyproject.toml with PEP 621

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -19,7 +19,7 @@ description = "ANTLR 4.9.3 runtime for Python 3.7"
 optional = true
 python-versions = "*"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"vtl\""
+markers = "extra == \"vtl\" or extra == \"all\""
 files = [
     {file = "antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b"},
 ]
@@ -54,7 +54,7 @@ description = "Classes Without Boilerplate"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"vtl\""
+markers = "extra == \"vtl\" or extra == \"all\""
 files = [
     {file = "attrs-25.1.0-py3-none-any.whl", hash = "sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a"},
     {file = "attrs-25.1.0.tar.gz", hash = "sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e"},
@@ -345,7 +345,7 @@ description = "DuckDB in-process database"
 optional = true
 python-versions = ">=3.7.0"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"vtl\""
+markers = "extra == \"vtl\" or extra == \"all\""
 files = [
     {file = "duckdb-1.1.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:1c0226dc43e2ee4cc3a5a4672fddb2d76fd2cf2694443f395c02dd1bea0b7fce"},
     {file = "duckdb-1.1.3-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:7c71169fa804c0b65e49afe423ddc2dc83e198640e3b041028da8110f7cd16f7"},
@@ -565,7 +565,7 @@ description = "An implementation of JSON Schema validation for Python"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"vtl\""
+markers = "extra == \"vtl\" or extra == \"all\""
 files = [
     {file = "jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566"},
     {file = "jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4"},
@@ -588,7 +588,7 @@ description = "The JSON Schema meta-schemas and vocabularies, exposed as a Regis
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"vtl\""
+markers = "extra == \"vtl\" or extra == \"all\""
 files = [
     {file = "jsonschema_specifications-2024.10.1-py3-none-any.whl", hash = "sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf"},
     {file = "jsonschema_specifications-2024.10.1.tar.gz", hash = "sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272"},
@@ -971,7 +971,7 @@ description = "Python package for creating and manipulating graphs and networks"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"vtl\""
+markers = "extra == \"vtl\" or extra == \"all\""
 files = [
     {file = "networkx-2.8.8-py3-none-any.whl", hash = "sha256:e435dfa75b1d7195c7b8378c3859f0445cd88c6b0375c181ed66823a9ceb7524"},
     {file = "networkx-2.8.8.tar.gz", hash = "sha256:230d388117af870fce5647a3c52401fcf753e94720e6ea6b4197a5355648885e"},
@@ -1303,7 +1303,7 @@ description = "Extensions to the standard Python datetime module"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 groups = ["main"]
-markers = "extra == \"dc\" or extra == \"all\" or extra == \"data\" or extra == \"vtl\""
+markers = "extra == \"data\" or extra == \"all\" or extra == \"vtl\" or extra == \"dc\""
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -1332,7 +1332,7 @@ description = "JSON Referencing + Python"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"vtl\""
+markers = "extra == \"vtl\" or extra == \"all\""
 files = [
     {file = "referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0"},
     {file = "referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa"},
@@ -1387,7 +1387,7 @@ description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"vtl\""
+markers = "extra == \"vtl\" or extra == \"all\""
 files = [
     {file = "rpds_py-0.22.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:6c7b99ca52c2c1752b544e310101b98a659b720b21db00e65edca34483259967"},
     {file = "rpds_py-0.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:be2eb3f2495ba669d2a985f9b426c1797b7d48d6963899276d22f23e33d47e37"},
@@ -1563,7 +1563,7 @@ description = "Python 2 and 3 compatibility utilities"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 groups = ["main"]
-markers = "extra == \"dc\" or extra == \"all\" or extra == \"data\" or extra == \"vtl\""
+markers = "extra == \"data\" or extra == \"all\" or extra == \"vtl\" or extra == \"dc\""
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -1792,7 +1792,7 @@ description = "An easily customizable SQL parser and transpiler"
 optional = true
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"vtl\""
+markers = "extra == \"vtl\" or extra == \"all\""
 files = [
     {file = "sqlglot-22.5.0-py3-none-any.whl", hash = "sha256:ef11f7e56e93732aca3caab3c74a6c11489e383a43c2ac5b5f86cc85517ef9f3"},
     {file = "sqlglot-22.5.0.tar.gz", hash = "sha256:27c7850298b62741d78f99f17904014cc6fa9bebb2fd29fb2e9a0a195ec2a523"},
@@ -1809,7 +1809,6 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev", "docs"]
-markers = "python_version < \"3.11\""
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -1844,6 +1843,7 @@ files = [
     {file = "tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc"},
     {file = "tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff"},
 ]
+markers = {dev = "python_full_version <= \"3.11.0a6\"", docs = "python_version < \"3.11\""}
 
 [[package]]
 name = "trove-classifiers"
@@ -1944,7 +1944,7 @@ description = "Run and Validate VTL Scripts"
 optional = true
 python-versions = "<4,>=3.9"
 groups = ["main"]
-markers = "extra == \"all\" or extra == \"vtl\""
+markers = "extra == \"vtl\" or extra == \"all\""
 files = [
     {file = "vtlengine-1.1rc1-py3-none-any.whl", hash = "sha256:02b195bdf09469a0e0ab2632bbe9a047b4e52cd473b7e4d1157f942355ebe2fa"},
     {file = "vtlengine-1.1rc1.tar.gz", hash = "sha256:331263b8cbd6e93d518c35fdc6e702e0bac052985d0e8f0112ba18b186af85b3"},
@@ -2005,5 +2005,5 @@ xml = ["lxml", "sdmxschemas", "xmltodict"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.9"
-content-hash = "963b601ca993253b7d8c955e95221681b57af72b1885d0604f248381a3237c52"
+python-versions = ">=3.9,<4.0"
+content-hash = "3810d79c28fb1b501c1351dde533e2e806f448e309eccf69bd37c60da50ca33e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,17 @@
-[tool.poetry]
+[project]
 name = "pysdmx"
 version = "1.1.1"
 description = "Your opinionated Python SDMX library"
-authors = [
-    "Xavier Sosnovsky <xavier.sosnovsky@bis.org>",
-    "Stratos Nikoloutsos <stratos.nikoloutsos@bis.org>",
-    "Francisco Javier Hernandez del Caño <javier.hernandez@meaningfuldata.eu>",
-    "Mateo de Lorenzo Argelés <mateo.delorenzo@meaningfuldata.eu>"
-]
+license = { text = "Apache-2.0" }
 readme = "README.rst"
-documentation = "https://bis-med-it.github.io/pysdmx"
+requires-python = ">=3.9"
+authors = [
+    { name = "Xavier Sosnovsky", email = "<xavier.sosnovsky@bis.org>" },
+    { name = "Stratos Nikoloutsos", email = "<stratos.nikoloutsos@bis.org>" },
+    { name = "Francisco Javier Hernandez del Caño", email = "<javier.hernandez@meaningfuldata.eu>" },
+    { name = "Mateo de Lorenzo Argelés", email = "<mateo.delorenzo@meaningfuldata.eu>" }
+]
 keywords = ["sdmx", "data discovery", "data retrieval", "metadata", "fmr"]
-repository = "https://github.com/bis-med-it/pysdmx"
-license = "Apache-2.0"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -20,25 +19,30 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Typing :: Typed"
 ]
+dependencies = [
+    "httpx>=0.*",
+    "msgspec>=0.*",
+    "parsy>=2.1",
+]
+
+[project.urls]
+homepage = "https://sdmx.io/tools/pysdmx"
+repository = "https://github.com/bis-med-it/pysdmx"
+documentation = "https://bis-med-it.github.io/pysdmx"
+"Bug Tracker" = "https://bis-med-it.github.io/pysdmx/issues"
+
+[project.optional-dependencies]
+data = ["pandas>=2.2.2"]
+dc = ["python-dateutil>=2.9.0.post0"]
+vtl = ["vtlengine>=1.1rc1"]
+xml = ["lxml>=5.*", "xmltodict>=0.*", "sdmxschemas>=0.2.0"]
+all = ["lxml>=5.*", "xmltodict>=0.*", "sdmxschemas>=0.2.0", "pandas>=2.2.2", "python-dateutil>=2.9.0.post0", "vtlengine>=1.1rc1"]
+
+[tool.poetry]
+requires-poetry = ">=2.0"
 
 [tool.poetry.dependencies]
-python = "^3.9"
-httpx = "0.*"
-msgspec = "0.*"
-lxml = { version = "5.*", optional = true }
-xmltodict = { version = "0.*", optional = true }
-sdmxschemas = { version = "0.2.0", optional = true }
-python-dateutil = { version = "^2.9.0.post0", optional = true }
-parsy = "^2.1"
-pandas = { version = "^2.2.2", optional = true }
-vtlengine = { version = "^1.1rc1", optional = true }
-
-[tool.poetry.extras]
-dc = ["python-dateutil"]
-xml = ["lxml", "xmltodict", "sdmxschemas"]
-data = ["pandas"]
-all = ["lxml", "xmltodict", "sdmxschemas", "pandas", "python-dateutil", "vtlengine"]
-vtl = ["vtlengine"]
+python = ">=3.9,<4.0"
 
 [tool.poetry.group.dev.dependencies]
 darglint = "^1.8.1"
@@ -60,7 +64,7 @@ sphinx-rtd-theme = "^1.3.0"
 sphinx-autodoc-typehints = "^1.24.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]


### PR DESCRIPTION
This PR aligns the pyproject.toml file to PEP 621. 

From the list of tasks, the following was done:

- Replace tool.poetry section with project
- Set the authors and maintainers with the new formats
- Agree on the specific versions we will support from the dependencies
- Set as extras the specific versions we will support on the optional-dependencies
- For dev and docs, keep the same format

The new file was checked with `poetry check` and the poetry.lock file was regenerated.

The following was **not** done:
- Remove the annotation for Python < 4.0, because this prevents the installation of darglint, a dev dependency.
- Discuss the use of `parsy` as a mandatory dependency, instead of being part of the dc extra. Personally, I'm not sure it should be a mandatory dependency, as it is only used in the dc module.
- Ensure some library dependencies works with the latest version of python3-* APT Packages in Ubuntu 24.04 LTS. I haven't done this, as I don't know which ones aren't working at the moment.