### PR TITLE
Handle series with empty dimensions

### DIFF
--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -561,3 +561,125 @@ def test_generic_writer_varying_attributes(header, content):
     assert result.count("<gen:Series>") == 2
     assert "A" in result
     assert "B" in result
+
+
+def test_all_dimensions_with_series_only_row(header):
+    # Dataset with empty DIM2
+    ds = PandasDataset(
+        data=pd.DataFrame(
+            {
+                "DIM1": ["A", "B", "C"],
+                "DIM2": ["X", "", "Z"],  # Empty dimension
+                "ATT1": ["a1", "a2", "a3"],
+                "M1": [10, 11, 12],
+            }
+        ),
+        structure=Schema(
+            context="datastructure",
+            id="TEST",
+            agency="MD",
+            version="1.0",
+            components=Components(
+                [
+                    Component(
+                        id="DIM1",
+                        role=Role.DIMENSION,
+                        concept=Concept(id="DIM1"),
+                        required=True,
+                    ),
+                    Component(
+                        id="DIM2",
+                        role=Role.DIMENSION,
+                        concept=Concept(id="DIM2"),
+                        required=True,
+                    ),
+                    Component(
+                        id="ATT1",
+                        role=Role.ATTRIBUTE,
+                        concept=Concept(id="ATT1"),
+                        required=False,
+                        attachment_level="DIM1",
+                    ),
+                    Component(
+                        id="M1",
+                        role=Role.MEASURE,
+                        concept=Concept(id="M1"),
+                        required=True,
+                    ),
+                ]
+            ),
+        ),
+    )
+
+    with pytest.raises(
+        Invalid,
+        match="AllDimensions requires all dimensions to have values. "
+        "Dimension 'DIM2' has empty values",
+    ):
+        write_str_spec(
+            [ds],
+            header=header,
+            dimension_at_observation={ds.structure.short_urn: "AllDimensions"},
+        )
+
+
+def test_series_format_with_series_no_obs(header):
+    ds = PandasDataset(
+        data=pd.DataFrame(
+            {
+                "DIM1": ["A", "A", "B"],
+                "DIM2": ["X", "Y", ""],  # B series has no obs (empty DIM2)
+                "ATT1": ["a1", "a1", "b1"],
+                "M1": [10, 11, ""],  # B series has no measure
+            }
+        ),
+        structure=Schema(
+            context="datastructure",
+            id="TEST",
+            agency="MD",
+            version="1.0",
+            components=Components(
+                [
+                    Component(
+                        id="DIM1",
+                        role=Role.DIMENSION,
+                        concept=Concept(id="DIM1"),
+                        required=True,
+                    ),
+                    Component(
+                        id="DIM2",
+                        role=Role.DIMENSION,
+                        concept=Concept(id="DIM2"),
+                        required=True,
+                    ),
+                    Component(
+                        id="ATT1",
+                        role=Role.ATTRIBUTE,
+                        concept=Concept(id="ATT1"),
+                        required=False,
+                        attachment_level="DIM1",
+                    ),
+                    Component(
+                        id="M1",
+                        role=Role.MEASURE,
+                        concept=Concept(id="M1"),
+                        required=True,
+                    ),
+                ]
+            ),
+        ),
+    )
+
+    result = write_str_spec(
+        [ds],
+        header=header,
+        prettyprint=True,
+        dimension_at_observation={ds.structure.short_urn: "DIM2"},
+    )
+
+    assert result is not None
+    # Series A should have observations
+    assert "<Series " in result
+    assert "<Obs " in result
+    # Series B should be "selfclosed" (no observations)
+    assert "/>" in result

--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -682,4 +682,4 @@ def test_series_format_with_series_no_obs(header):
     assert "<Series " in result
     assert "<Obs " in result
     # Series B should be "selfclosed" (no observations)
-    assert "/>" in result
+    assert '<Series DIM1="B" ATT1="b1" />' in result


### PR DESCRIPTION
Fixes #492 

## Issue

The writer had 2 problems:

- AllDimensions mode was outputting `<Obs>` elements with empty dimension values (e.g., `TIME_PERIOD=""`), which is invalid in SDMX.
- Was not properly handling series that have no valid observations.

## Changes

This PR implements:

- `__validate_all_dimensions_data()`: checks if any dimension column has empty values. If so, it raises an `Invalid` error with a clear message:

```
AllDimensions requires all dimensions to have values. Dimension '<the dimension>' has empty values.
```

- Series without observations are self-closed

Added `__has_valid_obs()` helper function and updated `__format_ser_str()` to output self-closing `<Series .../>` tags when a series has no valid observations, instead of `<Series>...</Series>` with empty `<Obs>` elements.

*Before:*

```xml
<Series FREQ="M" ...>
    <Obs TIME_PERIOD="" OBS_VALUE="" />
</Series>
```

*After:*

```xml
<Series FREQ="M" ... />
```

## Tests

Added:

- `test_all_dimensions_with_series_only_row()`: validates error is raised
- `test_series_format_with_series_no_obs()`: validates self-closing series tags
