### PR TITLE
Build a Query object out of an SDMX Reference or a URN

### DIFF
--- a/docs/api/query/registration.rst
+++ b/docs/api/query/registration.rst
@@ -1,0 +1,11 @@
+SDMX-REST Registration Queries
+==============================
+
+.. note::
+    Additional information about how to build SDMX-REST queries
+    can be found in the following tutorial:
+
+    - :ref:`sdmx-rest`.
+
+.. automodule:: pysdmx.api.qb.registration
+    :members: RegistrationByIdQuery, RegistrationByProviderQuery, RegistrationByContextQuery, RegistryFormat

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -24,5 +24,6 @@ API Reference
    query/availability
    query/data
    query/refmeta
+   query/registration
    query/schema
    query/structure

--- a/src/pysdmx/api/qb/refmeta.py
+++ b/src/pysdmx/api/qb/refmeta.py
@@ -11,6 +11,8 @@ from pysdmx.api.qb.structure import _API_RESOURCES, StructureType
 from pysdmx.api.qb.util import REST_ALL, REST_LATEST, ApiVersion, CoreQuery
 from pysdmx.errors import Invalid
 from pysdmx.io.format import RefMetaFormat
+from pysdmx.model import Reference
+from pysdmx.util import parse_urn
 
 
 class RefMetaDetail(Enum):
