### PR TITLE
Raise an error when trying to write a DataStructureDefinition with more than one measure in SDMX-ML 2.1

### DIFF
--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -381,7 +381,7 @@ def __write_item(
 
 
 def __write_components(
-    item: DataStructureDefinition, indent: str, references_30: bool = False
+    dsd: DataStructureDefinition, indent: str, references_30: bool = False
 ) -> str:
     """Writes the components to the XML file."""
     outfile = f"{indent}<{ABBR_STR}:{DSD_COMPS}>"
@@ -392,13 +392,19 @@ def __write_components(
         PRIM_MEASURE: [],
     }
 
-    for comp in item.components:
+    for comp in dsd.components:
         if comp.role == Role.DIMENSION:
             components[DIM].append(comp)
         elif comp.role == Role.ATTRIBUTE:
             components[ATT].append(comp)
         else:
             components[PRIM_MEASURE].append(comp)
+
+    if not references_30 and len(components[PRIM_MEASURE]) > 1:
+        raise Invalid(
+            f"SDMX-ML 2.1 does not support multiple measures. "
+            f"Check the {dsd.short_urn}."
+        )
 
     position = 1
     for _, comps in components.items():

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -404,8 +404,12 @@ def __write_components(
 
     if not references_30 and len(components[PRIM_MEASURE]) > 1:
         raise Invalid(
-            f"SDMX-ML 2.1 does not support multiple measures. "
-            f"Check the {dsd.short_urn}."
+            title="Request cannot be fulfilled",
+            description=f"SDMX-ML 2.1 does not support multiple measures. "
+            f"Check the {dsd.short_urn}.",
+            csi={
+                "measures_found": components[PRIM_MEASURE],
+            },
         )
 
     position = 1

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -515,57 +515,106 @@ def datastructure(concept_ds):
         version="7.0",
         agency="ESTAT",
         is_final=True,
-        components=[
-            Component(
-                id="freq_dim",
-                required=True,
-                role=Role.DIMENSION,
-                concept=concept_ds.concepts[0],
-                local_facets=Facets(min_length="1", max_length="1"),
-                urn="urn:sdmx:org.sdmx.infomodel.datastructure."
-                "TimeDimension=ESTAT:HLTH_RS_PRSHP1(7.0).FREQ",
-            ),
-            Component(
-                id="DIM2",
-                required=True,
-                role=Role.DIMENSION,
-                # Missing Concept Scheme
-                concept=ItemReference(
-                    id="CS_FREQ2",
-                    sdmx_type=CON,
-                    agency="BIS",
-                    version="1.0",
-                    item_id="DIM2",
+        components=Components(
+            [
+                Component(
+                    id="freq_dim",
+                    required=True,
+                    role=Role.DIMENSION,
+                    concept=concept_ds.concepts[0],
+                    local_facets=Facets(min_length="1", max_length="1"),
+                    urn="urn:sdmx:org.sdmx.infomodel.datastructure."
+                    "TimeDimension=ESTAT:HLTH_RS_PRSHP1(7.0).FREQ",
                 ),
-                local_facets=Facets(min_length="1", max_length="1"),
-                urn="urn:sdmx:org.sdmx.infomodel.datastructure."
-                "TimeDimension=ESTAT:HLTH_RS_PRSHP1(7.0).DIM2",
-            ),
-            Component(
-                id="DIM3",
-                required=True,
-                role=Role.DIMENSION,
-                # Missing Concept in Concept Identity
-                concept=ItemReference(
-                    id="CS_FREQ",
-                    sdmx_type=CON,
-                    agency="BIS",
-                    version="1.0",
-                    item_id="DIM3",
+                Component(
+                    id="DIM2",
+                    required=True,
+                    role=Role.DIMENSION,
+                    # Missing Concept Scheme
+                    concept=ItemReference(
+                        id="CS_FREQ2",
+                        sdmx_type=CON,
+                        agency="BIS",
+                        version="1.0",
+                        item_id="DIM2",
+                    ),
+                    local_facets=Facets(min_length="1", max_length="1"),
+                    urn="urn:sdmx:org.sdmx.infomodel.datastructure."
+                    "TimeDimension=ESTAT:HLTH_RS_PRSHP1(7.0).DIM2",
                 ),
-                local_facets=Facets(min_length="1", max_length="1"),
-                urn="urn:sdmx:org.sdmx.infomodel.datastructure."
-                "TimeDimension=ESTAT:HLTH_RS_PRSHP1(7.0).DIM2",
-            ),
-            Component(
-                id="OBS_VALUE",
-                required=True,
-                role=Role.MEASURE,
-                concept=concept_ds.concepts[1],
-                urn="urn:sdmx:org.sdmx.infomodel.datastructure."
-                "PrimaryMeasure=ESTAT:HLTH_RS_PRSHP1(7.0).OBS_VALUE",
-            ),
+                Component(
+                    id="DIM3",
+                    required=True,
+                    role=Role.DIMENSION,
+                    # Missing Concept in Concept Identity
+                    concept=ItemReference(
+                        id="CS_FREQ",
+                        sdmx_type=CON,
+                        agency="BIS",
+                        version="1.0",
+                        item_id="DIM3",
+                    ),
+                    local_facets=Facets(min_length="1", max_length="1"),
+                    urn="urn:sdmx:org.sdmx.infomodel.datastructure."
+                    "TimeDimension=ESTAT:HLTH_RS_PRSHP1(7.0).DIM2",
+                ),
+                Component(
+                    id="OBS_VALUE",
+                    required=True,
+                    role=Role.MEASURE,
+                    concept=concept_ds.concepts[1],
+                    urn="urn:sdmx:org.sdmx.infomodel.datastructure."
+                    "PrimaryMeasure=ESTAT:HLTH_RS_PRSHP1(7.0).OBS_VALUE",
+                ),
+            ]
+        ),
+        description="Healthcare resource partnership statistics",
+    )
+
+
+@pytest.fixture
+def datastructure_two_measures(concept_ds):
+    return DataStructureDefinition(
+        annotations=[
+            Annotation(title="OBS_FLAG", type="DISSEMINATION_FLAG_SETTINGS"),
+            Annotation(title="time", type="DISSEMINATION_TIME_DIMENSION_CODE"),
         ],
+        urn="urn:sdmx:org.sdmx.infomodel.datastructure."
+        "DataStructure=ESTAT:HLTH_RS_PRSHP1(7.0)",
+        id="HLTH_RS_PRSHP1",
+        name="HLTH_RS_PRSHP1",
+        version="7.0",
+        agency="ESTAT",
+        is_final=True,
+        components=Components(
+            [
+                Component(
+                    id="freq_dim",
+                    required=True,
+                    role=Role.DIMENSION,
+                    concept=concept_ds.concepts[0],
+                    local_facets=Facets(min_length="1", max_length="1"),
+                    urn="urn:sdmx:org.sdmx.infomodel.datastructure."
+                    "TimeDimension=ESTAT:HLTH_RS_PRSHP1(7.0).FREQ",
+                ),
+                Component(
+                    id="OBS_VALUE_1",
+                    required=True,
+                    role=Role.MEASURE,
+                    concept=concept_ds.concepts[1],
+                    urn="urn:sdmx:org.sdmx.infomodel.datastructure."
+                    "PrimaryMeasure=ESTAT:HLTH_RS_PRSHP1(7.0).OBS_VALUE_1",
+                ),
+                Component(
+                    id="OBS_VALUE_2",
+                    required=True,
+                    role=Role.MEASURE,
+                    concept=concept_ds.concepts[1],
+                    urn="urn:sdmx:org.sdmx.infomodel.datastructure."
+                    "PrimaryMeasure=ESTAT:HLTH_RS_PRSHP1(7.0).OBS_VALUE_2",
+                ),
+            ]
+        ),
         description="Healthcare resource partnership statistics",
     )
 
@@ -991,3 +1040,14 @@ def test_read_write_vtl_complete(vtl_complete):
         ts_2.name_personalisation_scheme, NamePersonalisationScheme
     )
     assert ts_2.name_personalisation_scheme == ts.name_personalisation_scheme
+
+
+def test_writing_more_than_one_measure(datastructure_two_measures):
+    content = [datastructure_two_measures]
+    with pytest.raises(
+        Invalid, match="SDMX-ML 2.1 does not support multiple measures"
+    ):
+        write(
+            content,
+            prettyprint=True,
+        )


### PR DESCRIPTION
# Summary of changes

- Added an error message to prevent writing SDMX-ML 2.1 when a DataStructureDefinition has multiple measures
- Refactored name of variable in write_components