### PR TITLE
pysdmx should not require xml extras

### DIFF
--- a/src/pysdmx/io/input_processor.py
+++ b/src/pysdmx/io/input_processor.py
@@ -13,8 +13,10 @@ from httpx import HTTPStatusError, create_ssl_context
 
 from pysdmx.errors import Invalid, NotImplemented
 from pysdmx.io.format import Format
-from pysdmx.io.xml.__parse_xml import SCHEMA_ROOT_31
 from pysdmx.util import map_httpx_errors
+
+SCHEMA_ROOT_31 = "http://www.sdmx.org/resources/sdmxml/schemas/v3_1/"
+SCHEMA_ROOT_30 = "http://www.sdmx.org/resources/sdmxml/schemas/v3_0/"
 
 
 def __remove_bom(input_string: str) -> str:
@@ -55,8 +57,6 @@ def __get_sdmx_ml_flavour(input_str: str) -> Tuple[str, Format]:
     flavour_check = input_str[:1000].lower()
     if ":generic" in flavour_check:
         return input_str, Format.DATA_SDMX_ML_2_1_GEN
-    # Local import to ensure xml extra is checked at the latest moment
-    from pysdmx.io.xml.__parse_xml import SCHEMA_ROOT_30
 
     if ":structurespecificdata" in flavour_check:
         if SCHEMA_ROOT_30 in flavour_check:


### PR DESCRIPTION
This affects version `1.5.0`

- Removed the xml import from input_processor