### PR TITLE
Wrap the utility functions for parsing URNs

### DIFF
--- a/docs/api/helper/urn.rst
+++ b/docs/api/helper/urn.rst
@@ -11,8 +11,9 @@ maintained by ``SDMX`` will have the following unique URN:
 
 ``pysdmx`` offers helper methods to:
 
-- Parse URNs of maintainable artefacts (``parse_urn``).
+- Parse URNs of maintainable artefacts (``parse_maintainable_urn``).
 - Parse URNs of items (``parse_item_urn``).
+- Parse URNs of any type (``parse_urn``).
 - Find the artefact identified by the supplied URN in a collection of
   artefacts (``find_by_urn``).
 
@@ -20,6 +21,8 @@ Functions
 ---------
 
 .. autofunction:: pysdmx.util.parse_urn
+
+.. autofunction:: pysdmx.util.parse_maintainable_urn
 
 .. autofunction:: pysdmx.util.parse_item_urn
 

--- a/src/pysdmx/io/xml/sdmx21/reader/header.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/header.py
@@ -31,7 +31,7 @@ from pysdmx.io.xml.sdmx21.__tokens import (
 from pysdmx.io.xml.sdmx21.reader.__parse_xml import parse_xml
 from pysdmx.model import Organisation, Reference
 from pysdmx.model.message import Header
-from pysdmx.util import parse_urn
+from pysdmx.util import parse_maintainable_urn
 
 
 def __parse_sender_receiver(
@@ -112,7 +112,7 @@ def __parse_structure(
             version=version,
         )
     else:
-        ref_obj = parse_urn(structure_info[URN])
+        ref_obj = parse_maintainable_urn(structure_info[URN])
     return {str(ref_obj): dim_at_obs}
 
 

--- a/src/pysdmx/util/__init__.py
+++ b/src/pysdmx/util/__init__.py
@@ -12,6 +12,7 @@ NF = "Not found"
 maintainable_urn_pattern = re.compile(r"^.*\.(.*)=(.*):(.*)\((.*)\)$")
 item_urn_pattern = re.compile(r"^.*\.(.*)=(.*):(.*)\((.*)\)\.(.*)$")
 short_urn_pattern = re.compile(r"^(.*)=(.*):(.*)\((.*)\)$")
+short_item_urn_pattern = re.compile(r"^(.*)=(.*):(.*)\((.*)\)\.(.*)$")
 
 
 def parse_urn(urn: str) -> Union[ItemReference, Reference]:
@@ -25,7 +26,10 @@ def parse_urn(urn: str) -> Union[ItemReference, Reference]:
             try:
                 return parse_short_urn(urn)
             except Invalid:
-                raise Invalid(NF, "{urn} does not match any known pattern")
+                try:
+                    return parse_short_item_urn(urn)
+                except Invalid:
+                    raise Invalid(NF, "{urn} does not match any known pattern")
 
 
 def parse_maintainable_urn(urn: str) -> Reference:
@@ -71,6 +75,21 @@ def parse_short_urn(urn: str) -> Reference:
         raise Invalid(NF, f"{urn} does not match {short_urn_pattern}.")
 
 
+def parse_short_item_urn(urn: str) -> Reference:
+    """Parses an SDMX short item urn and returns the details."""
+    m = re.match(short_item_urn_pattern, urn)
+    if m:
+        return ItemReference(
+            sdmx_type=m.group(1),
+            agency=m.group(2),
+            id=m.group(3),
+            version=m.group(4),
+            item_id=m.group(5),
+        )
+    else:
+        raise Invalid(NF, f"{urn} does not match {short_item_urn_pattern}.")
+
+
 def find_by_urn(artefacts: Sequence[Any], urn: str) -> Any:
     """Returns the maintainable artefact matching the supplied urn."""
     r = parse_urn(urn)
@@ -110,6 +129,7 @@ __all__ = [
     "parse_maintainable_urn",
     "parse_urn",
     "parse_short_urn",
+    "parse_short_item_urn",
     "ItemReference",
     "Reference",
 ]

--- a/src/pysdmx/util/__init__.py
+++ b/src/pysdmx/util/__init__.py
@@ -29,7 +29,9 @@ def parse_urn(urn: str) -> Union[ItemReference, Reference]:
                 try:
                     return parse_short_item_urn(urn)
                 except Invalid:
-                    raise Invalid(NF, "{urn} does not match any known pattern")
+                    raise Invalid(
+                        NF, "{urn} does not match any known pattern"
+                    ) from None
 
 
 def parse_maintainable_urn(urn: str) -> Reference:
@@ -75,7 +77,7 @@ def parse_short_urn(urn: str) -> Reference:
         raise Invalid(NF, f"{urn} does not match {short_urn_pattern}.")
 
 
-def parse_short_item_urn(urn: str) -> Reference:
+def parse_short_item_urn(urn: str) -> ItemReference:
     """Parses an SDMX short item urn and returns the details."""
     m = re.match(short_item_urn_pattern, urn)
     if m:

--- a/src/pysdmx/util/__init__.py
+++ b/src/pysdmx/util/__init__.py
@@ -1,7 +1,7 @@
 """Collection of utility functions."""
 
 import re
-from typing import Any, Sequence
+from typing import Any, Sequence, Union
 
 from pysdmx.errors import Invalid, NotFound
 from pysdmx.model import Agency, ItemReference, Reference
@@ -14,7 +14,7 @@ item_urn_pattern = re.compile(r"^.*\.(.*)=(.*):(.*)\((.*)\)\.(.*)$")
 short_urn_pattern = re.compile(r"^(.*)=(.*):(.*)\((.*)\)$")
 
 
-def parse_urn(urn: str) -> Reference:
+def parse_urn(urn: str) -> Union[ItemReference, Reference]:
     """Parses an SDMX urn and returns the details."""
     try:
         return parse_maintainable_urn(urn)

--- a/src/pysdmx/util/__init__.py
+++ b/src/pysdmx/util/__init__.py
@@ -15,7 +15,21 @@ short_urn_pattern = re.compile(r"^(.*)=(.*):(.*)\((.*)\)$")
 
 
 def parse_urn(urn: str) -> Reference:
-    """Parses an SDMX urn and returns an object with the details."""
+    """Parses an SDMX urn and returns the details."""
+    try:
+        return parse_maintainable_urn(urn)
+    except Invalid:
+        try:
+            return parse_item_urn(urn)
+        except Invalid:
+            try:
+                return parse_short_urn(urn)
+            except Invalid:
+                raise Invalid(NF, "{urn} does not match any known pattern")
+
+
+def parse_maintainable_urn(urn: str) -> Reference:
+    """Parses an SDMX maintainable urn and returns the details."""
     m = re.match(maintainable_urn_pattern, urn)
     if m:
         return Reference(
@@ -29,7 +43,7 @@ def parse_urn(urn: str) -> Reference:
 
 
 def parse_item_urn(urn: str) -> ItemReference:
-    """Parses an SDMX item urn and returns an object with the details."""
+    """Parses an SDMX item urn and returns the details."""
     m = re.match(item_urn_pattern, urn)
     if m:
         return ItemReference(
@@ -44,7 +58,7 @@ def parse_item_urn(urn: str) -> ItemReference:
 
 
 def parse_short_urn(urn: str) -> Reference:
-    """Parses an SDMX short urn and returns an object with the details."""
+    """Parses an SDMX short urn and returns the details."""
     m = re.match(short_urn_pattern, urn)
     if m:
         return Reference(
@@ -93,6 +107,7 @@ __all__ = [
     "convert_dpm",
     "find_by_urn",
     "parse_item_urn",
+    "parse_maintainable_urn",
     "parse_urn",
     "parse_short_urn",
     "ItemReference",

--- a/tests/util/test_parse_any_urn.py
+++ b/tests/util/test_parse_any_urn.py
@@ -1,0 +1,47 @@
+import pytest
+
+from pysdmx.errors import Invalid
+from pysdmx.model import ItemReference, Reference
+from pysdmx.util import parse_urn
+
+
+def test_no_match():
+    with pytest.raises(Invalid):
+        parse_urn("test")
+
+
+def test_match_maintainable():
+    cl = "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=SDMX:CL_FREQ(1.0)"
+
+    m = parse_urn(cl)
+
+    assert isinstance(m, Reference)
+    assert m.sdmx_type == "Codelist"
+    assert m.agency == "SDMX"
+    assert m.id == "CL_FREQ"
+    assert m.version == "1.0"
+
+
+def test_match_item():
+    cl = "urn:sdmx:org.sdmx.infomodel.codelist.Code=SDMX:CL_FREQ(1.0).A"
+
+    m = parse_urn(cl)
+
+    assert isinstance(m, ItemReference)
+    assert m.sdmx_type == "Code"
+    assert m.agency == "SDMX"
+    assert m.id == "CL_FREQ"
+    assert m.version == "1.0"
+    assert m.item_id == "A"
+
+
+def test_match_short():
+    cl = "Codelist=SDMX:CL_FREQ(1.0)"
+
+    m = parse_urn(cl)
+
+    assert isinstance(m, Reference)
+    assert m.sdmx_type == "Codelist"
+    assert m.agency == "SDMX"
+    assert m.id == "CL_FREQ"
+    assert m.version == "1.0"

--- a/tests/util/test_parse_any_urn.py
+++ b/tests/util/test_parse_any_urn.py
@@ -35,7 +35,7 @@ def test_match_item():
     assert m.item_id == "A"
 
 
-def test_match_short():
+def test_match_short_maintainable():
     cl = "Codelist=SDMX:CL_FREQ(1.0)"
 
     m = parse_urn(cl)
@@ -45,3 +45,16 @@ def test_match_short():
     assert m.agency == "SDMX"
     assert m.id == "CL_FREQ"
     assert m.version == "1.0"
+
+
+def test_match_short_item():
+    cl = "Code=SDMX:CL_FREQ(1.0).A"
+
+    m = parse_urn(cl)
+
+    assert isinstance(m, ItemReference)
+    assert m.sdmx_type == "Code"
+    assert m.agency == "SDMX"
+    assert m.id == "CL_FREQ"
+    assert m.version == "1.0"
+    assert m.item_id == "A"

--- a/tests/util/test_parse_item_urn.py
+++ b/tests/util/test_parse_item_urn.py
@@ -21,3 +21,19 @@ def test_match():
     assert m.id == "CL_FREQ"
     assert m.version == "1.0"
     assert m.item_id == "A"
+
+
+def test_match_nested():
+    cl = (
+        "urn:sdmx:org.sdmx.infomodel.categoryscheme.Category="
+        "TEST:TESTCS(1.42).TOP.SUB"
+    )
+
+    m = parse_item_urn(cl)
+
+    assert isinstance(m, ItemReference)
+    assert m.sdmx_type == "Category"
+    assert m.agency == "TEST"
+    assert m.id == "TESTCS"
+    assert m.version == "1.42"
+    assert m.item_id == "TOP.SUB"

--- a/tests/util/test_parse_maintainable_urn.py
+++ b/tests/util/test_parse_maintainable_urn.py
@@ -2,18 +2,18 @@ import pytest
 
 from pysdmx.errors import Invalid
 from pysdmx.model import Reference
-from pysdmx.util import parse_urn
+from pysdmx.util import parse_maintainable_urn
 
 
 def test_no_match():
     with pytest.raises(Invalid):
-        parse_urn("test")
+        parse_maintainable_urn("test")
 
 
 def test_match():
     cl = "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=SDMX:CL_FREQ(1.0)"
 
-    m = parse_urn(cl)
+    m = parse_maintainable_urn(cl)
 
     assert isinstance(m, Reference)
     assert m.sdmx_type == "Codelist"

--- a/tests/util/test_parse_short_item_urn.py
+++ b/tests/util/test_parse_short_item_urn.py
@@ -21,3 +21,16 @@ def test_match():
     assert m.id == "CL_FREQ"
     assert m.version == "1.0"
     assert m.item_id == "A"
+
+
+def test_match_nested():
+    cl = "Category=TEST:TESTCS(1.42).TOP.SUB"
+
+    m = parse_short_item_urn(cl)
+
+    assert isinstance(m, ItemReference)
+    assert m.sdmx_type == "Category"
+    assert m.agency == "TEST"
+    assert m.id == "TESTCS"
+    assert m.version == "1.42"
+    assert m.item_id == "TOP.SUB"

--- a/tests/util/test_parse_short_item_urn.py
+++ b/tests/util/test_parse_short_item_urn.py
@@ -1,0 +1,23 @@
+import pytest
+
+from pysdmx.errors import Invalid
+from pysdmx.model import ItemReference
+from pysdmx.util import parse_short_item_urn
+
+
+def test_no_match():
+    with pytest.raises(Invalid):
+        parse_short_item_urn("test")
+
+
+def test_match():
+    cl = "Code=SDMX:CL_FREQ(1.0).A"
+
+    m = parse_short_item_urn(cl)
+
+    assert isinstance(m, ItemReference)
+    assert m.sdmx_type == "Code"
+    assert m.agency == "SDMX"
+    assert m.id == "CL_FREQ"
+    assert m.version == "1.0"
+    assert m.item_id == "A"


### PR DESCRIPTION
In this PR, the following changes have been made to the URN parsing utility functions:

- The original `parse_urn` function has been renamed to `parse_maintainable_urn`.
- A function to parse short URNs of items has been added.
- The new `parse_urn` function is now generic, i.e. it will try all specific functions until a match is found. If no match is found, an `Invalid` error will be returned.

Tests have also been added, to verify that URNs of nested items can be parsed too.

The changes above are deemed backward compatible because the new `parse_urn` function can do anything the old could do, i.e. clients should not be impacted by the change. 

Close #288