### PR TITLE
Add version to metadata reports

### DIFF
--- a/src/pysdmx/io/json/fusion/messages/report.py
+++ b/src/pysdmx/io/json/fusion/messages/report.py
@@ -20,6 +20,7 @@ class FusionMetadataReport(Struct, frozen=True):
     metadataflow: str
     targets: Sequence[str]
     attributes: Sequence[MetadataAttribute]
+    version: str
 
 
 class FusionMetadataSets(Struct, frozen=True):
@@ -36,7 +37,7 @@ class FusionMetadataMessage(Struct, frozen=True):
     def __create_report(self, r: FusionMetadataReport) -> MetadataReport:
         attrs = merge_attributes(r.attributes)
         return MetadataReport(
-            r.id, r.names[0].value, r.metadataflow, r.targets, attrs
+            r.id, r.names[0].value, r.metadataflow, r.targets, attrs, r.version
         )
 
     def to_model(self, fetch_all: bool = False) -> Sequence[MetadataReport]:

--- a/src/pysdmx/io/json/sdmxjson2/messages/report.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/report.py
@@ -20,7 +20,9 @@ class JsonMetadataMessage(Struct, frozen=True):
 
     def __create_report(self, r: MetadataReport) -> MetadataReport:
         attrs = merge_attributes(r.attributes)
-        return MetadataReport(r.id, r.name, r.metadataflow, r.targets, attrs)
+        return MetadataReport(
+            r.id, r.name, r.metadataflow, r.targets, attrs, r.version
+        )
 
     def to_model(self, fetch_all: bool = False) -> Sequence[MetadataReport]:
         """Returns the requested metadata report(s)."""

--- a/src/pysdmx/model/metadata.py
+++ b/src/pysdmx/model/metadata.py
@@ -54,6 +54,7 @@ class MetadataReport(Struct, frozen=True, omit_defaults=True):
         targets: The URN(s) of SDMX artefact(s) to which the report relates.
         attributes: The list of metadata attributes included in the report.
             Attributes may contain other attributes.
