### PR TITLE
Failure to read SDMX-ML 2.1 Generic message when Obs has no ObsValue

### DIFF
--- a/src/pysdmx/io/xml/sdmx21/reader/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/generic.py
@@ -87,7 +87,7 @@ def __reading_generic_all(dataset: Dict[str, Any]) -> pd.DataFrame:
         obs = {
             **obs,
             **__get_element_to_list(data, mode=OBS_KEY),
-            OBS_VALUE_ID: data[OBS_VALUE_XML_TAG][VALUE.lower()],
+            OBS_VALUE_ID: data[OBS_VALUE_XML_TAG][VALUE.lower()] if OBS_VALUE_XML_TAG in data else "",
         }
         if ATTRIBUTES in data:
             obs = {**obs, **__get_element_to_list(data, mode=ATTRIBUTES)}

--- a/src/pysdmx/io/xml/sdmx21/reader/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/generic.py
@@ -58,7 +58,7 @@ def __reading_generic_series(dataset: Dict[str, Any]) -> pd.DataFrame:
             for data in series[OBS]:
                 obs = {
                     OBS_DIM: data[OBS_DIM][VALUE.lower()],
-                    OBS_VALUE_ID: data[OBS_VALUE_XML_TAG][VALUE.lower()],
+                    OBS_VALUE_ID: data[OBS_VALUE_XML_TAG][VALUE.lower()] if OBS_VALUE_XML_TAG in data else "",
                 }
                 if ATTRIBUTES in data:
                     obs = {

--- a/src/pysdmx/io/xml/sdmx21/reader/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/generic.py
@@ -58,7 +58,9 @@ def __reading_generic_series(dataset: Dict[str, Any]) -> pd.DataFrame:
             for data in series[OBS]:
                 obs = {
                     OBS_DIM: data[OBS_DIM][VALUE.lower()],
-                    OBS_VALUE_ID: data[OBS_VALUE_XML_TAG][VALUE.lower()] if OBS_VALUE_XML_TAG in data else "",
+                    OBS_VALUE_ID: data[OBS_VALUE_XML_TAG][VALUE.lower()]
+                    if OBS_VALUE_XML_TAG in data
+                    else "",
                 }
                 if ATTRIBUTES in data:
                     obs = {
@@ -87,7 +89,9 @@ def __reading_generic_all(dataset: Dict[str, Any]) -> pd.DataFrame:
         obs = {
             **obs,
             **__get_element_to_list(data, mode=OBS_KEY),
-            OBS_VALUE_ID: data[OBS_VALUE_XML_TAG][VALUE.lower()] if OBS_VALUE_XML_TAG in data else "",
+            OBS_VALUE_ID: data[OBS_VALUE_XML_TAG][VALUE.lower()]
+            if OBS_VALUE_XML_TAG in data
+            else "",
         }
         if ATTRIBUTES in data:
             obs = {**obs, **__get_element_to_list(data, mode=ATTRIBUTES)}

--- a/tests/io/xml/sdmx21/reader/samples/gen_all.xml
+++ b/tests/io/xml/sdmx21/reader/samples/gen_all.xml
@@ -40,7 +40,6 @@
                 <generic:Value id="DER_BASIS" value="C"/>
                 <generic:Value id="TIME_PERIOD" value="2002"/>
             </generic:ObsKey>
-            <generic:ObsValue value=""/>
             <generic:Attributes>
                 <generic:Value id="AVAILABILITY" value="K"/>
                 <generic:Value id="COLLECTION" value="S"/>

--- a/tests/io/xml/sdmx21/reader/samples/gen_ser.xml
+++ b/tests/io/xml/sdmx21/reader/samples/gen_ser.xml
@@ -45,7 +45,6 @@
             </generic:Attributes>
             <generic:Obs>
                 <generic:ObsDimension value="2002"/>
-                <generic:ObsValue value=""/>
                 <generic:Attributes>
                     <generic:Value id="OBS_STATUS" value="M"/>
                     <generic:Value id="OBS_CONF" value="F"/>


### PR DESCRIPTION
# Summary of changes
- Added inline if to ensure we read an empty value when the ObsValue tag is missing
- Modified SDMX-ML 2.1 Generic test files to cover this case