### PR TITLE
Unmerge attributes with multiple values when writing to SDMX-JSON

### DIFF
--- a/src/pysdmx/io/json/sdmxjson2/messages/report.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/report.py
@@ -20,6 +20,7 @@ from pysdmx.model.metadata import (
     MetadataAttribute,
     MetadataReport,
     merge_attributes,
+    unmerge_attributes,
 )
 
 
@@ -105,7 +106,7 @@ class JsonMetadataReport(ItemSchemeType, frozen=True, omit_defaults=True):
                 "SDMX-JSON metadata reports must have a name",
                 {"metadata_report": report.id},
             )
-
+        attrs = unmerge_attributes(report.attributes)
         return JsonMetadataReport(
             agency=(
                 report.agency.id
@@ -125,10 +126,7 @@ class JsonMetadataReport(ItemSchemeType, frozen=True, omit_defaults=True):
             metadataflow=report.metadataflow,
             targets=report.targets,
             attributes=tuple(
-                [
-                    JsonMetadataAttribute.from_model(a)
-                    for a in report.attributes
-                ]
+                [JsonMetadataAttribute.from_model(a) for a in attrs]
             ),
             metadataProvisionAgreement=report.metadataProvisionAgreement,
             publicationPeriod=report.publicationPeriod,

--- a/tests/io/json/sdmxjson2/ser/test_metadatareport_ser.py
+++ b/tests/io/json/sdmxjson2/ser/test_metadatareport_ser.py
@@ -39,6 +39,34 @@ def metadata_report():
 
 
 @pytest.fixture
+def metadata_report_mult_values():
+    attr = MetadataAttribute(
+        id="ATTR1",
+        value=["test value 1", "test value 2"],
+    )
+    return MetadataReport(
+        id="MR1",
+        name="Metadata Report",
+        agency="BIS",
+        description="Test metadata report",
+        version="1.0",
+        annotations=[Annotation(type="test")],
+        is_external_reference=False,
+        valid_from=datetime.now(tz.utc),
+        valid_to=datetime.now(tz.utc),
+        metadataflow="urn:sdmx:org.sdmx.infomodel.metadatastructure.Metadataflow=BIS:MF1(1.0)",
+        targets=["TARGET1", "TARGET2"],
+        attributes=[attr],
+        metadataProvisionAgreement="MPA1",
+        publicationPeriod="2023-Q1",
+        publicationYear="2023",
+        reportingBegin="2023-01-01",
+        reportingEnd="2023-03-31",
+        action=ActionType.Append,
+    )
+
+
+@pytest.fixture
 def metadata_report_org():
     attr = MetadataAttribute(
         id="ATTR1",
@@ -82,6 +110,9 @@ def test_metadata_report(metadata_report: MetadataReport):
     assert sjson.metadataflow == metadata_report.metadataflow
     assert sjson.targets == metadata_report.targets
     assert len(sjson.attributes) == 1
+    for attr in sjson.attributes:
+        assert attr.id == "ATTR1"
+        assert attr.value == "test value"
     assert (
         sjson.metadataProvisionAgreement
         == metadata_report.metadataProvisionAgreement
@@ -102,3 +133,14 @@ def test_metadata_report_org(metadata_report_org: MetadataReport):
 def test_metadata_report_no_name(metadata_report_no_name):
     with pytest.raises(errors.Invalid, match="must have a name"):
         JsonMetadataReport.from_model(metadata_report_no_name)
+
+
+def test_metadata_report_multiple_values(
+    metadata_report_mult_values: MetadataReport,
+):
+    sjson = JsonMetadataReport.from_model(metadata_report_mult_values)
+
+    assert len(sjson.attributes) == 2
+    for attr in sjson.attributes:
+        assert attr.id == "ATTR1"
+        assert attr.value in ["test value 1", "test value 2"]


### PR DESCRIPTION
In the same way that we merge multiple attributes with the same ID when reading SDMX-JSON metadata reports, we need to unmerge them, when writing SDMX-JSON reports.

Additional details are available in #523 