+        version: The version of the metadata report.
     """
 
     id: str
@@ -61,6 +62,7 @@ class MetadataReport(Struct, frozen=True, omit_defaults=True):
     metadataflow: str
     targets: Sequence[str]
     attributes: Sequence[MetadataAttribute]
+    version: str = "1.0"
 
     def __iter__(self) -> Iterator[MetadataAttribute]:
         """Return an iterator over the list of report attributes."""

--- a/tests/api/fmr/report_checks.py
+++ b/tests/api/fmr/report_checks.py
@@ -33,6 +33,7 @@ def check_report(
     assert isinstance(report, MetadataReport)
     assert report.id == "DTI_BIS_MACRO"
     assert report.name == "Technical metadata for BIS.MACRO:BIS_MACRO"
+    assert report.version == "1.0.42"
     assert report.metadataflow == (
         "urn:sdmx:org.sdmx.infomodel.metadatastructure.Metadataflow="
         "BIS.MEDIT:DTI(1.0)"

--- a/tests/api/fmr/samples/refmeta/report.fusion.json
+++ b/tests/api/fmr/samples/refmeta/report.fusion.json
@@ -15,7 +15,7 @@
         "metadatasets": [
             {
                 "id": "DTI_BIS_MACRO",
-                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataSet=BIS.MEDIT:DTI_BIS_MACRO(1.0)",
+                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataSet=BIS.MEDIT:DTI_BIS_MACRO(1.0.42)",
                 "names": [
                     {
                         "locale": "en",
@@ -23,7 +23,7 @@
                     }
                 ],
                 "agencyId": "BIS.MEDIT",
-                "version": "1.0",
+                "version": "1.0.42",
                 "isFinal": false,
                 "metadataflow": "urn:sdmx:org.sdmx.infomodel.metadatastructure.Metadataflow=BIS.MEDIT:DTI(1.0)",
                 "targets": [
@@ -32,28 +32,28 @@
                 "attributes": [
                     {
                         "id": "idea_partition_details",
-                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_details",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0.42).idea_partition_details",
                         "attributes": [
                             {
                                 "id": "idea_partition_name",
-                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_name",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0.42).idea_partition_name",
                                 "value": "dt"
                             },
                             {
                                 "id": "idea_partition_pattern",
-                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_pattern",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0.42).idea_partition_pattern",
                                 "value": "\\d{4}-(0\\d|1[012])"
                             },
                             {
                                 "id": "idea_partition_type",
-                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_type",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0.42).idea_partition_type",
                                 "value": "string"
                             }
                         ]
                     },
                     {
                         "id": "record_format",
-                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).record_format",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0.42).record_format",
                         "value": "A"
                     }
                 ]

--- a/tests/api/fmr/samples/refmeta/report.json
+++ b/tests/api/fmr/samples/refmeta/report.json
@@ -19,7 +19,7 @@
                         "rel": "self",
                         "type": "metadataset",
                         "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
-                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataSet=BIS.MEDIT:DTI_BIS_MACRO(1.0)"
+                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataSet=BIS.MEDIT:DTI_BIS_MACRO(1.0.42)"
                     }
                 ],
                 "id": "DTI_BIS_MACRO",
@@ -27,7 +27,7 @@
                 "names": {
                     "en": "Technical metadata for BIS.MACRO:BIS_MACRO"
                 },
-                "version": "1.0",
+                "version": "1.0.42",
                 "agencyID": "BIS.MEDIT",
                 "isExternalReference": false,
                 "isFinal": false,
@@ -42,7 +42,7 @@
                                 "rel": "self",
                                 "type": "metadataattribute",
                                 "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
-                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_name"
+                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0.42).idea_partition_name"
                             }
                         ],
                         "id": "idea_partition_details",
@@ -53,7 +53,7 @@
                                         "rel": "self",
                                         "type": "metadataattribute",
                                         "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
-                                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_name"
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0.42).idea_partition_name"
                                     }
                                 ],
                                 "id": "idea_partition_name",
@@ -65,7 +65,7 @@
                                         "rel": "self",
                                         "type": "metadataattribute",
                                         "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
-                                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_pattern"
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0.42).idea_partition_pattern"
                                     }
                                 ],
                                 "id": "idea_partition_pattern",
@@ -77,7 +77,7 @@
                                         "rel": "self",
                                         "type": "metadataattribute",
                                         "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
-                                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).idea_partition_type"
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0.42).idea_partition_type"
                                     }
                                 ],
                                 "id": "idea_partition_type",
@@ -91,7 +91,7 @@
                                 "rel": "self",
                                 "type": "metadataattribute",
                                 "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
-                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0).record_format"
+                                "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataAttribute=BIS.MEDIT:DTI_BIS_MACRO(1.0.42).record_format"
                             }
                         ],
                         "id": "record_format",

--- a/tests/model/test_metadata_report.py
+++ b/tests/model/test_metadata_report.py
@@ -41,7 +41,25 @@ def attributes():
     ]
 
 
-def test_full_initialization(id, name, structure, targets, attributes):
+@pytest.fixture
+def version():
+    return "1.0.42"
+
+
+def test_full_initialization(
+    id, name, structure, targets, attributes, version
+):
+    report = MetadataReport(id, name, structure, targets, attributes, version)
+
+    assert report.id == id
+    assert report.name == name
+    assert report.metadataflow == structure
+    assert report.targets == targets
+    assert report.attributes == attributes
+    assert report.version == version
+
+
+def test_default_version(id, name, structure, targets, attributes):
     report = MetadataReport(id, name, structure, targets, attributes)
 
     assert report.id == id
@@ -49,6 +67,7 @@ def test_full_initialization(id, name, structure, targets, attributes):
     assert report.metadataflow == structure
     assert report.targets == targets
     assert report.attributes == attributes
+    assert report.version == "1.0"
 
 
 def test_immutable(id, name, structure, targets, attributes):


### PR DESCRIPTION
The purpose of this PR is to add the version attribute to metadata reports. Both the model class and the FMR json deserializers have been updated.

Close #279 