@@ -81,6 +83,33 @@ class RefMetaByMetadatasetQuery(
     version: Union[str, Sequence[str]] = REST_LATEST
     detail: RefMetaDetail = RefMetaDetail.FULL
     as_of: Optional[datetime] = None
+
+    @staticmethod
+    def from_ref(ref: Union[Reference, str]) -> "RefMetaByMetadatasetQuery":
+        """Create a RefMetaByMetadatasetQuery out of the supplied reference.
+
+        Args:
+            ref: Either a reference object or an SDMX urn.
+
+        Returns:
+            A RefMetaByMetadatasetQuery to retrieve the supplied reference.
+
+        Raises:
+            Invalid: If reference is a string and it is not an SDMX urn,
+                or if the artefact type is not MetadataSet.
+        """
+        if isinstance(ref, str):
+            ref = parse_urn(ref)
+        if ref.sdmx_type != "MetadataSet":
+            raise Invalid(
+                "Unexpected artefact type",
+                (
+                    "Only references of type MetadataSet can be converted"
+                    "into a RefMetaByMetadatasetQuery"
+                ),
+                {"received_type": ref.sdmx_type},
+            )
+        return RefMetaByMetadatasetQuery(ref.agency, ref.id, ref.version)
 
     def _validate_query(self, version: ApiVersion) -> None:
         super().validate()

--- a/src/pysdmx/api/qb/refmeta.py
+++ b/src/pysdmx/api/qb/refmeta.py
@@ -99,17 +99,21 @@ class RefMetaByMetadatasetQuery(
                 or if the artefact type is not MetadataSet.
         """
         if isinstance(ref, str):
-            ref = parse_urn(ref)
-        if ref.sdmx_type != "MetadataSet":
+            ref = parse_urn(ref)  # type: ignore[assignment]
+        if ref.sdmx_type != "MetadataSet":  # type: ignore[union-attr]
             raise Invalid(
                 "Unexpected artefact type",
                 (
                     "Only references of type MetadataSet can be converted"
                     "into a RefMetaByMetadatasetQuery"
                 ),
-                {"received_type": ref.sdmx_type},
+                {"received_type": ref.sdmx_type},  # type: ignore[union-attr]
             )
-        return RefMetaByMetadatasetQuery(ref.agency, ref.id, ref.version)
+        return RefMetaByMetadatasetQuery(
+            ref.agency,  # type: ignore[union-attr]
+            ref.id,  # type: ignore[union-attr]
+            ref.version,  # type: ignore[union-attr]
+        )
 
     def _validate_query(self, version: ApiVersion) -> None:
         super().validate()

--- a/src/pysdmx/api/qb/structure.py
+++ b/src/pysdmx/api/qb/structure.py
@@ -15,6 +15,8 @@ from pysdmx.api.qb.util import (
 )
 from pysdmx.errors import Invalid
 from pysdmx.io.format import StructureFormat
+from pysdmx.model import Reference, ItemReference
+from pysdmx.util import parse_urn
 
 
 class StructureDetail(Enum):
@@ -142,6 +144,27 @@ class StructureType(Enum):
     METADATA_PROVIDER_SCHEME = "metadataproviderscheme"
     METADATA_PROVISION_AGREEMENT = "metadataprovisionagreement"
     ALL = REST_ALL
+
+    @classmethod
+    def from_type(
+        cls, sdmx_type: str, is_item: bool = False
+    ) -> "StructureType":
+        sdmx_type = sdmx_type.lower()
+        if sdmx_type == "code":
+            return StructureType.CODELIST
+        elif sdmx_type == "reportingcategory":
+            return StructureType.REPORTING_TAXONOMY
+        elif sdmx_type == "hierarchicalcode":
+            return StructureType.HIERARCHY
+        else:
+            val = f"{sdmx_type}scheme" if is_item else sdmx_type
+            try:
+                return StructureType(val)
+            except ValueError as ve:
+                raise Invalid(
+                    "Unknow type",
+                    f"The supplied artefact type is unknown: {val}",
+                ) from ve
 
 
 ITEM_SCHEMES = {
@@ -276,6 +299,31 @@ class StructureQuery(CoreQuery, frozen=True, omit_defaults=True):
     detail: StructureDetail = StructureDetail.FULL
     references: StructureReference = StructureReference.NONE
     as_of: Optional[datetime] = None
+
+    @staticmethod
+    def from_ref(
+        ref: Union[ItemReference, Reference, str],
+    ) -> "StructureQuery":
+        """Create a StructureQuery out of the supplied reference.
+
+        Args:
+            ref: Either a reference object (Reference for maintainable
+                artefacts, or ItemReference for items), or an SDMX urn.
+
+        Returns:
+            A StructureQuery to retrieve the supplied reference.
+
+        Raises:
+            Invalid: If reference is a string and it is not an SDMX urn,
+                or if the type cannot be translated into a StructureType.
+        """
+        if isinstance(ref, str):
+            ref = parse_urn(ref)
+        item = ref.item_id if isinstance(ref, ItemReference) else None
+        atype = StructureType.from_type(
+            ref.sdmx_type, isinstance(ref, ItemReference)
+        )
+        return StructureQuery(atype, ref.agency, ref.id, ref.version, item)
 
     def _validate_query(self, version: ApiVersion) -> None:
         self.validate()

--- a/src/pysdmx/api/qb/structure.py
+++ b/src/pysdmx/api/qb/structure.py
@@ -149,6 +149,7 @@ class StructureType(Enum):
     def from_type(
         cls, sdmx_type: str, is_item: bool = False
     ) -> "StructureType":
+        """Create a StructureType from an sdmx type string."""
         sdmx_type = sdmx_type.lower()
         if sdmx_type == "code":
             return StructureType.CODELIST

--- a/src/pysdmx/api/qb/structure.py
+++ b/src/pysdmx/api/qb/structure.py
@@ -320,7 +320,7 @@ class StructureQuery(CoreQuery, frozen=True, omit_defaults=True):
         """
         if isinstance(ref, str):
             ref = parse_urn(ref)
-        item = ref.item_id if isinstance(ref, ItemReference) else None
+        item = ref.item_id if isinstance(ref, ItemReference) else REST_ALL
         atype = StructureType.from_type(
             ref.sdmx_type, isinstance(ref, ItemReference)
         )

--- a/src/pysdmx/api/qb/structure.py
+++ b/src/pysdmx/api/qb/structure.py
@@ -15,7 +15,7 @@ from pysdmx.api.qb.util import (
 )
 from pysdmx.errors import Invalid
 from pysdmx.io.format import StructureFormat
-from pysdmx.model import Reference, ItemReference
+from pysdmx.model import ItemReference, Reference
 from pysdmx.util import parse_urn
 
 

--- a/tests/api/qb/refmeta/test_refmeta_mds_query_factory.py
+++ b/tests/api/qb/refmeta/test_refmeta_mds_query_factory.py
@@ -1,0 +1,52 @@
+import pytest
+
+from pysdmx.api.qb.refmeta import RefMetaByMetadatasetQuery
+from pysdmx.errors import Invalid
+from pysdmx.model import Reference
+
+
+@pytest.fixture
+def ref() -> Reference:
+    return Reference("MetadataSet", "BIS", "DTI_CBS", "2.1")
+
+
+@pytest.fixture
+def unsuported_ref() -> Reference:
+    return Reference("Codelist", "SDMX", "CL_FREQ", "2.1")
+
+
+def test_ref(ref: Reference):
+    q = RefMetaByMetadatasetQuery.from_ref(ref)
+
+    assert isinstance(q, RefMetaByMetadatasetQuery)
+    assert q.provider_id == "BIS"
+    assert q.metadataset_id == "DTI_CBS"
+    assert q.version == "2.1"
+
+
+def test_unknown_maintainable_ref(unsuported_ref: Reference):
+    with pytest.raises(Invalid):
+        RefMetaByMetadatasetQuery.from_ref(unsuported_ref)
+
+
+__base_urn = "urn:sdmx:org.sdmx.infomodel."
+
+
+def test_parse_urn():
+    urn = f"{__base_urn}metadatastructure.MetadataSet=BIS:DTI_CBS(2.1)"
+
+    q = RefMetaByMetadatasetQuery.from_ref(urn)
+
+    assert isinstance(q, RefMetaByMetadatasetQuery)
+    assert q.provider_id == "BIS"
+    assert q.metadataset_id == "DTI_CBS"
+    assert q.version == "2.1"
+
+
+def test_parse_unsupported_urn():
+    unsupported_urn = (
+        f"{__base_urn}datastructure.DataStructure=ESTAT:CPI(2.1.0)"
+    )
+
+    with pytest.raises(Invalid):
+        RefMetaByMetadatasetQuery.from_ref(unsupported_urn)

--- a/tests/api/qb/structure/test_structure_query_factory.py
+++ b/tests/api/qb/structure/test_structure_query_factory.py
@@ -1,0 +1,174 @@
+import pytest
+
+from pysdmx.api.qb.structure import (
+    REST_ALL,
+    REST_LATEST,
+    StructureQuery,
+    StructureType,
+)
+from pysdmx.errors import Invalid
+from pysdmx.model import ItemReference, Reference
+
+
+@pytest.fixture
+def maintainable_ref() -> Reference:
+    return Reference("Codelist", "SDMX", "CL_FREQ", "2.1")
+
+
+@pytest.fixture
+def unknown_ref() -> Reference:
+    return Reference("xxx", "SDMX", "REP_TAX", "2.1")
+
+
+@pytest.fixture
+def code_ref() -> ItemReference:
+    return ItemReference("Code", "SDMX", "CL_FREQ", "2.1", "A")
+
+
+@pytest.fixture
+def concept_ref() -> ItemReference:
+    return ItemReference("Concept", "SDMX", "CROSS_DOMAIN", "2.0", "FREQ")
+
+
+@pytest.fixture
+def rep_ref() -> ItemReference:
+    return ItemReference("reportingcategory", "SDMX", "REP_TAX", "2.1", "CAT1")
+
+
+@pytest.fixture
+def unknown_item_ref() -> ItemReference:
+    return ItemReference("xxx", "SDMX", "REP_TAX", "2.1", "CAT1")
+
+
+def test_maintainable_ref(maintainable_ref: Reference):
+    q = StructureQuery.from_ref(maintainable_ref)
+
+    assert isinstance(q, StructureQuery)
+    assert q.artefact_type == StructureType.CODELIST
+    assert q.agency_id == maintainable_ref.agency
+    assert q.resource_id == maintainable_ref.id
+    assert q.version == maintainable_ref.version
+
+
+def test_unknown_maintainable_ref(unknown_ref: Reference):
+    with pytest.raises(Invalid):
+        StructureQuery.from_ref(unknown_ref)
+
+
+def test_item_query_code(code_ref: ItemReference):
+    q = StructureQuery.from_ref(code_ref)
+
+    assert isinstance(q, StructureQuery)
+    assert q.artefact_type == StructureType.CODELIST
+    assert q.agency_id == code_ref.agency
+    assert q.resource_id == code_ref.id
+    assert q.version == code_ref.version
+    assert q.item_id == code_ref.item_id
+
+
+def test_item_query_rep_cat(rep_ref: ItemReference):
+    q = StructureQuery.from_ref(rep_ref)
+
+    assert isinstance(q, StructureQuery)
+    assert q.artefact_type == StructureType.REPORTING_TAXONOMY
+    assert q.agency_id == rep_ref.agency
+    assert q.resource_id == rep_ref.id
+    assert q.version == rep_ref.version
+    assert q.item_id == rep_ref.item_id
+
+
+def test_item_query_concept(concept_ref: ItemReference):
+    q = StructureQuery.from_ref(concept_ref)
+
+    assert isinstance(q, StructureQuery)
+    assert q.artefact_type == StructureType.CONCEPT_SCHEME
+    assert q.agency_id == concept_ref.agency
+    assert q.resource_id == concept_ref.id
+    assert q.version == concept_ref.version
+    assert q.item_id == concept_ref.item_id
+
+
+def test_unknown_ref(unknown_item_ref: ItemReference):
+    with pytest.raises(Invalid):
+        StructureQuery.from_ref(unknown_item_ref)
+
+
+__base_urn = "urn:sdmx:org.sdmx.infomodel."
+maintainable_urns = [
+    (
+        f"{__base_urn}datastructure.DataStructure=ESTAT:CPI(2.1.0)",
+        StructureType.DATA_STRUCTURE,
+    ),
+    (
+        f"{__base_urn}datastructure.Dataflow=ESTAT:BPM6_BOP_M(2.4.0)",
+        StructureType.DATAFLOW,
+    ),
+    (
+        f"{__base_urn}registry.DataConstraint=IAEG-SDGs:CN_SDG_GLC(1.20)",
+        StructureType.DATA_CONSTRAINT,
+    ),
+    (
+        f"{__base_urn}base.AgencyScheme=SDMX:AGENCIES(1.0)",
+        StructureType.AGENCY_SCHEME,
+    ),
+    (
+        f"{__base_urn}codelist.Codelist=ESTAT:CL_ACTIVITY(1.11.0)",
+        StructureType.CODELIST,
+    ),
+    (
+        f"{__base_urn}codelist.Hierarchy=ESTAT:HCL_WSTATUS_SCL_BNSPART(1.0)",
+        StructureType.HIERARCHY,
+    ),
+    (
+        f"{__base_urn}conceptscheme.ConceptScheme=ESTAT:CS_NA(1.17.0)",
+        StructureType.CONCEPT_SCHEME,
+    ),
+    (
+        f"{__base_urn}categoryscheme.CategoryScheme=ESTAT:ESA2010TP(1.0)",
+        StructureType.CATEGORY_SCHEME,
+    ),
+]
+
+
+@pytest.mark.parametrize("urn,expected_type", maintainable_urns)
+def test_from_maintainable_urn(urn, expected_type):
+    q = StructureQuery.from_ref(urn)
+
+    assert isinstance(q, StructureQuery)
+    assert q.artefact_type == expected_type
+    assert q.agency_id != REST_ALL
+    assert q.resource_id != REST_ALL
+    assert q.version != REST_LATEST
+    assert q.item_id is None
+
+
+item_urns = [
+    (
+        f"{__base_urn}categoryscheme.Category=ESTAT:ESA2010TP(1.0).ESA2010MA",
+        StructureType.CATEGORY_SCHEME,
+    ),
+    (
+        f"{__base_urn}conceptscheme.Concept=ESTAT:CS_NA(1.17.0).FREQ",
+        StructureType.CONCEPT_SCHEME,
+    ),
+    (
+        f"{__base_urn}codelist.Code=ESTAT:CL_ACTIVITY(1.11.0).A",
+        StructureType.CODELIST,
+    ),
+    (
+        f"{__base_urn}codelist.HierarchicalCode=ESTAT:TEST(1.0).thUA",
+        StructureType.HIERARCHY,
+    ),
+]
+
+
+@pytest.mark.parametrize("urn,expected_type", item_urns)
+def test_from_item_urn(urn, expected_type):
+    q = StructureQuery.from_ref(urn)
+
+    assert isinstance(q, StructureQuery)
+    assert q.artefact_type == expected_type
+    assert q.agency_id != REST_ALL
+    assert q.resource_id != REST_ALL
+    assert q.version != REST_LATEST
+    assert q.item_id is not None

--- a/tests/api/qb/structure/test_structure_query_factory.py
+++ b/tests/api/qb/structure/test_structure_query_factory.py
@@ -130,7 +130,7 @@ maintainable_urns = [
 ]
 
 
-@pytest.mark.parametrize("urn,expected_type", maintainable_urns)
+@pytest.mark.parametrize(("urn", "expected_type"), maintainable_urns)
 def test_from_maintainable_urn(urn, expected_type):
     q = StructureQuery.from_ref(urn)
 
@@ -170,7 +170,7 @@ item_urns = [
 ]
 
 
-@pytest.mark.parametrize("urn,expected_type", item_urns)
+@pytest.mark.parametrize(("urn", "expected_type"), item_urns)
 def test_from_item_urn(urn, expected_type):
     q = StructureQuery.from_ref(urn)
 

--- a/tests/api/qb/structure/test_structure_query_factory.py
+++ b/tests/api/qb/structure/test_structure_query_factory.py
@@ -159,6 +159,14 @@ item_urns = [
         f"{__base_urn}codelist.HierarchicalCode=ESTAT:TEST(1.0).thUA",
         StructureType.HIERARCHY,
     ),
+    (
+        f"{__base_urn}.base.Agency=SDMX:AGENCIES(1.0).ILO",
+        StructureType.AGENCY_SCHEME,
+    ),
+    (
+        f"{__base_urn}.base.DataProvider=ESTAT:DATA_PROVIDERS(1.0).OECD",
+        StructureType.DATA_PROVIDER_SCHEME,
+    ),
 ]
 
 

--- a/tests/api/qb/structure/test_structure_query_factory.py
+++ b/tests/api/qb/structure/test_structure_query_factory.py
@@ -139,7 +139,7 @@ def test_from_maintainable_urn(urn, expected_type):
     assert q.agency_id != REST_ALL
     assert q.resource_id != REST_ALL
     assert q.version != REST_LATEST
-    assert q.item_id is None
+    assert q.item_id == REST_ALL
 
 
 item_urns = [


### PR DESCRIPTION
This PR adds a factory method to `StructureQuery` and `RefMetaByMetadatasetQuery`. The factory methods allow creating an instance of these queries out of a reference object or an SDMX URN.

Close #289