### PR TITLE
Support observation-level attachments in measureless DSDs

### DIFF
--- a/src/pysdmx/io/json/fusion/messages/dsd.py
+++ b/src/pysdmx/io/json/fusion/messages/dsd.py
@@ -90,6 +90,8 @@ class FusionAttribute(Struct, frozen=True):
                 return "O"
             else:
                 return ",".join(self.measureReferences)
+        elif self.attachmentLevel == "OBSERVATION":
+            return "O"
         elif self.attachmentLevel == "DATA_SET":
             return "D"
         elif self.attachmentLevel == "GROUP":

--- a/src/pysdmx/io/json/sdmxjson2/messages/dsd.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/dsd.py
@@ -133,6 +133,8 @@ class JsonAttributeRelationship(Struct, frozen=True, omit_defaults=True):
                 return "O"
             else:
                 return ",".join(measures)
+        elif self.observation is not None:
+            return "O"
         elif self.dimensions:
             return ",".join(self.dimensions)
         elif self.group:

--- a/tests/api/fmr/dsd_checks.py
+++ b/tests/api/fmr/dsd_checks.py
@@ -62,6 +62,21 @@ def check_multi_meas(mock, fmr: RegistryClient, query, body):
             assert a.attachment_level == "OI,TO"
 
 
+def check_measureless_dsd(mock, fmr: RegistryClient, query, body):
+    """Check obs-level attachment of measureless DSDs."""
+    mock.get(query).mock(return_value=httpx.Response(200, content=body))
+
+    dsds = fmr.get_data_structures("TEST", "NM_DSD", "1.0")
+
+    assert len(mock.calls) == 1
+    dsd = dsds[0]
+
+    assert len(dsd.components.attributes) == 1
+    for a in dsd.components.attributes:
+        assert a.id == "MIC"
+        assert a.attachment_level == "O"
+
+
 def __check_content(dsds, partial_cs: bool = False):
     assert len(dsds) == 1
     dsd = dsds[0]

--- a/tests/api/fmr/fusion/test_dsds.py
+++ b/tests/api/fmr/fusion/test_dsds.py
@@ -43,6 +43,18 @@ def query_mm(fmr):
 
 
 @pytest.fixture
+def query_no_measure(fmr):
+    res = "/structure/datastructure/"
+    agency = "TEST"
+    id = "NM_DSD"
+    version = "1.0"
+    return (
+        f"{fmr.api_endpoint}{res}{agency}/{id}/{version}"
+        "?detail=referencepartial&references=descendants"
+    )
+
+
+@pytest.fixture
 def body():
     with open("tests/api/fmr/samples/dsd/dsd.fusion.json", "rb") as f:
         return f.read()
@@ -59,6 +71,14 @@ def body_partial_cs():
 @pytest.fixture
 def body_mm():
     with open("tests/api/fmr/samples/dsd/multi_meas.fusion.json", "rb") as f:
+        return f.read()
+
+
+@pytest.fixture
+def body_no_measure():
+    with open(
+        "tests/api/fmr/samples/dsd/dsd_no_measure.fusion.json", "rb"
+    ) as f:
         return f.read()
 
 
@@ -81,3 +101,10 @@ def test_multiple_measures(respx_mock, fmr, query_mm, body_mm):
 def test_dsd_partial_cs(respx_mock, fmr, query, body_partial_cs):
     """get_data_structures() returns a DSD even if concepts are missing."""
     checks.check_dsd_partial_cs(respx_mock, fmr, query, body_partial_cs)
+
+
+def test_no_measures(respx_mock, fmr, query_no_measure, body_no_measure):
+    """Observation-level attributes work in measureless DSDs."""
+    checks.check_measureless_dsd(
+        respx_mock, fmr, query_no_measure, body_no_measure
+    )

--- a/tests/api/fmr/samples/dsd/dsd_no_measure.fusion.json
+++ b/tests/api/fmr/samples/dsd/dsd_no_measure.fusion.json
@@ -1,0 +1,97 @@
+{
+    "meta": {
+        "id": "IREF851005",
+        "test": false,
+        "prepared": "2026-02-13T12:18:20Z",
+        "contentLanguages": [
+            "en"
+        ],
+        "sender": {
+            "id": "5B0_DEV"
+        }
+    },
+    "ConceptScheme": [
+        {
+            "id": "NM_DSD_CS",
+            "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=TEST:NM_DSD_CS(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Test concepts"
+                }
+            ],
+            "agencyId": "TEST",
+            "version": "1.0",
+            "isFinal": false,
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "CONTRACT_CODE",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=TEST:NM_DSD_CS(1.0).CONTRACT_CODE",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Contract Code"
+                        }
+                    ]
+                },
+                {
+                    "id": "MIC",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=TEST:NM_DSD_CS(1.0).MIC",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "MIC"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "DataStructure": [
+        {
+            "id": "NM_DSD",
+            "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=TEST:NM_DSD(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Test Schema"
+                }
+            ],
+            "agencyId": "TEST",
+            "version": "1.0",
+            "isFinal": false,
+            "dimensionList": {
+                "dimensions": [
+                    {
+                        "id": "CONTRACT_CODE",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=TEST:NM_DSD(1.0).CONTRACT_CODE",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String"
+                            }
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=TEST:NM_DSD_CS(1.0).CONTRACT_CODE"
+                    }
+                ]
+            },
+            "attributeList": {
+                "attributes": [
+                    {
+                        "id": "MIC",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=TEST:NM_DSD(1.0).MIC",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String"
+                            }
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=TEST:NM_DSD_CS(1.0).MIC",
+                        "mandatory": false,
+                        "attachmentLevel": "OBSERVATION"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/tests/api/fmr/samples/dsd/dsd_no_measure.json
+++ b/tests/api/fmr/samples/dsd/dsd_no_measure.json
@@ -1,0 +1,157 @@
+{
+    "meta": {
+        "id": "IREF697392",
+        "test": false,
+        "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+        "prepared": "2026-02-13T08:02:15Z",
+        "contentLanguages": [
+            "en"
+        ],
+        "sender": {
+            "id": "5B0_DEV"
+        }
+    },
+    "data": {
+        "conceptSchemes": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "conceptscheme",
+                        "uri": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=TEST:NM_DSD_CS(1.0)"
+                    }
+                ],
+                "id": "NM_DSD_CS",
+                "name": "Test concepts",
+                "names": {
+                    "en": "Test concepts"
+                },
+                "version": "1.0",
+                "agencyID": "TEST",
+                "isExternalReference": false,
+                "isPartial": true,
+                "concepts": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=TEST:NM_DSD_CS(1.0).CONTRACT_CODE"
+                            }
+                        ],
+                        "id": "CONTRACT_CODE",
+                        "name": "Contract Code",
+                        "names": {
+                            "en": "Contract Code"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=TEST:NM_DSD_CS(1.0).MIC"
+                            }
+                        ],
+                        "id": "MIC",
+                        "name": "MIC",
+                        "names": {
+                            "en": "MIC"
+                        }
+                    }
+                ]
+            }
+        ],
+        "dataStructures": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "datastructure",
+                        "uri": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=TEST:NM_DSD(1.0)"
+                    }
+                ],
+                "id": "NM_DSD",
+                "name": "Test Schema",
+                "names": {
+                    "en": "Test Schema"
+                },
+                "version": "1.0",
+                "agencyID": "TEST",
+                "isExternalReference": false,
+                "dataStructureComponents": {
+                    "attributeList": {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "attributedescriptor",
+                                "uri": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.AttributeDescriptor=TEST:NM_DSD(1.0).AttributeDescriptor"
+                            }
+                        ],
+                        "id": "AttributeDescriptor",
+                        "attributes": [
+                            {
+                                "usage": "optional",
+                                "attributeRelationship": {
+                                    "observation": {}
+                                },
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dataattribute",
+                                        "uri": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=TEST:NM_DSD(1.0).MIC"
+                                    }
+                                ],
+                                "id": "MIC",
+                                "localRepresentation": {
+                                    "format": {
+                                        "dataType": "String"
+                                    }
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=TEST:NM_DSD_CS(1.0).MIC"
+                            }
+                        ]
+                    },
+                    "dimensionList": {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "dimensiondescriptor",
+                                "uri": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DimensionDescriptor=TEST:NM_DSD(1.0).DimensionDescriptor"
+                            }
+                        ],
+                        "id": "DimensionDescriptor",
+                        "dimensions": [
+                            {
+                                "position": 1,
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dimension",
+                                        "uri": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=TEST:NM_DSD(1.0).CONTRACT_CODE"
+                                    }
+                                ],
+                                "id": "CONTRACT_CODE",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "dataType": "String"
+                                    }
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=TEST:NM_DSD_CS(1.0).CONTRACT_CODE"
+                            }
+                        ]
+                    },
+                    "measureList": {}
+                }
+            }
+        ]
+    }
+}

--- a/tests/api/fmr/sdmx/test_dsds.py
+++ b/tests/api/fmr/sdmx/test_dsds.py
@@ -43,6 +43,18 @@ def query_mm(fmr):
 
 
 @pytest.fixture
+def query_no_measure(fmr):
+    res = "/structure/datastructure/"
+    agency = "TEST"
+    id = "NM_DSD"
+    version = "1.0"
+    return (
+        f"{fmr.api_endpoint}{res}{agency}/{id}/{version}"
+        "?detail=referencepartial&references=descendants"
+    )
+
+
+@pytest.fixture
 def body():
     with open("tests/api/fmr/samples/dsd/dsd.json", "rb") as f:
         return f.read()
@@ -57,6 +69,12 @@ def body_partial_cs():
 @pytest.fixture
 def body_mm():
     with open("tests/api/fmr/samples/dsd/multi_meas.json", "rb") as f:
+        return f.read()
+
+
+@pytest.fixture
+def body_no_measure():
+    with open("tests/api/fmr/samples/dsd/dsd_no_measure.json", "rb") as f:
         return f.read()
 
 
@@ -79,3 +97,10 @@ def test_multiple_measures(respx_mock, fmr, query_mm, body_mm):
 def test_dsd_partial_cs(respx_mock, fmr, query, body_partial_cs):
     """get_data_structures() returns a DSD even if concepts are missing."""
     checks.check_dsd_partial_cs(respx_mock, fmr, query, body_partial_cs)
+
+
+def test_no_measures(respx_mock, fmr, query_no_measure, body_no_measure):
+    """Observation-level attributes work in measureless DSDs."""
+    checks.check_measureless_dsd(
+        respx_mock, fmr, query_no_measure, body_no_measure
+    )


### PR DESCRIPTION
It is possible to have DSDs without measures and with attributes attached to the observation-level.

In that case, pysdmx fails to infer the attachment level because the property with the measure references is missing.

The purpose of this PR is to address this issue.

Close #524 