### PR TITLE
Add SDMX-ML constraints support

### DIFF
--- a/src/pysdmx/io/json/sdmxjson2/messages/constraint.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/constraint.py
@@ -183,7 +183,11 @@ class JsonDataConstraint(MaintainableType, frozen=True, omit_defaults=True):
 
     def to_model(self) -> DataConstraint:
         """Converts a JsonDataConstraint to a pysdmx Data Constraint."""
-        at = self.constraintAttachment.to_model()  # type: ignore[union-attr]
+        at = (
+            self.constraintAttachment.to_model()
+            if self.constraintAttachment
+            else None
+        )
         return DataConstraint(
             id=self.id,
             name=self.name,

--- a/src/pysdmx/io/xml/__structure_aux_reader.py
+++ b/src/pysdmx/io/xml/__structure_aux_reader.py
@@ -1052,6 +1052,11 @@ class StructureParser(Struct):
     def __format_constraint(self, element: Dict[str, Any]) -> Dict[str, Any]:
         # role is a SDMX 3.0 attribute not present in the model
         if "role" in element:
+            if element["role"] == "Actual":
+                raise NotImplementedError(
+                    "DataConstraint with role='Actual' is not supported, "
+                    "pysdmx only supports maintainable (Allowed) constraints."
+                )
             del element["role"]
 
         # ConstraintAttachment

--- a/src/pysdmx/io/xml/__structure_aux_reader.py
+++ b/src/pysdmx/io/xml/__structure_aux_reader.py
@@ -34,18 +34,25 @@ from pysdmx.io.xml.__tokens import (
     COMPONENT_MAPS,
     COMPS,
     CON,
+    CON_CONS,
     CON_ID,
     CON_LOW,
     CON_ROLE,
     CON_SCHEMES,
     CONCEPTS,
+    CONS_ATT,
+    CONSTRAINTS,
     CONTACT,
     CORE_REP,
     CS,
+    CUBE_REGION,
     CUSTOM_TYPE,
     CUSTOM_TYPE_SCHEME,
     CUSTOM_TYPE_SCHEMES,
     CUSTOM_TYPES,
+    DATA_CONS,
+    DATA_CONSTRAINTS,
+    DATA_KEY_SET,
     DATA_PROV,
     DATE_PATTERN_MAP,
     DEPARTMENT,
@@ -74,12 +81,16 @@ from pysdmx.io.xml.__tokens import (
     GROUP_DIM,
     GROUPS_LOW,
     ID,
+    INCLUDE,
+    INCLUDED,
     IS_EXTERNAL_REF,
     IS_EXTERNAL_REF_LOW,
     IS_FINAL,
     IS_FINAL_LOW,
     IS_PARTIAL,
     IS_PARTIAL_LOW,
+    KEY,
+    KEY_VALUE,
     LINK,
     LOCAL_CODES_LOW,
     LOCAL_DTYPE,
@@ -145,6 +156,7 @@ from pysdmx.io.xml.__tokens import (
     VALID_FROM_LOW,
     VALID_TO,
     VALID_TO_LOW,
+    VALUE,
     VALUE_ITEM,
     VALUE_LIST,
     VALUE_LIST_LOW,
@@ -165,11 +177,19 @@ from pysdmx.model import (
     ComponentMap,
     Concept,
     ConceptScheme,
+    ConstraintAttachment,
+    CubeKeyValue,
+    CubeRegion,
+    CubeValue,
+    DataConstraint,
+    DataKey,
+    DataKeyValue,
     DataType,
     DatePatternMap,
     Facets,
     FixedValueMap,
     ImplicitComponentMap,
+    KeySet,
     MultiComponentMap,
     MultiValueMap,
     RepresentationMap,
@@ -234,6 +254,8 @@ STRUCTURES_MAPPING = {
     NAME_PER_SCHEME: NamePersonalisationScheme,
     CUSTOM_TYPE_SCHEME: CustomTypeScheme,
     PROV_AGREEMENTS: ProvisionAgreement,
+    CONSTRAINTS: DataConstraint,
+    DATA_CONSTRAINTS: DataConstraint,
 }
 ITEMS_CLASSES = {
     AGENCY: Agency,
@@ -329,6 +351,7 @@ class StructureParser(Struct):
     concepts: Dict[str, ConceptScheme] = {}
     datastructures: Dict[str, DataStructureDefinition] = {}
     dataflows: Dict[str, Dataflow] = {}
+    constraints: Dict[str, DataConstraint] = {}
     rulesets: Dict[str, RulesetScheme] = {}
     udos: Dict[str, UserDefinedOperatorScheme] = {}
     vtl_mappings: Dict[str, VtlMappingScheme] = {}
@@ -911,6 +934,158 @@ class StructureParser(Struct):
 
         return element
 
+    def __parse_data_provider(
+        self, attachment: Dict[str, Any]
+    ) -> Optional[str]:
+        if DATA_PROV not in attachment:
+            return None
+        dp_elem = attachment[DATA_PROV]
+        if isinstance(dp_elem, str):
+            # SDMX 3.0 format (direct URN)
+            return dp_elem
+        # SDMX 2.1 format (Ref element)
+        ref = dp_elem[REF]
+        ref_data_prov = ItemReference(
+            sdmx_type=ref[CLASS],
+            agency=ref[AGENCY_ID],
+            id=ref[PAR_ID],
+            version=ref[PAR_VER],
+            item_id=ref[ID],
+        )
+        return (
+            f"{ref_data_prov.sdmx_type}={ref_data_prov.agency}:"
+            f"{ref_data_prov.id}({ref_data_prov.version})"
+            f".{ref_data_prov.item_id}"
+        )
+
+    def __parse_references(
+        self, attachment: Dict[str, Any], key: str, sdmx_type: str
+    ) -> List[str]:
+        """Extracts and converts references to URNs."""
+        if key not in attachment:
+            return []
+        ref_list = add_list(attachment[key])
+
+        urns = []
+        for ref_elem in ref_list:
+            if isinstance(ref_elem, str):
+                # SDMX 3.0 format (direct URN)
+                urns.append(ref_elem)
+            else:
+                # SDMX 2.1 format
+                ref = ref_elem[REF]
+                urn = (
+                    f"urn:sdmx:org.sdmx.infomodel.{sdmx_type}="
+                    f"{ref[AGENCY_ID]}:{ref[ID]}({ref[VERSION]})"
+                )
+                urns.append(urn)
+        return urns
+
+    def __format_constraint_attachment(
+        self, attachment: Dict[str, Any]
+    ) -> ConstraintAttachment:
+        data_provider = self.__parse_data_provider(attachment)
+        dataflows = self.__parse_references(
+            attachment, DFW, "datastructure.Dataflow"
+        )
+        data_structures = self.__parse_references(
+            attachment, DSD, "datastructure.DataStructure"
+        )
+        provision_agreements = self.__parse_references(
+            attachment, PROV_AGREEMENT, "registry.ProvisionAgreement"
+        )
+
+        return ConstraintAttachment(
+            data_provider=data_provider,
+            data_structures=data_structures if data_structures else None,
+            dataflows=dataflows if dataflows else None,
+            provision_agreements=(
+                provision_agreements if provision_agreements else None
+            ),
+        )
+
+    def __format_cube_region(self, region_elem: Dict[str, Any]) -> CubeRegion:
+        if region_elem is None:
+            return CubeRegion(key_values=[], is_included=True)
+        is_included = True
+        if INCLUDE in region_elem:
+            is_included = region_elem[INCLUDE].lower() == "true"
+
+        key_values = []
+        if KEY_VALUE in region_elem:
+            kv_list = add_list(region_elem[KEY_VALUE])
+            for kv in kv_list:
+                values = []
+                value_list = add_list(kv[VALUE])
+                for v in value_list:
+                    value_text = v if isinstance(v, str) else v.get("#text", v)
+                    values.append(CubeValue(value=value_text))
+
+                key_values.append(CubeKeyValue(id=kv[ID], values=values))
+
+        return CubeRegion(key_values=key_values, is_included=is_included)
+
+    def __format_key_set(self, keyset_elem: Dict[str, Any]) -> KeySet:
+        is_included = keyset_elem[INCLUDED].lower() == "true"
+
+        keys = []
+        key_list = add_list(keyset_elem[KEY])
+        for k in key_list:
+            if k is None:
+                keys.append(DataKey(keys_values=[]))
+                continue
+            keys_values = []
+            if KEY_VALUE in k:
+                kv_list = add_list(k[KEY_VALUE])
+                for kv in kv_list:
+                    v = kv[VALUE]
+                    value_text = v if isinstance(v, str) else v.get("#text", v)
+
+                    keys_values.append(
+                        DataKeyValue(id=kv[ID], value=value_text)
+                    )
+
+            keys.append(DataKey(keys_values=keys_values))
+
+        return KeySet(keys=keys, is_included=is_included)
+
+    def __format_constraint(self, element: Dict[str, Any]) -> Dict[str, Any]:
+        # role is a SDMX 3.0 attribute not present in the model
+        if "role" in element:
+            del element["role"]
+
+        # ConstraintAttachment
+        constraint_attachment = None
+        if CONS_ATT in element:
+            constraint_attachment = self.__format_constraint_attachment(
+                element[CONS_ATT]
+            )
+            del element[CONS_ATT]
+
+        # CubeRegions
+        cube_regions: List[CubeRegion] = []
+        if CUBE_REGION in element:
+            region_list = add_list(element[CUBE_REGION])
+            cube_regions.extend(
+                self.__format_cube_region(region) for region in region_list
+            )
+            del element[CUBE_REGION]
+
+        # KeySets
+        key_sets: List[KeySet] = []
+        if DATA_KEY_SET in element:
+            keyset_list = add_list(element[DATA_KEY_SET])
+            key_sets.extend(
+                self.__format_key_set(keyset) for keyset in keyset_list
+            )
+            del element[DATA_KEY_SET]
+
+        element["constraint_attachment"] = constraint_attachment
+        element["cube_regions"] = cube_regions
+        element["key_sets"] = key_sets
+
+        return element
+
     def __format_vtl(self, json_vtl: Dict[str, Any]) -> Dict[str, Any]:
         # VTL Scheme Handling
         _format_lower_key("vtlVersion", json_vtl)
@@ -1278,6 +1453,8 @@ class StructureParser(Struct):
             element = self.__format_maps(element)
             if item == PROV_AGREEMENT:
                 element = self.__format_prov_agreement(element)
+            if item in [CON_CONS, DATA_CONS]:
+                element = self.__format_constraint(element)
 
             if "xmlns" in element:
                 del element["xmlns"]
@@ -1487,6 +1664,18 @@ class StructureParser(Struct):
                     data, REPRESENTATION_MAP, REPRESENTATION_MAP
                 ),
                 "representation_maps",
+            ),
+            CONSTRAINTS: process_structure(
+                CONSTRAINTS,
+                lambda data: self.__format_schema(data, CONSTRAINTS, CON_CONS),
+                "constraints",
+            ),
+            DATA_CONSTRAINTS: process_structure(
+                DATA_CONSTRAINTS,
+                lambda data: self.__format_schema(
+                    data, DATA_CONSTRAINTS, DATA_CONS
+                ),
+                "constraints",
             ),
             TRANS_SCHEMES: process_structure(
                 TRANS_SCHEMES,

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -1150,12 +1150,24 @@ def __write_structure_map(
     return outfile
 
 
-def __write_data_provider(data_provider: str, indent: str) -> str:
+def __write_data_provider(
+    data_provider: str, indent: str, references_30: bool = False
+) -> str:
     """Writes a DataProvider reference to the XML file."""
-    outfile = f"{indent}<{ABBR_STR}:DataProvider>"
-    outfile += f"{add_indent(add_indent(indent))}<{REF} "
-    outfile += f"{ID}={data_provider!r}/>"
-    outfile += f"{indent}</{ABBR_STR}:DataProvider>"
+    outfile = f"{add_indent(indent)}<{ABBR_STR}:DataProvider>"
+    if references_30:
+        # SDMX 3.0: URN
+        outfile += data_provider
+    else:
+        # SDMX 2.1: Ref with attributes
+        outfile += f"{add_indent(add_indent(indent))}<{REF} "
+        ref = parse_urn(data_provider)
+        outfile += f"{AGENCY_ID}={ref.agency!r} "
+        outfile += f"{PAR_ID}={ref.id!r} "
+        outfile += f"{PAR_VER}={ref.version!r} "
+        outfile += f"{ID}={ref.item_id!r} "
+        outfile += f"{CLASS}={DATA_PROV!r}/>"
+    outfile += f"</{ABBR_STR}:DataProvider>"
     return outfile
 
 
@@ -1226,7 +1238,9 @@ def __write_constraint_attachment(
 
     # DataProvider
     if attachment.data_provider:
-        outfile += __write_data_provider(attachment.data_provider, indent)
+        outfile += __write_data_provider(
+            attachment.data_provider, indent, references_30
+        )
 
     # DataStructures
     if attachment.data_structures:

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -1342,12 +1342,8 @@ def __write_data_constraint(
 
     data = __write_maintainable(constraint, indent, references_30)
 
-    # Add role attribute for SDMX 3.0 (required)
-
-    # TODO: add 'role' field to 'DataConstraint'
-    # to know which role to use (Allowed | Actual)
-    # In SDMX-JSON role is ignored and
-    # was deleted from JsonDataConstraint (PR #468)
+    # SDMX 3.0 requires role; pysdmx only supports maintainable (Allowed) constraints.
+    # "Actual" constraints are deprecated in SDMX 3.1
     if references_30:
         data["Attributes"] += ' role="Allowed"'
 

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -1161,7 +1161,7 @@ def __write_data_provider(
     else:
         # SDMX 2.1: Ref with attributes
         outfile += f"{add_indent(add_indent(indent))}<{REF} "
-        ref = parse_urn(data_provider)
+        ref = parse_short_item_urn(data_provider)
         outfile += f"{AGENCY_ID}={ref.agency!r} "
         outfile += f"{PAR_ID}={ref.id!r} "
         outfile += f"{PAR_VER}={ref.version!r} "

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -1342,7 +1342,8 @@ def __write_data_constraint(
 
     data = __write_maintainable(constraint, indent, references_30)
 
-    # SDMX 3.0 requires role; pysdmx only supports maintainable (Allowed) constraints.
+    # SDMX 3.0 requires role,
+    # but pysdmx only supports maintainable (Allowed) constraints.
     # "Actual" constraints are deprecated in SDMX 3.1
     if references_30:
         data["Attributes"] += ' role="Allowed"'

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -1167,6 +1167,8 @@ def __write_data_provider(
         outfile += f"{PAR_VER}={ref.version!r} "
         outfile += f"{ID}={ref.item_id!r} "
         outfile += f"{CLASS}={DATA_PROV!r}/>"
+        outfile += f"{add_indent(indent)}</{ABBR_STR}:DataProvider>"
+        return outfile
     outfile += f"</{ABBR_STR}:DataProvider>"
     return outfile
 
@@ -1187,6 +1189,8 @@ def __write_data_structure(
         outfile += f"{ID}={ref.id!r} "
         outfile += f"{VERSION}={ref.version!r} "
         outfile += f"{CLASS}={DSD!r}/>"
+        outfile += f"{add_indent(indent)}</{ABBR_STR}:DataStructure>"
+        return outfile
     outfile += f"</{ABBR_STR}:DataStructure>"
     return outfile
 
@@ -1207,6 +1211,8 @@ def __write_dataflow(
         outfile += f"{ID}={ref.id!r} "
         outfile += f"{VERSION}={ref.version!r} "
         outfile += f"{CLASS}={DFW!r}/>"
+        outfile += f"{add_indent(indent)}</{ABBR_STR}:Dataflow>"
+        return outfile
     outfile += f"</{ABBR_STR}:Dataflow>"
     return outfile
 
@@ -1226,6 +1232,8 @@ def __write_provision_agreement(
         outfile += f"{AGENCY_ID}={ref.agency!r} "
         outfile += f"{ID}={ref.id!r} "
         outfile += f"{VERSION}={ref.version!r}/>"
+        outfile += f"{add_indent(indent)}</{ABBR_STR}:ProvisionAgreement>"
+        return outfile
     outfile += f"</{ABBR_STR}:ProvisionAgreement>"
     return outfile
 

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -1155,21 +1155,21 @@ def __write_data_provider(
 ) -> str:
     """Writes a DataProvider reference to the XML file."""
     outfile = f"{add_indent(indent)}<{ABBR_STR}:DataProvider>"
+    # SDMX 3.0: URN
     if references_30:
-        # SDMX 3.0: URN
         outfile += data_provider
-    else:
-        # SDMX 2.1: Ref with attributes
-        outfile += f"{add_indent(add_indent(indent))}<{REF} "
-        ref = parse_short_item_urn(data_provider)
-        outfile += f"{AGENCY_ID}={ref.agency!r} "
-        outfile += f"{PAR_ID}={ref.id!r} "
-        outfile += f"{PAR_VER}={ref.version!r} "
-        outfile += f"{ID}={ref.item_id!r} "
-        outfile += f"{CLASS}={DATA_PROV!r}/>"
-        outfile += f"{add_indent(indent)}</{ABBR_STR}:DataProvider>"
+        outfile += f"</{ABBR_STR}:DataProvider>"
         return outfile
-    outfile += f"</{ABBR_STR}:DataProvider>"
+
+    # SDMX 2.1: Ref with attributes
+    outfile += f"{add_indent(add_indent(indent))}<{REF} "
+    ref = parse_short_item_urn(data_provider)
+    outfile += f"{AGENCY_ID}={ref.agency!r} "
+    outfile += f"{PAR_ID}={ref.id!r} "
+    outfile += f"{PAR_VER}={ref.version!r} "
+    outfile += f"{ID}={ref.item_id!r} "
+    outfile += f"{CLASS}={DATA_PROV!r}/>"
+    outfile += f"{add_indent(indent)}</{ABBR_STR}:DataProvider>"
     return outfile
 
 
@@ -1178,20 +1178,20 @@ def __write_data_structure(
 ) -> str:
     """Writes a DataStructure reference to the XML file."""
     outfile = f"{add_indent(indent)}<{ABBR_STR}:DataStructure>"
+    # SDMX 3.0: URN
     if references_30:
-        # SDMX 3.0: URN
         outfile += data_structure
-    else:
-        # SDMX 2.1: Ref with attributes
-        outfile += f"{add_indent(add_indent(indent))}<{REF} "
-        ref = parse_urn(data_structure)
-        outfile += f"{AGENCY_ID}={ref.agency!r} "
-        outfile += f"{ID}={ref.id!r} "
-        outfile += f"{VERSION}={ref.version!r} "
-        outfile += f"{CLASS}={DSD!r}/>"
-        outfile += f"{add_indent(indent)}</{ABBR_STR}:DataStructure>"
+        outfile += f"</{ABBR_STR}:DataStructure>"
         return outfile
-    outfile += f"</{ABBR_STR}:DataStructure>"
+
+    # SDMX 2.1: Ref with attributes
+    outfile += f"{add_indent(add_indent(indent))}<{REF} "
+    ref = parse_urn(data_structure)
+    outfile += f"{AGENCY_ID}={ref.agency!r} "
+    outfile += f"{ID}={ref.id!r} "
+    outfile += f"{VERSION}={ref.version!r} "
+    outfile += f"{CLASS}={DSD!r}/>"
+    outfile += f"{add_indent(indent)}</{ABBR_STR}:DataStructure>"
     return outfile
 
 
@@ -1200,20 +1200,20 @@ def __write_dataflow(
 ) -> str:
     """Writes a Dataflow reference to the XML file."""
     outfile = f"{add_indent(indent)}<{ABBR_STR}:Dataflow>"
+    # SDMX 3.0: URN
     if references_30:
-        # SDMX 3.0: URN
         outfile += dataflow
-    else:
-        # SDMX 2.1: Ref with attributes
-        outfile += f"{add_indent(add_indent(indent))}<{REF} "
-        ref = parse_urn(dataflow)
-        outfile += f"{AGENCY_ID}={ref.agency!r} "
-        outfile += f"{ID}={ref.id!r} "
-        outfile += f"{VERSION}={ref.version!r} "
-        outfile += f"{CLASS}={DFW!r}/>"
-        outfile += f"{add_indent(indent)}</{ABBR_STR}:Dataflow>"
+        outfile += f"</{ABBR_STR}:Dataflow>"
         return outfile
-    outfile += f"</{ABBR_STR}:Dataflow>"
+
+    # SDMX 2.1: Ref with attributes
+    outfile += f"{add_indent(add_indent(indent))}<{REF} "
+    ref = parse_urn(dataflow)
+    outfile += f"{AGENCY_ID}={ref.agency!r} "
+    outfile += f"{ID}={ref.id!r} "
+    outfile += f"{VERSION}={ref.version!r} "
+    outfile += f"{CLASS}={DFW!r}/>"
+    outfile += f"{add_indent(indent)}</{ABBR_STR}:Dataflow>"
     return outfile
 
 
@@ -1222,19 +1222,19 @@ def __write_provision_agreement(
 ) -> str:
     """Writes a ProvisionAgreement reference to the XML file."""
     outfile = f"{add_indent(indent)}<{ABBR_STR}:ProvisionAgreement>"
+    # SDMX 3.0: URN
     if references_30:
-        # SDMX 3.0: URN
         outfile += provision_agreement
-    else:
-        # SDMX 2.1: Ref with attributes
-        outfile += f"{add_indent(add_indent(indent))}<{REF} "
-        ref = parse_urn(provision_agreement)
-        outfile += f"{AGENCY_ID}={ref.agency!r} "
-        outfile += f"{ID}={ref.id!r} "
-        outfile += f"{VERSION}={ref.version!r}/>"
-        outfile += f"{add_indent(indent)}</{ABBR_STR}:ProvisionAgreement>"
+        outfile += f"</{ABBR_STR}:ProvisionAgreement>"
         return outfile
-    outfile += f"</{ABBR_STR}:ProvisionAgreement>"
+
+    # SDMX 2.1: Ref with attributes
+    outfile += f"{add_indent(add_indent(indent))}<{REF} "
+    ref = parse_urn(provision_agreement)
+    outfile += f"{AGENCY_ID}={ref.agency!r} "
+    outfile += f"{ID}={ref.id!r} "
+    outfile += f"{VERSION}={ref.version!r}/>"
+    outfile += f"{add_indent(indent)}</{ABBR_STR}:ProvisionAgreement>"
     return outfile
 
 

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -433,13 +433,22 @@ def __write_item(
 
 
 def __write_groups(
-    groups: list[Group], indent: str, references_30: bool = False
+    groups: list[Group],
+    indent: str,
+    dsd: DataStructureDefinition,
+    references_30: bool = False,
 ) -> str:
     out_file = ""
     for group in groups:
+        urn = group.urn
+        if urn is None:
+            urn = (
+                "urn:sdmx:org.sdmx.infomodel.datastructure"
+                ".GroupDimensionDescriptor"
+                f"={dsd.agency}:{dsd.id}({dsd.version}).{group.id}"
+            )
         out_file += (
-            f"{indent}<{ABBR_STR}:{GROUP} {URN_LOW}={group.urn!r}"
-            f" {ID}={group.id!r}>"
+            f"{indent}<{ABBR_STR}:{GROUP} {URN_LOW}={urn!r} {ID}={group.id!r}>"
         )
         for dimension in group.dimensions:
             if references_30:
@@ -482,7 +491,9 @@ def __write_components(  # noqa: C901
     out_group = ""
     groups = getattr(dsd, GROUPS_LOW, [])
     if groups is not None and len(groups) > 0:
-        out_group = __write_groups(groups, add_indent(indent), references_30)
+        out_group = __write_groups(
+            groups, add_indent(indent), dsd, references_30
+        )
 
     for comp in dsd.components:
         if comp.role == Role.DIMENSION:

--- a/src/pysdmx/io/xml/__tokens.py
+++ b/src/pysdmx/io/xml/__tokens.py
@@ -94,6 +94,7 @@ CON_SCHEMES = "ConceptSchemes"
 DSDS = "DataStructures"
 DATAFLOWS = "Dataflows"
 CONSTRAINTS = "Constraints"
+DATA_CONSTRAINTS = "DataConstraints"
 PROV_AGREEMENTS = "ProvisionAgreements"
 
 
@@ -154,6 +155,7 @@ DIM_REF = "DimensionReference"
 
 # Constraints
 CON_CONS = "ContentConstraint"
+DATA_CONS = "DataConstraint"
 CONS_ATT = "ConstraintAttachment"
 CUBE_REGION = "CubeRegion"
 CONTENT_REGION = "dataContentRegion"
@@ -163,6 +165,7 @@ DATA_KEY_SET = "DataKeySet"
 DATA_KEY_SET_LOW = "dataKeySet"
 INCLUDED = "isIncluded"
 INCLUDE = "include"
+COMPONENT = "Component"
 
 # Annotation
 ANNOTATION = "Annotation"

--- a/src/pysdmx/io/xml/__write_aux.py
+++ b/src/pysdmx/io/xml/__write_aux.py
@@ -71,6 +71,7 @@ CONCEPTS_SCHEMES = "ConceptSchemes"
 DSDS = "DataStructures"
 DATAFLOWS = "Dataflows"
 CONSTRAINTS = "Constraints"
+DATA_CONSTRAINTS = "DataConstraints"
 PROV_AGREEMENTS = "ProvisionAgreements"
 REPRESENTATION_MAPS_KEY = "RepresentationMaps"
 STRUCTURE_MAPS_KEY = "StructureMaps"
@@ -209,7 +210,7 @@ MSG_CONTENT_PKG_21 = OrderedDict(
         (CODELISTS, "Codelists"),
         (CONCEPTS, "Concepts"),
         (DSDS, "DataStructures"),
-        (CONSTRAINTS, "ContentConstraints"),
+        (CONSTRAINTS, "Constraints"),
         (REPRESENTATION_MAPS, "RepresentationMaps"),
         (STRUCTURE_MAPS, "StructureMaps"),
         (CUSTOM_TYPES, "CustomTypes"),
@@ -230,7 +231,7 @@ MSG_CONTENT_PKG_30 = OrderedDict(
         (CODELISTS, "Codelists"),
         (CONCEPTS_SCHEMES, "ConceptSchemes"),
         (DSDS, "DataStructures"),
-        (CONSTRAINTS, "ContentConstraints"),
+        (DATA_CONSTRAINTS, "DataConstraints"),
         (REPRESENTATION_MAPS, "RepresentationMaps"),
         (STRUCTURE_MAPS, "StructureMaps"),
         (CUSTOM_TYPE_SCHEMES, "CustomTypeSchemes"),

--- a/tests/io/json/sdmxjson2/deser/test_cube_constraint.py
+++ b/tests/io/json/sdmxjson2/deser/test_cube_constraint.py
@@ -1,3 +1,5 @@
+import json
+
 import msgspec
 import pytest
 
@@ -47,3 +49,18 @@ def test_cube_deser(body):
             assert v.value == "N"
             assert v.valid_from is None
             assert v.valid_to is None
+
+
+def test_cube_deser_without_attachment(body):
+    data = json.loads(body)
+    constraint = data["data"]["dataConstraints"][0]
+    del constraint["constraintAttachment"]
+    modified_body = json.dumps(data).encode()
+
+    res = msgspec.json.Decoder(JsonDataConstraintMessage).decode(modified_body)
+    cubes = res.to_model()
+
+    assert len(cubes) == 1
+    cube = cubes[0]
+    assert isinstance(cube, DataConstraint)
+    assert cube.constraint_attachment is None

--- a/tests/io/xml/sdmx21/reader/samples/constraint_cube.xml
+++ b/tests/io/xml/sdmx21/reader/samples/constraint_cube.xml
@@ -28,6 +28,13 @@
 						<com:Value>UK</com:Value>
 					</com:KeyValue>
 				</str:CubeRegion>
+				<str:CubeRegion>
+					<com:Attribute id="OBS_STATUS">
+						<com:Value>A</com:Value>
+					</com:Attribute>
+				</str:CubeRegion>
+				<str:CubeRegion>
+				</str:CubeRegion>
 			</str:ContentConstraint>
 		</str:Constraints>
 	</mes:Structures>

--- a/tests/io/xml/sdmx21/reader/samples/constraint_cube.xml
+++ b/tests/io/xml/sdmx21/reader/samples/constraint_cube.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Constraints>
+			<str:ContentConstraint id="TEST_CONSTRAINT_CUBE" version="1.0" isExternalReference="false" isFinal="false" agencyID="TEST_AGENCY">
+				<com:Name xml:lang="en">Test Constraint with Cube Region</com:Name>
+				<com:Description xml:lang="en">A test constraint with cube region</com:Description>
+				<str:ConstraintAttachment>
+					<str:Dataflow>
+						<Ref agencyID="TEST_AGENCY" id="TEST_DF" version="1.0" class="Dataflow"/>
+					</str:Dataflow>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<com:KeyValue id="FREQ">
+						<com:Value>M</com:Value>
+						<com:Value>Q</com:Value>
+					</com:KeyValue>
+					<com:KeyValue id="REF_AREA">
+						<com:Value>US</com:Value>
+						<com:Value>UK</com:Value>
+					</com:KeyValue>
+				</str:CubeRegion>
+			</str:ContentConstraint>
+		</str:Constraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/reader/samples/constraint_datastructure.xml
+++ b/tests/io/xml/sdmx21/reader/samples/constraint_datastructure.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Constraints>
+			<str:ContentConstraint id="TEST_CONSTRAINT_DSD" version="1.0" isExternalReference="false" isFinal="false" agencyID="TEST_AGENCY">
+				<com:Name xml:lang="en">Test Constraint with Data Structure</com:Name>
+				<com:Description xml:lang="en">A test constraint attached to a data structure</com:Description>
+				<str:ConstraintAttachment>
+					<str:DataStructure>
+						<Ref agencyID="TEST_AGENCY" id="TEST_DSD" version="1.0" class="DataStructure"/>
+					</str:DataStructure>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<com:KeyValue id="FREQ">
+						<com:Value>A</com:Value>
+					</com:KeyValue>
+				</str:CubeRegion>
+			</str:ContentConstraint>
+		</str:Constraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/reader/samples/constraint_keyset.xml
+++ b/tests/io/xml/sdmx21/reader/samples/constraint_keyset.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Constraints>
+			<str:ContentConstraint id="TEST_CONSTRAINT_KEYSET" version="1.0" isExternalReference="false" isFinal="false" agencyID="TEST_AGENCY">
+				<com:Name xml:lang="en">Test Constraint with Key Set</com:Name>
+				<com:Description xml:lang="en">A test constraint with key set</com:Description>
+				<str:ConstraintAttachment>
+					<str:Dataflow>
+						<Ref agencyID="TEST_AGENCY" id="TEST_DF" version="1.0" class="Dataflow"/>
+					</str:Dataflow>
+				</str:ConstraintAttachment>
+				<str:DataKeySet isIncluded="true">
+					<str:Key>
+						<com:KeyValue id="FREQ">
+							<com:Value>M</com:Value>
+						</com:KeyValue>
+						<com:KeyValue id="REF_AREA">
+							<com:Value>US</com:Value>
+						</com:KeyValue>
+					</str:Key>
+					<str:Key>
+						<com:KeyValue id="FREQ">
+							<com:Value>Q</com:Value>
+						</com:KeyValue>
+						<com:KeyValue id="REF_AREA">
+							<com:Value>UK</com:Value>
+						</com:KeyValue>
+					</str:Key>
+				</str:DataKeySet>
+			</str:ContentConstraint>
+		</str:Constraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/reader/samples/constraint_no_attachment.xml
+++ b/tests/io/xml/sdmx21/reader/samples/constraint_no_attachment.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Constraints>
+			<str:ContentConstraint id="TEST_CONSTRAINT_NO_ATTACH" version="1.0" isExternalReference="false" isFinal="false" agencyID="TEST_AGENCY">
+				<com:Name xml:lang="en">Test Constraint without Attachment</com:Name>
+				<com:Description xml:lang="en">A test constraint without constraint attachment</com:Description>
+				<str:CubeRegion include="true">
+					<com:KeyValue id="FREQ">
+						<com:Value>Q</com:Value>
+					</com:KeyValue>
+				</str:CubeRegion>
+			</str:ContentConstraint>
+		</str:Constraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/reader/samples/constraint_provider.xml
+++ b/tests/io/xml/sdmx21/reader/samples/constraint_provider.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Constraints>
+			<str:ContentConstraint id="TEST_CONSTRAINT_PROV" version="1.0" isExternalReference="false" isFinal="false" agencyID="TEST_AGENCY">
+				<com:Name xml:lang="en">Test Constraint with Provider</com:Name>
+				<com:Description xml:lang="en">A test constraint attached to a provider</com:Description>
+				<str:ConstraintAttachment>
+					<str:DataProvider>
+						<Ref agencyID="TEST_AGENCY" maintainableParentID="DATA_PROVIDERS" maintainableParentVersion="1.0" id="PROVIDER_ID" class="DataProvider"/>
+					</str:DataProvider>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<com:KeyValue id="FREQ">
+						<com:Value>M</com:Value>
+					</com:KeyValue>
+				</str:CubeRegion>
+			</str:ContentConstraint>
+		</str:Constraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/reader/samples/constraint_provision_agreement.xml
+++ b/tests/io/xml/sdmx21/reader/samples/constraint_provision_agreement.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Constraints>
+			<str:ContentConstraint id="TEST_CONSTRAINT_PA" version="1.0" isExternalReference="false" isFinal="false" agencyID="TEST_AGENCY">
+				<com:Name xml:lang="en">Test Constraint with Provision Agreement</com:Name>
+				<com:Description xml:lang="en">A test constraint attached to a provision agreement</com:Description>
+				<str:ConstraintAttachment>
+					<str:ProvisionAgreement>
+						<Ref agencyID="TEST_AGENCY" id="TEST_PA" version="1.0"/>
+					</str:ProvisionAgreement>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<com:KeyValue id="FREQ">
+						<com:Value>A</com:Value>
+					</com:KeyValue>
+				</str:CubeRegion>
+			</str:ContentConstraint>
+		</str:Constraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/reader/test_reader.py
+++ b/tests/io/xml/sdmx21/reader/test_reader.py
@@ -1028,7 +1028,7 @@ def test_constraint_with_cube_region(samples_folder):
         "Dataflow=TEST_AGENCY:TEST_DF(1.0)"
     ]
     # Cube Region
-    assert len(constraint.cube_regions) == 1
+    assert len(constraint.cube_regions) == 3
     region = constraint.cube_regions[0]
     assert isinstance(region, CubeRegion)
     assert region.is_included is True
@@ -1039,6 +1039,16 @@ def test_constraint_with_cube_region(samples_folder):
     assert [v.value for v in region.key_values[0].values] == ["M", "Q"]
     assert region.key_values[1].id == "REF_AREA"
     assert [v.value for v in region.key_values[1].values] == ["US", "UK"]
+    # CubeRegion without include attr and no KeyValue
+    region2 = constraint.cube_regions[1]
+    assert isinstance(region2, CubeRegion)
+    assert region2.is_included is True
+    assert len(region2.key_values) == 0
+    # Empty CubeRegion
+    region3 = constraint.cube_regions[2]
+    assert isinstance(region3, CubeRegion)
+    assert region3.is_included is True
+    assert len(region3.key_values) == 0
 
 
 def test_constraint_with_keyset(samples_folder):

--- a/tests/io/xml/sdmx21/writer/samples/constraint_cube.xml
+++ b/tests/io/xml/sdmx21/writer/samples/constraint_cube.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Constraints>
+			<str:ContentConstraint id="TEST_CONSTRAINT_CUBE" version="1.0" isExternalReference="false" isFinal="false" agencyID="TEST_AGENCY">
+				<com:Name xml:lang="en">Test Constraint with Cube Region</com:Name>
+				<com:Description xml:lang="en">A test constraint with cube region</com:Description>
+				<str:ConstraintAttachment>
+					<str:Dataflow>
+						<Ref agencyID="TEST_AGENCY" id="TEST_DF" version="1.0" class="Dataflow"/>
+					</str:Dataflow>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<com:KeyValue id="FREQ">
+						<com:Value>M</com:Value>
+						<com:Value>Q</com:Value>
+					</com:KeyValue>
+					<com:KeyValue id="REF_AREA">
+						<com:Value>US</com:Value>
+						<com:Value>UK</com:Value>
+					</com:KeyValue>
+				</str:CubeRegion>
+			</str:ContentConstraint>
+		</str:Constraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/writer/samples/constraint_cube.xml
+++ b/tests/io/xml/sdmx21/writer/samples/constraint_cube.xml
@@ -28,6 +28,8 @@
 						<com:Value>UK</com:Value>
 					</com:KeyValue>
 				</str:CubeRegion>
+				<str:CubeRegion include="true">
+				</str:CubeRegion>
 			</str:ContentConstraint>
 		</str:Constraints>
 	</mes:Structures>

--- a/tests/io/xml/sdmx21/writer/samples/constraint_datastructure.xml
+++ b/tests/io/xml/sdmx21/writer/samples/constraint_datastructure.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Constraints>
+			<str:ContentConstraint id="TEST_CONSTRAINT_DSD" version="1.0" isExternalReference="false" isFinal="false" agencyID="TEST_AGENCY">
+				<com:Name xml:lang="en">Test Constraint with Data Structure</com:Name>
+				<com:Description xml:lang="en">A test constraint attached to a data structure</com:Description>
+				<str:ConstraintAttachment>
+					<str:DataStructure>
+						<Ref agencyID="TEST_AGENCY" id="TEST_DSD" version="1.0" class="DataStructure"/>
+					</str:DataStructure>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<com:KeyValue id="FREQ">
+						<com:Value>A</com:Value>
+					</com:KeyValue>
+				</str:CubeRegion>
+			</str:ContentConstraint>
+		</str:Constraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/writer/samples/constraint_keyset.xml
+++ b/tests/io/xml/sdmx21/writer/samples/constraint_keyset.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Constraints>
+			<str:ContentConstraint id="TEST_CONSTRAINT_KEYSET" version="1.0" isExternalReference="false" isFinal="false" agencyID="TEST_AGENCY">
+				<com:Name xml:lang="en">Test Constraint with Key Set</com:Name>
+				<com:Description xml:lang="en">A test constraint with key set</com:Description>
+				<str:ConstraintAttachment>
+					<str:Dataflow>
+						<Ref agencyID="TEST_AGENCY" id="TEST_DF" version="1.0" class="Dataflow"/>
+					</str:Dataflow>
+				</str:ConstraintAttachment>
+				<str:DataKeySet isIncluded="true">
+					<str:Key>
+						<com:KeyValue id="FREQ">
+							<com:Value>M</com:Value>
+						</com:KeyValue>
+						<com:KeyValue id="REF_AREA">
+							<com:Value>US</com:Value>
+						</com:KeyValue>
+					</str:Key>
+					<str:Key>
+						<com:KeyValue id="FREQ">
+							<com:Value>Q</com:Value>
+						</com:KeyValue>
+						<com:KeyValue id="REF_AREA">
+							<com:Value>UK</com:Value>
+						</com:KeyValue>
+					</str:Key>
+				</str:DataKeySet>
+			</str:ContentConstraint>
+		</str:Constraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/writer/samples/constraint_no_attachment.xml
+++ b/tests/io/xml/sdmx21/writer/samples/constraint_no_attachment.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Constraints>
+			<str:ContentConstraint id="TEST_CONSTRAINT_NO_ATTACH" version="1.0" isExternalReference="false" isFinal="false" agencyID="TEST_AGENCY">
+				<com:Name xml:lang="en">Test Constraint without Attachment</com:Name>
+				<com:Description xml:lang="en">A test constraint without constraint attachment</com:Description>
+				<str:CubeRegion include="true">
+					<com:KeyValue id="FREQ">
+						<com:Value>Q</com:Value>
+					</com:KeyValue>
+				</str:CubeRegion>
+			</str:ContentConstraint>
+		</str:Constraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/writer/samples/constraint_provider.xml
+++ b/tests/io/xml/sdmx21/writer/samples/constraint_provider.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Constraints>
+			<str:ContentConstraint id="TEST_CONSTRAINT_PROV" version="1.0" isExternalReference="false" isFinal="false" agencyID="TEST_AGENCY">
+				<com:Name xml:lang="en">Test Constraint with Provider</com:Name>
+				<com:Description xml:lang="en">A test constraint attached to a provider</com:Description>
+				<str:ConstraintAttachment>
+					<str:DataProvider>
+						<Ref agencyID="TEST_AGENCY" maintainableParentID="DATA_PROVIDERS" maintainableParentVersion="1.0" id="PROVIDER_ID" class="DataProvider"/>
+					</str:DataProvider>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<com:KeyValue id="FREQ">
+						<com:Value>M</com:Value>
+					</com:KeyValue>
+				</str:CubeRegion>
+			</str:ContentConstraint>
+		</str:Constraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/writer/samples/constraint_provision_agreement.xml
+++ b/tests/io/xml/sdmx21/writer/samples/constraint_provision_agreement.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Constraints>
+			<str:ContentConstraint id="TEST_CONSTRAINT_PA" version="1.0" isExternalReference="false" isFinal="false" agencyID="TEST_AGENCY">
+				<com:Name xml:lang="en">Test Constraint with Provision Agreement</com:Name>
+				<com:Description xml:lang="en">A test constraint attached to a provision agreement</com:Description>
+				<str:ConstraintAttachment>
+					<str:ProvisionAgreement>
+						<Ref agencyID="TEST_AGENCY" id="TEST_PA" version="1.0"/>
+					</str:ProvisionAgreement>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<com:KeyValue id="FREQ">
+						<com:Value>A</com:Value>
+					</com:KeyValue>
+				</str:CubeRegion>
+			</str:ContentConstraint>
+		</str:Constraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -828,6 +828,10 @@ def constraint_with_cube():
                 ],
                 is_included=True,
             ),
+            CubeRegion(
+                key_values=[],
+                is_included=True,
+            ),
         ],
         key_sets=[],
     )

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -19,9 +19,17 @@ from pysdmx.model import (
     Codelist,
     Concept,
     ConceptScheme,
+    ConstraintAttachment,
+    CubeKeyValue,
+    CubeRegion,
+    CubeValue,
     CustomTypeScheme,
+    DataConstraint,
+    DataKey,
+    DataKeyValue,
     Facets,
     FromVtlMapping,
+    KeySet,
     NamePersonalisationScheme,
     Ruleset,
     RulesetScheme,
@@ -783,6 +791,259 @@ def prov_agreement_sample():
         return f.read()
 
 
+@pytest.fixture
+def constraint_with_cube():
+    return DataConstraint(
+        id="TEST_CONSTRAINT_CUBE",
+        name="Test Constraint with Cube Region",
+        agency="TEST_AGENCY",
+        version="1.0",
+        description="A test constraint with cube region",
+        constraint_attachment=ConstraintAttachment(
+            data_provider=None,
+            dataflows=[
+                "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow="
+                "TEST_AGENCY:TEST_DF(1.0)"
+            ],
+            data_structures=None,
+            provision_agreements=None,
+        ),
+        cube_regions=[
+            CubeRegion(
+                key_values=[
+                    CubeKeyValue(
+                        id="FREQ",
+                        values=[
+                            CubeValue(value="M"),
+                            CubeValue(value="Q"),
+                        ],
+                    ),
+                    CubeKeyValue(
+                        id="REF_AREA",
+                        values=[
+                            CubeValue(value="US"),
+                            CubeValue(value="UK"),
+                        ],
+                    ),
+                ],
+                is_included=True,
+            ),
+        ],
+        key_sets=[],
+    )
+
+
+@pytest.fixture
+def constraint_with_keyset():
+    return DataConstraint(
+        id="TEST_CONSTRAINT_KEYSET",
+        name="Test Constraint with Key Set",
+        agency="TEST_AGENCY",
+        version="1.0",
+        description="A test constraint with key set",
+        constraint_attachment=ConstraintAttachment(
+            data_provider=None,
+            dataflows=[
+                "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow="
+                "TEST_AGENCY:TEST_DF(1.0)"
+            ],
+            data_structures=None,
+            provision_agreements=None,
+        ),
+        cube_regions=[],
+        key_sets=[
+            KeySet(
+                keys=[
+                    DataKey(
+                        keys_values=[
+                            DataKeyValue(id="FREQ", value="M"),
+                            DataKeyValue(id="REF_AREA", value="US"),
+                        ],
+                        valid_from=None,
+                        valid_to=None,
+                    ),
+                    DataKey(
+                        keys_values=[
+                            DataKeyValue(id="FREQ", value="Q"),
+                            DataKeyValue(id="REF_AREA", value="UK"),
+                        ],
+                        valid_from=None,
+                        valid_to=None,
+                    ),
+                ],
+                is_included=True,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def constraint_cube_sample():
+    base_path = Path(__file__).parent / "samples" / "constraint_cube.xml"
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def constraint_keyset_sample():
+    base_path = Path(__file__).parent / "samples" / "constraint_keyset.xml"
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def constraint_with_data_structure():
+    return DataConstraint(
+        id="TEST_CONSTRAINT_DSD",
+        name="Test Constraint with Data Structure",
+        agency="TEST_AGENCY",
+        version="1.0",
+        description="A test constraint attached to a data structure",
+        constraint_attachment=ConstraintAttachment(
+            data_provider=None,
+            dataflows=None,
+            data_structures=[
+                "urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure="
+                "TEST_AGENCY:TEST_DSD(1.0)"
+            ],
+            provision_agreements=None,
+        ),
+        cube_regions=[
+            CubeRegion(
+                key_values=[
+                    CubeKeyValue(
+                        id="FREQ",
+                        values=[CubeValue(value="A")],
+                    ),
+                ],
+                is_included=True,
+            ),
+        ],
+        key_sets=[],
+    )
+
+
+@pytest.fixture
+def constraint_with_provider():
+    return DataConstraint(
+        id="TEST_CONSTRAINT_PROV",
+        name="Test Constraint with Provider",
+        agency="TEST_AGENCY",
+        version="1.0",
+        description="A test constraint attached to a provider",
+        constraint_attachment=ConstraintAttachment(
+            data_provider="DataProvider=TEST_AGENCY:DATA_PROVIDERS(1.0).PROVIDER_ID",
+            dataflows=None,
+            data_structures=None,
+            provision_agreements=None,
+        ),
+        cube_regions=[
+            CubeRegion(
+                key_values=[
+                    CubeKeyValue(
+                        id="FREQ",
+                        values=[CubeValue(value="M")],
+                    ),
+                ],
+                is_included=True,
+            ),
+        ],
+        key_sets=[],
+    )
+
+
+@pytest.fixture
+def constraint_datastructure_sample():
+    base_path = (
+        Path(__file__).parent / "samples" / "constraint_datastructure.xml"
+    )
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def constraint_provider_sample():
+    base_path = Path(__file__).parent / "samples" / "constraint_provider.xml"
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def constraint_with_provision_agreement():
+    return DataConstraint(
+        id="TEST_CONSTRAINT_PA",
+        name="Test Constraint with Provision Agreement",
+        agency="TEST_AGENCY",
+        version="1.0",
+        description="A test constraint attached to a provision agreement",
+        constraint_attachment=ConstraintAttachment(
+            data_provider=None,
+            dataflows=None,
+            data_structures=None,
+            provision_agreements=[
+                "urn:sdmx:org.sdmx.infomodel.registry.ProvisionAgreement="
+                "TEST_AGENCY:TEST_PA(1.0)"
+            ],
+        ),
+        cube_regions=[
+            CubeRegion(
+                key_values=[
+                    CubeKeyValue(
+                        id="FREQ",
+                        values=[CubeValue(value="A")],
+                    ),
+                ],
+                is_included=True,
+            ),
+        ],
+        key_sets=[],
+    )
+
+
+@pytest.fixture
+def constraint_provision_agreement_sample():
+    base_path = (
+        Path(__file__).parent
+        / "samples"
+        / "constraint_provision_agreement.xml"
+    )
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def constraint_without_attachment():
+    return DataConstraint(
+        id="TEST_CONSTRAINT_NO_ATTACH",
+        name="Test Constraint without Attachment",
+        agency="TEST_AGENCY",
+        version="1.0",
+        description="A test constraint without constraint attachment",
+        constraint_attachment=None,
+        cube_regions=[
+            CubeRegion(
+                key_values=[
+                    CubeKeyValue(
+                        id="FREQ",
+                        values=[CubeValue(value="Q")],
+                    ),
+                ],
+                is_included=True,
+            ),
+        ],
+        key_sets=[],
+    )
+
+
+@pytest.fixture
+def constraint_no_attachment_sample():
+    base_path = (
+        Path(__file__).parent / "samples" / "constraint_no_attachment.xml"
+    )
+    with open(base_path, "r") as f:
+        return f.read()
+
+
 def test_codelist(codelist_sample, complete_header, codelist):
     content = [codelist]
     result = write(
@@ -1182,3 +1443,81 @@ def test_concept_identity_without_urn():
         Invalid, match="Cannot select concept identity without URN"
     ):
         write([dsd])
+
+
+def test_constraint_with_cube_region(
+    complete_header, constraint_with_cube, constraint_cube_sample
+):
+    content = [constraint_with_cube]
+    result = write(
+        content,
+        header=complete_header,
+    )
+    read(result, validate=True)
+    assert result == constraint_cube_sample
+
+
+def test_constraint_with_keyset(
+    complete_header, constraint_with_keyset, constraint_keyset_sample
+):
+    content = [constraint_with_keyset]
+    result = write(
+        content,
+        header=complete_header,
+    )
+    read(result, validate=True)
+    assert result == constraint_keyset_sample
+
+
+def test_constraint_with_data_structure(
+    complete_header,
+    constraint_with_data_structure,
+    constraint_datastructure_sample,
+):
+    content = [constraint_with_data_structure]
+    result = write(
+        content,
+        header=complete_header,
+    )
+    read(result, validate=True)
+    assert result == constraint_datastructure_sample
+
+
+def test_constraint_with_provider(
+    complete_header, constraint_with_provider, constraint_provider_sample
+):
+    content = [constraint_with_provider]
+    result = write(
+        content,
+        header=complete_header,
+    )
+    read(result, validate=True)
+    assert result == constraint_provider_sample
+
+
+def test_constraint_with_provision_agreement(
+    complete_header,
+    constraint_with_provision_agreement,
+    constraint_provision_agreement_sample,
+):
+    content = [constraint_with_provision_agreement]
+    result = write(
+        content,
+        header=complete_header,
+    )
+    read(result, validate=True)
+    assert result == constraint_provision_agreement_sample
+
+
+def test_constraint_without_attachment(
+    complete_header,
+    constraint_without_attachment,
+    constraint_no_attachment_sample,
+):
+    content = [constraint_without_attachment]
+    result = write(
+        content,
+        header=complete_header,
+    )
+    read(result, validate=True)
+    assert result == constraint_no_attachment_sample

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -53,6 +53,7 @@ from pysdmx.model.dataflow import (
     Components,
     Dataflow,
     DataStructureDefinition,
+    Group,
     ProvisionAgreement,
     Role,
 )
@@ -1525,3 +1526,22 @@ def test_constraint_without_attachment(
     )
     read(result, validate=True)
     assert result == constraint_no_attachment_sample
+
+
+def test_write_group_without_urn(complete_header, datastructure):
+    dsd_with_group = datastructure.__replace__(
+        groups=[Group(id="Sibling", dimensions=["FREQ"])],
+    )
+    content = [dsd_with_group]
+    result = write(
+        content,
+        header=complete_header,
+        prettyprint=True,
+    )
+    expected_urn = (
+        "urn:sdmx:org.sdmx.infomodel.datastructure"
+        ".GroupDimensionDescriptor"
+        "=ESTAT:HLTH_RS_PRSHP1(7.0).Sibling"
+    )
+    assert expected_urn in result
+    read(result, validate=True)

--- a/tests/io/xml/sdmx30/reader/samples/constraint_actual.xml
+++ b/tests/io/xml/sdmx30/reader/samples/constraint_actual.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_ACTUAL" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Actual">
+				<com:Name xml:lang="en">Test Constraint with Actual Role</com:Name>
+				<str:ConstraintAttachment>
+					<str:Dataflow>urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=TEST_AGENCY:TEST_DF(1.0)</str:Dataflow>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<str:KeyValue id="FREQ">
+						<str:Value>M</str:Value>
+					</str:KeyValue>
+				</str:CubeRegion>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/reader/samples/constraint_cube.xml
+++ b/tests/io/xml/sdmx30/reader/samples/constraint_cube.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_CUBE" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Allowed">
+				<com:Name xml:lang="en">Test Constraint with Cube Region</com:Name>
+				<com:Description xml:lang="en">A test constraint with cube region</com:Description>
+				<str:ConstraintAttachment>
+					<str:Dataflow>urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=TEST_AGENCY:TEST_DF(1.0)</str:Dataflow>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<str:KeyValue id="FREQ">
+						<str:Value>M</str:Value>
+						<str:Value>Q</str:Value>
+					</str:KeyValue>
+					<str:KeyValue id="REF_AREA">
+						<str:Value>US</str:Value>
+						<str:Value>UK</str:Value>
+					</str:KeyValue>
+				</str:CubeRegion>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/reader/samples/constraint_datastructure.xml
+++ b/tests/io/xml/sdmx30/reader/samples/constraint_datastructure.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_DSD" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Allowed">
+				<com:Name xml:lang="en">Test Constraint with Data Structure</com:Name>
+				<com:Description xml:lang="en">A test constraint attached to a data structure</com:Description>
+				<str:ConstraintAttachment>
+					<str:DataStructure>urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=TEST_AGENCY:TEST_DSD(1.0)</str:DataStructure>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<str:KeyValue id="FREQ">
+						<str:Value>A</str:Value>
+					</str:KeyValue>
+				</str:CubeRegion>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/reader/samples/constraint_keyset.xml
+++ b/tests/io/xml/sdmx30/reader/samples/constraint_keyset.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_KEYSET" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Allowed">
+				<com:Name xml:lang="en">Test Constraint with Key Set</com:Name>
+				<com:Description xml:lang="en">A test constraint with key set</com:Description>
+				<str:ConstraintAttachment>
+					<str:Dataflow>urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=TEST_AGENCY:TEST_DF(1.0)</str:Dataflow>
+				</str:ConstraintAttachment>
+				<str:DataKeySet isIncluded="true">
+					<str:Key>
+						<str:KeyValue id="FREQ">
+							<str:Value>M</str:Value>
+						</str:KeyValue>
+						<str:KeyValue id="REF_AREA">
+							<str:Value>US</str:Value>
+						</str:KeyValue>
+					</str:Key>
+					<str:Key>
+						<str:KeyValue id="FREQ">
+							<str:Value>Q</str:Value>
+						</str:KeyValue>
+						<str:KeyValue id="REF_AREA">
+							<str:Value>UK</str:Value>
+						</str:KeyValue>
+					</str:Key>
+				</str:DataKeySet>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/reader/samples/constraint_keyset.xml
+++ b/tests/io/xml/sdmx30/reader/samples/constraint_keyset.xml
@@ -33,6 +33,13 @@
 							<str:Value>UK</str:Value>
 						</str:KeyValue>
 					</str:Key>
+					<str:Key>
+						<str:Component id="OBS_STATUS">
+							<str:Value>A</str:Value>
+						</str:Component>
+					</str:Key>
+					<str:Key>
+					</str:Key>
 				</str:DataKeySet>
 			</str:DataConstraint>
 		</str:DataConstraints>

--- a/tests/io/xml/sdmx30/reader/samples/constraint_no_attachment.xml
+++ b/tests/io/xml/sdmx30/reader/samples/constraint_no_attachment.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_NO_ATTACH" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Allowed">
+				<com:Name xml:lang="en">Test Constraint without Attachment</com:Name>
+				<com:Description xml:lang="en">A test constraint without constraint attachment</com:Description>
+				<str:CubeRegion include="true">
+					<str:KeyValue id="FREQ">
+						<str:Value>Q</str:Value>
+					</str:KeyValue>
+				</str:CubeRegion>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/reader/samples/constraint_provider.xml
+++ b/tests/io/xml/sdmx30/reader/samples/constraint_provider.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_PROV" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Allowed">
+				<com:Name xml:lang="en">Test Constraint with Provider</com:Name>
+				<com:Description xml:lang="en">A test constraint attached to a provider</com:Description>
+				<str:ConstraintAttachment>
+					<str:DataProvider>urn:sdmx:org.sdmx.infomodel.base.DataProvider=TEST_AGENCY:DATA_PROVIDERS(1.0).PROVIDER_ID</str:DataProvider>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<str:KeyValue id="FREQ">
+						<str:Value>M</str:Value>
+					</str:KeyValue>
+				</str:CubeRegion>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/reader/samples/constraint_provision_agreement.xml
+++ b/tests/io/xml/sdmx30/reader/samples/constraint_provision_agreement.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_PA" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Allowed">
+				<com:Name xml:lang="en">Test Constraint with Provision Agreement</com:Name>
+				<com:Description xml:lang="en">A test constraint attached to a provision agreement</com:Description>
+				<str:ConstraintAttachment>
+					<str:ProvisionAgreement>urn:sdmx:org.sdmx.infomodel.registry.ProvisionAgreement=TEST_AGENCY:TEST_PA(1.0)</str:ProvisionAgreement>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<str:KeyValue id="FREQ">
+						<str:Value>A</str:Value>
+					</str:KeyValue>
+				</str:CubeRegion>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/reader/test_reader.py
+++ b/tests/io/xml/sdmx30/reader/test_reader.py
@@ -14,11 +14,19 @@ from pysdmx.model import (
     Code,
     Codelist,
     ConceptScheme,
+    ConstraintAttachment,
     Contact,
+    CubeKeyValue,
+    CubeRegion,
+    CubeValue,
     CustomType,
     CustomTypeScheme,
+    DataConstraint,
     Dataflow,
+    DataKey,
+    DataKeyValue,
     ItemReference,
+    KeySet,
     NamePersonalisation,
     NamePersonalisationScheme,
     Reference,
@@ -695,3 +703,178 @@ def test_read_multiple_measure_relationship(samples_folder):
     attr = dsd.components.attributes[2]
     assert attr.id == "OBS_CONF"
     assert attr.attachment_level == "OBS_VALUE,OBS_VALUE1"
+
+
+def test_constraint_with_cube_region(samples_folder):
+    data_path = samples_folder / "constraint_cube.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_0
+    result = read_sdmx(input_str, validate=True).get_data_constraints()
+    assert result is not None
+    assert len(result) == 1
+    constraint = result[0]
+    assert isinstance(constraint, DataConstraint)
+    assert constraint.id == "TEST_CONSTRAINT_CUBE"
+    assert constraint.agency == "TEST_AGENCY"
+    assert constraint.version == "1.0"
+    assert constraint.name == "Test Constraint with Cube Region"
+    assert constraint.description == "A test constraint with cube region"
+    # Attachment
+    att = constraint.constraint_attachment
+    assert isinstance(att, ConstraintAttachment)
+    assert att.dataflows == [
+        "urn:sdmx:org.sdmx.infomodel.datastructure."
+        "Dataflow=TEST_AGENCY:TEST_DF(1.0)"
+    ]
+    # Cube Region
+    assert len(constraint.cube_regions) == 1
+    region = constraint.cube_regions[0]
+    assert isinstance(region, CubeRegion)
+    assert region.is_included is True
+    assert len(region.key_values) == 2
+    assert isinstance(region.key_values[0], CubeKeyValue)
+    assert region.key_values[0].id == "FREQ"
+    assert isinstance(region.key_values[0].values[0], CubeValue)
+    assert [v.value for v in region.key_values[0].values] == ["M", "Q"]
+    assert region.key_values[1].id == "REF_AREA"
+    assert [v.value for v in region.key_values[1].values] == ["US", "UK"]
+
+
+def test_constraint_with_keyset(samples_folder):
+    data_path = samples_folder / "constraint_keyset.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_0
+    result = read_sdmx(input_str, validate=True).get_data_constraints()
+    assert result is not None
+    assert len(result) == 1
+    constraint = result[0]
+    assert isinstance(constraint, DataConstraint)
+    assert constraint.id == "TEST_CONSTRAINT_KEYSET"
+    assert constraint.name == "Test Constraint with Key Set"
+    # Attachment
+    att = constraint.constraint_attachment
+    assert isinstance(att, ConstraintAttachment)
+    assert att.dataflows == [
+        "urn:sdmx:org.sdmx.infomodel.datastructure."
+        "Dataflow=TEST_AGENCY:TEST_DF(1.0)"
+    ]
+    # Key Set
+    assert len(constraint.key_sets) == 1
+    ks = constraint.key_sets[0]
+    assert isinstance(ks, KeySet)
+    assert ks.is_included is True
+    assert len(ks.keys) == 2
+    assert isinstance(ks.keys[0], DataKey)
+    assert isinstance(ks.keys[0].keys_values[0], DataKeyValue)
+    assert ks.keys[0].keys_values[0].id == "FREQ"
+    assert ks.keys[0].keys_values[0].value == "M"
+    assert ks.keys[0].keys_values[1].id == "REF_AREA"
+    assert ks.keys[0].keys_values[1].value == "US"
+    assert ks.keys[1].keys_values[0].id == "FREQ"
+    assert ks.keys[1].keys_values[0].value == "Q"
+    assert ks.keys[1].keys_values[1].id == "REF_AREA"
+    assert ks.keys[1].keys_values[1].value == "UK"
+
+
+def test_constraint_with_data_structure(samples_folder):
+    data_path = samples_folder / "constraint_datastructure.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_0
+    result = read_sdmx(input_str, validate=True).get_data_constraints()
+    assert result is not None
+    assert len(result) == 1
+    constraint = result[0]
+    assert isinstance(constraint, DataConstraint)
+    assert constraint.id == "TEST_CONSTRAINT_DSD"
+    assert constraint.name == "Test Constraint with Data Structure"
+    # Attachment
+    att = constraint.constraint_attachment
+    assert isinstance(att, ConstraintAttachment)
+    assert att.data_structures == [
+        "urn:sdmx:org.sdmx.infomodel.datastructure."
+        "DataStructure=TEST_AGENCY:TEST_DSD(1.0)"
+    ]
+    # Cube Region
+    assert len(constraint.cube_regions) == 1
+    assert isinstance(constraint.cube_regions[0], CubeRegion)
+    assert constraint.cube_regions[0].is_included is True
+    assert constraint.cube_regions[0].key_values[0].id == "FREQ"
+    assert [
+        v.value for v in constraint.cube_regions[0].key_values[0].values
+    ] == ["A"]
+
+
+def test_constraint_with_provider(samples_folder):
+    data_path = samples_folder / "constraint_provider.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_0
+    result = read_sdmx(input_str, validate=True).get_data_constraints()
+    assert result is not None
+    assert len(result) == 1
+    constraint = result[0]
+    assert isinstance(constraint, DataConstraint)
+    assert constraint.id == "TEST_CONSTRAINT_PROV"
+    assert constraint.name == "Test Constraint with Provider"
+    # Attachment
+    att = constraint.constraint_attachment
+    assert isinstance(att, ConstraintAttachment)
+    assert (
+        att.data_provider == "urn:sdmx:org.sdmx.infomodel.base.DataProvider="
+        "TEST_AGENCY:DATA_PROVIDERS(1.0).PROVIDER_ID"
+    )
+    # Cube Region
+    assert len(constraint.cube_regions) == 1
+    assert isinstance(constraint.cube_regions[0], CubeRegion)
+    assert constraint.cube_regions[0].key_values[0].id == "FREQ"
+    assert [
+        v.value for v in constraint.cube_regions[0].key_values[0].values
+    ] == ["M"]
+
+
+def test_constraint_with_provision_agreement(samples_folder):
+    data_path = samples_folder / "constraint_provision_agreement.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_0
+    result = read_sdmx(input_str, validate=True).get_data_constraints()
+    assert result is not None
+    assert len(result) == 1
+    constraint = result[0]
+    assert isinstance(constraint, DataConstraint)
+    assert constraint.id == "TEST_CONSTRAINT_PA"
+    assert constraint.name == "Test Constraint with Provision Agreement"
+    # Attachment
+    att = constraint.constraint_attachment
+    assert isinstance(att, ConstraintAttachment)
+    assert att.provision_agreements == [
+        "urn:sdmx:org.sdmx.infomodel.registry."
+        "ProvisionAgreement=TEST_AGENCY:TEST_PA(1.0)"
+    ]
+    # Cube Region
+    assert len(constraint.cube_regions) == 1
+    assert isinstance(constraint.cube_regions[0], CubeRegion)
+    assert constraint.cube_regions[0].key_values[0].id == "FREQ"
+    assert [
+        v.value for v in constraint.cube_regions[0].key_values[0].values
+    ] == ["A"]
+
+
+def test_constraint_without_attachment(samples_folder):
+    data_path = samples_folder / "constraint_no_attachment.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_0
+    result = read_sdmx(input_str, validate=True).get_data_constraints()
+    assert result is not None
+    assert len(result) == 1
+    constraint = result[0]
+    assert isinstance(constraint, DataConstraint)
+    assert constraint.id == "TEST_CONSTRAINT_NO_ATTACH"
+    assert constraint.name == "Test Constraint without Attachment"
+    assert constraint.constraint_attachment is None
+    # Cube Region
+    assert len(constraint.cube_regions) == 1
+    assert isinstance(constraint.cube_regions[0], CubeRegion)
+    assert constraint.cube_regions[0].is_included is True
+    assert constraint.cube_regions[0].key_values[0].id == "FREQ"
+    assert [
+        v.value for v in constraint.cube_regions[0].key_values[0].values
+    ] == ["Q"]

--- a/tests/io/xml/sdmx30/reader/test_reader.py
+++ b/tests/io/xml/sdmx30/reader/test_reader.py
@@ -763,7 +763,7 @@ def test_constraint_with_keyset(samples_folder):
     ks = constraint.key_sets[0]
     assert isinstance(ks, KeySet)
     assert ks.is_included is True
-    assert len(ks.keys) == 2
+    assert len(ks.keys) == 4
     assert isinstance(ks.keys[0], DataKey)
     assert isinstance(ks.keys[0].keys_values[0], DataKeyValue)
     assert ks.keys[0].keys_values[0].id == "FREQ"
@@ -774,6 +774,10 @@ def test_constraint_with_keyset(samples_folder):
     assert ks.keys[1].keys_values[0].value == "Q"
     assert ks.keys[1].keys_values[1].id == "REF_AREA"
     assert ks.keys[1].keys_values[1].value == "UK"
+    # Key with Component but no KeyValue
+    assert len(ks.keys[2].keys_values) == 0
+    # Empty Key
+    assert len(ks.keys[3].keys_values) == 0
 
 
 def test_constraint_with_data_structure(samples_folder):

--- a/tests/io/xml/sdmx30/reader/test_reader.py
+++ b/tests/io/xml/sdmx30/reader/test_reader.py
@@ -882,3 +882,10 @@ def test_constraint_without_attachment(samples_folder):
     assert [
         v.value for v in constraint.cube_regions[0].key_values[0].values
     ] == ["Q"]
+
+
+def test_constraint_with_actual_role_raises(samples_folder):
+    data_path = samples_folder / "constraint_actual.xml"
+    input_str, _ = process_string_to_read(data_path)
+    with pytest.raises(NotImplementedError):
+        read_sdmx(input_str)

--- a/tests/io/xml/sdmx30/writer/samples/constraint_cube.xml
+++ b/tests/io/xml/sdmx30/writer/samples/constraint_cube.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_CUBE" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Allowed">
+				<com:Name xml:lang="en">Test Constraint with Cube Region</com:Name>
+				<com:Description xml:lang="en">A test constraint with cube region</com:Description>
+				<str:ConstraintAttachment>
+					<str:Dataflow>urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=TEST_AGENCY:TEST_DF(1.0)</str:Dataflow>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<str:KeyValue id="FREQ">
+						<str:Value>M</str:Value>
+						<str:Value>Q</str:Value>
+					</str:KeyValue>
+					<str:KeyValue id="REF_AREA">
+						<str:Value>US</str:Value>
+						<str:Value>UK</str:Value>
+					</str:KeyValue>
+				</str:CubeRegion>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/writer/samples/constraint_datastructure.xml
+++ b/tests/io/xml/sdmx30/writer/samples/constraint_datastructure.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_DSD" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Allowed">
+				<com:Name xml:lang="en">Test Constraint with Data Structure</com:Name>
+				<com:Description xml:lang="en">A test constraint attached to a data structure</com:Description>
+				<str:ConstraintAttachment>
+					<str:DataStructure>urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=TEST_AGENCY:TEST_DSD(1.0)</str:DataStructure>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<str:KeyValue id="FREQ">
+						<str:Value>A</str:Value>
+					</str:KeyValue>
+				</str:CubeRegion>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/writer/samples/constraint_keyset.xml
+++ b/tests/io/xml/sdmx30/writer/samples/constraint_keyset.xml
@@ -33,6 +33,8 @@
 							<str:Value>UK</str:Value>
 						</str:KeyValue>
 					</str:Key>
+					<str:Key>
+					</str:Key>
 				</str:DataKeySet>
 			</str:DataConstraint>
 		</str:DataConstraints>

--- a/tests/io/xml/sdmx30/writer/samples/constraint_keyset.xml
+++ b/tests/io/xml/sdmx30/writer/samples/constraint_keyset.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_KEYSET" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Allowed">
+				<com:Name xml:lang="en">Test Constraint with Key Set</com:Name>
+				<com:Description xml:lang="en">A test constraint with key set</com:Description>
+				<str:ConstraintAttachment>
+					<str:Dataflow>urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=TEST_AGENCY:TEST_DF(1.0)</str:Dataflow>
+				</str:ConstraintAttachment>
+				<str:DataKeySet isIncluded="true">
+					<str:Key>
+						<str:KeyValue id="FREQ">
+							<str:Value>M</str:Value>
+						</str:KeyValue>
+						<str:KeyValue id="REF_AREA">
+							<str:Value>US</str:Value>
+						</str:KeyValue>
+					</str:Key>
+					<str:Key>
+						<str:KeyValue id="FREQ">
+							<str:Value>Q</str:Value>
+						</str:KeyValue>
+						<str:KeyValue id="REF_AREA">
+							<str:Value>UK</str:Value>
+						</str:KeyValue>
+					</str:Key>
+				</str:DataKeySet>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/writer/samples/constraint_no_attachment.xml
+++ b/tests/io/xml/sdmx30/writer/samples/constraint_no_attachment.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_NO_ATTACH" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Allowed">
+				<com:Name xml:lang="en">Test Constraint without Attachment</com:Name>
+				<com:Description xml:lang="en">A test constraint without constraint attachment</com:Description>
+				<str:CubeRegion include="true">
+					<str:KeyValue id="FREQ">
+						<str:Value>Q</str:Value>
+					</str:KeyValue>
+				</str:CubeRegion>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/writer/samples/constraint_provider.xml
+++ b/tests/io/xml/sdmx30/writer/samples/constraint_provider.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_PROV" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Allowed">
+				<com:Name xml:lang="en">Test Constraint with Provider</com:Name>
+				<com:Description xml:lang="en">A test constraint attached to a provider</com:Description>
+				<str:ConstraintAttachment>
+					<str:DataProvider>urn:sdmx:org.sdmx.infomodel.base.DataProvider=TEST_AGENCY:DATA_PROVIDERS(1.0).PROVIDER_ID</str:DataProvider>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<str:KeyValue id="FREQ">
+						<str:Value>M</str:Value>
+					</str:KeyValue>
+				</str:CubeRegion>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/writer/samples/constraint_provision_agreement.xml
+++ b/tests/io/xml/sdmx30/writer/samples/constraint_provision_agreement.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:DataConstraints>
+			<str:DataConstraint id="TEST_CONSTRAINT_PA" version="1.0" isExternalReference="false" agencyID="TEST_AGENCY" role="Allowed">
+				<com:Name xml:lang="en">Test Constraint with Provision Agreement</com:Name>
+				<com:Description xml:lang="en">A test constraint attached to a provision agreement</com:Description>
+				<str:ConstraintAttachment>
+					<str:ProvisionAgreement>urn:sdmx:org.sdmx.infomodel.registry.ProvisionAgreement=TEST_AGENCY:TEST_PA(1.0)</str:ProvisionAgreement>
+				</str:ConstraintAttachment>
+				<str:CubeRegion include="true">
+					<str:KeyValue id="FREQ">
+						<str:Value>A</str:Value>
+					</str:KeyValue>
+				</str:CubeRegion>
+			</str:DataConstraint>
+		</str:DataConstraints>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx30/writer/test_structures_writing.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 import pytest
 
-from pysdmx.io.reader import read_sdmx as read_sdmx
+from pysdmx.io.reader import read_sdmx
+from pysdmx.io.xml.sdmx30.reader.structure import read
 from pysdmx.io.xml.sdmx30.writer.structure import write
 from pysdmx.model import (
     Agency,
@@ -13,11 +14,19 @@ from pysdmx.model import (
     Codelist,
     Concept,
     ConceptScheme,
+    ConstraintAttachment,
+    CubeKeyValue,
+    CubeRegion,
+    CubeValue,
     CustomType,
     CustomTypeScheme,
+    DataConstraint,
+    DataKey,
+    DataKeyValue,
     DataType,
     Facets,
     FromVtlMapping,
+    KeySet,
     NamePersonalisation,
     NamePersonalisationScheme,
     Ruleset,
@@ -837,6 +846,260 @@ def prov_agreement_sample():
         return f.read()
 
 
+@pytest.fixture
+def constraint_with_cube():
+    return DataConstraint(
+        id="TEST_CONSTRAINT_CUBE",
+        name="Test Constraint with Cube Region",
+        agency="TEST_AGENCY",
+        version="1.0",
+        description="A test constraint with cube region",
+        constraint_attachment=ConstraintAttachment(
+            data_provider=None,
+            dataflows=[
+                "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow="
+                "TEST_AGENCY:TEST_DF(1.0)"
+            ],
+            data_structures=None,
+            provision_agreements=None,
+        ),
+        cube_regions=[
+            CubeRegion(
+                key_values=[
+                    CubeKeyValue(
+                        id="FREQ",
+                        values=[
+                            CubeValue(value="M"),
+                            CubeValue(value="Q"),
+                        ],
+                    ),
+                    CubeKeyValue(
+                        id="REF_AREA",
+                        values=[
+                            CubeValue(value="US"),
+                            CubeValue(value="UK"),
+                        ],
+                    ),
+                ],
+                is_included=True,
+            ),
+        ],
+        key_sets=[],
+    )
+
+
+@pytest.fixture
+def constraint_with_keyset():
+    return DataConstraint(
+        id="TEST_CONSTRAINT_KEYSET",
+        name="Test Constraint with Key Set",
+        agency="TEST_AGENCY",
+        version="1.0",
+        description="A test constraint with key set",
+        constraint_attachment=ConstraintAttachment(
+            data_provider=None,
+            dataflows=[
+                "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow="
+                "TEST_AGENCY:TEST_DF(1.0)"
+            ],
+            data_structures=None,
+            provision_agreements=None,
+        ),
+        cube_regions=[],
+        key_sets=[
+            KeySet(
+                keys=[
+                    DataKey(
+                        keys_values=[
+                            DataKeyValue(id="FREQ", value="M"),
+                            DataKeyValue(id="REF_AREA", value="US"),
+                        ],
+                        valid_from=None,
+                        valid_to=None,
+                    ),
+                    DataKey(
+                        keys_values=[
+                            DataKeyValue(id="FREQ", value="Q"),
+                            DataKeyValue(id="REF_AREA", value="UK"),
+                        ],
+                        valid_from=None,
+                        valid_to=None,
+                    ),
+                ],
+                is_included=True,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def constraint_cube_sample():
+    base_path = Path(__file__).parent / "samples" / "constraint_cube.xml"
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def constraint_keyset_sample():
+    base_path = Path(__file__).parent / "samples" / "constraint_keyset.xml"
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def constraint_with_data_structure():
+    return DataConstraint(
+        id="TEST_CONSTRAINT_DSD",
+        name="Test Constraint with Data Structure",
+        agency="TEST_AGENCY",
+        version="1.0",
+        description="A test constraint attached to a data structure",
+        constraint_attachment=ConstraintAttachment(
+            data_provider=None,
+            dataflows=None,
+            data_structures=[
+                "urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure="
+                "TEST_AGENCY:TEST_DSD(1.0)"
+            ],
+            provision_agreements=None,
+        ),
+        cube_regions=[
+            CubeRegion(
+                key_values=[
+                    CubeKeyValue(
+                        id="FREQ",
+                        values=[CubeValue(value="A")],
+                    ),
+                ],
+                is_included=True,
+            ),
+        ],
+        key_sets=[],
+    )
+
+
+@pytest.fixture
+def constraint_with_provider():
+    return DataConstraint(
+        id="TEST_CONSTRAINT_PROV",
+        name="Test Constraint with Provider",
+        agency="TEST_AGENCY",
+        version="1.0",
+        description="A test constraint attached to a provider",
+        constraint_attachment=ConstraintAttachment(
+            data_provider="urn:sdmx:org.sdmx.infomodel.base.DataProvider="
+            "TEST_AGENCY:DATA_PROVIDERS(1.0).PROVIDER_ID",
+            dataflows=None,
+            data_structures=None,
+            provision_agreements=None,
+        ),
+        cube_regions=[
+            CubeRegion(
+                key_values=[
+                    CubeKeyValue(
+                        id="FREQ",
+                        values=[CubeValue(value="M")],
+                    ),
+                ],
+                is_included=True,
+            ),
+        ],
+        key_sets=[],
+    )
+
+
+@pytest.fixture
+def constraint_datastructure_sample():
+    base_path = (
+        Path(__file__).parent / "samples" / "constraint_datastructure.xml"
+    )
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def constraint_provider_sample():
+    base_path = Path(__file__).parent / "samples" / "constraint_provider.xml"
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def constraint_with_provision_agreement():
+    return DataConstraint(
+        id="TEST_CONSTRAINT_PA",
+        name="Test Constraint with Provision Agreement",
+        agency="TEST_AGENCY",
+        version="1.0",
+        description="A test constraint attached to a provision agreement",
+        constraint_attachment=ConstraintAttachment(
+            data_provider=None,
+            dataflows=None,
+            data_structures=None,
+            provision_agreements=[
+                "urn:sdmx:org.sdmx.infomodel.registry.ProvisionAgreement="
+                "TEST_AGENCY:TEST_PA(1.0)"
+            ],
+        ),
+        cube_regions=[
+            CubeRegion(
+                key_values=[
+                    CubeKeyValue(
+                        id="FREQ",
+                        values=[CubeValue(value="A")],
+                    ),
+                ],
+                is_included=True,
+            ),
+        ],
+        key_sets=[],
+    )
+
+
+@pytest.fixture
+def constraint_provision_agreement_sample():
+    base_path = (
+        Path(__file__).parent
+        / "samples"
+        / "constraint_provision_agreement.xml"
+    )
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def constraint_without_attachment():
+    return DataConstraint(
+        id="TEST_CONSTRAINT_NO_ATTACH",
+        name="Test Constraint without Attachment",
+        agency="TEST_AGENCY",
+        version="1.0",
+        description="A test constraint without constraint attachment",
+        constraint_attachment=None,
+        cube_regions=[
+            CubeRegion(
+                key_values=[
+                    CubeKeyValue(
+                        id="FREQ",
+                        values=[CubeValue(value="Q")],
+                    ),
+                ],
+                is_included=True,
+            ),
+        ],
+        key_sets=[],
+    )
+
+
+@pytest.fixture
+def constraint_no_attachment_sample():
+    base_path = (
+        Path(__file__).parent / "samples" / "constraint_no_attachment.xml"
+    )
+    with open(base_path, "r") as f:
+        return f.read()
+
+
 def test_codelist(complete_header, codelist, codelist_sample):
     content = [codelist]
     result = write(
@@ -1036,3 +1299,87 @@ def test_prov_agreement(
     )
     read_sdmx(result, validate=True)
     assert result == prov_agreement_sample
+
+
+def test_constraint_with_cube_region(
+    complete_header, constraint_with_cube, constraint_cube_sample
+):
+    content = [constraint_with_cube]
+    result = write(
+        content,
+        header=complete_header,
+        prettyprint=True,
+    )
+    read(result, validate=True)
+    assert result == constraint_cube_sample
+
+
+def test_constraint_with_keyset(
+    complete_header, constraint_with_keyset, constraint_keyset_sample
+):
+    content = [constraint_with_keyset]
+    result = write(
+        content,
+        header=complete_header,
+        prettyprint=True,
+    )
+    read(result, validate=True)
+    assert result == constraint_keyset_sample
+
+
+def test_constraint_with_data_structure(
+    complete_header,
+    constraint_with_data_structure,
+    constraint_datastructure_sample,
+):
+    content = [constraint_with_data_structure]
+    result = write(
+        content,
+        header=complete_header,
+        prettyprint=True,
+    )
+    read(result, validate=True)
+    assert result == constraint_datastructure_sample
+
+
+def test_constraint_with_provider(
+    complete_header, constraint_with_provider, constraint_provider_sample
+):
+    content = [constraint_with_provider]
+    result = write(
+        content,
+        header=complete_header,
+        prettyprint=True,
+    )
+    read(result, validate=True)
+    assert result == constraint_provider_sample
+
+
+def test_constraint_with_provision_agreement(
+    complete_header,
+    constraint_with_provision_agreement,
+    constraint_provision_agreement_sample,
+):
+    content = [constraint_with_provision_agreement]
+    result = write(
+        content,
+        header=complete_header,
+        prettyprint=True,
+    )
+    read(result, validate=True)
+    assert result == constraint_provision_agreement_sample
+
+
+def test_constraint_without_attachment(
+    complete_header,
+    constraint_without_attachment,
+    constraint_no_attachment_sample,
+):
+    content = [constraint_without_attachment]
+    result = write(
+        content,
+        header=complete_header,
+        prettyprint=True,
+    )
+    read(result, validate=True)
+    assert result == constraint_no_attachment_sample

--- a/tests/io/xml/sdmx30/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx30/writer/test_structures_writing.py
@@ -925,6 +925,11 @@ def constraint_with_keyset():
                         valid_from=None,
                         valid_to=None,
                     ),
+                    DataKey(
+                        keys_values=[],
+                        valid_from=None,
+                        valid_to=None,
+                    ),
                 ],
                 is_included=True,
             ),

--- a/tests/io/xml/sdmx30/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx30/writer/test_structures_writing.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from pysdmx.io import write_sdmx
+from pysdmx.io.format import Format
 from pysdmx.io.reader import read_sdmx
 from pysdmx.io.xml.sdmx30.reader.structure import read
 from pysdmx.io.xml.sdmx30.writer.structure import write
@@ -53,6 +55,7 @@ from pysdmx.model.dataflow import (
     Components,
     Dataflow,
     DataStructureDefinition,
+    Group,
     ProvisionAgreement,
     Role,
 )
@@ -1388,3 +1391,20 @@ def test_constraint_without_attachment(
     )
     read(result, validate=True)
     assert result == constraint_no_attachment_sample
+
+
+def test_write_group_without_urn(datastructure):
+    dsd_with_group = datastructure.__replace__(
+        groups=[Group(id="Sibling", dimensions=["FREQ"])],
+    )
+    result = write_sdmx(
+        [dsd_with_group],
+        sdmx_format=Format.STRUCTURE_SDMX_ML_3_0,
+    )
+    expected_urn = (
+        "urn:sdmx:org.sdmx.infomodel.datastructure"
+        ".GroupDimensionDescriptor"
+        "=MD:DS(1.0).Sibling"
+    )
+    assert expected_urn in result
+    read_sdmx(result, validate=True)

--- a/tests/io/xml/sdmx31/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx31/writer/test_structures_writing.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from pysdmx.io import write_sdmx
+from pysdmx.io.format import Format
 from pysdmx.io.reader import read_sdmx as read_sdmx
 from pysdmx.io.xml.sdmx31.writer.structure import write
 from pysdmx.model import (
@@ -38,6 +40,7 @@ from pysdmx.model.dataflow import (
     Components,
     Dataflow,
     DataStructureDefinition,
+    Group,
     ProvisionAgreement,
     Role,
 )
@@ -736,3 +739,20 @@ def test_prov_agreement(
     )
     read_sdmx(result, validate=True)
     assert result == prov_agreement_sample
+
+
+def test_write_group_without_urn(datastructure):
+    dsd_with_group = datastructure.__replace__(
+        groups=[Group(id="Sibling", dimensions=["FREQ"])],
+    )
+    result = write_sdmx(
+        [dsd_with_group],
+        sdmx_format=Format.STRUCTURE_SDMX_ML_3_1,
+    )
+    expected_urn = (
+        "urn:sdmx:org.sdmx.infomodel.datastructure"
+        ".GroupDimensionDescriptor"
+        "=MD:DS(1.0).Sibling"
+    )
+    assert expected_urn in result
+    read_sdmx(result, validate=True)


### PR DESCRIPTION
Closes #530

This PR implements read/write support for `DataConstraint` structures in SDMX-ML (both SDMX 2.1 and SDMX 3.0 formats). The model classes (`DataConstraint`, `ConstraintAttachment`, `CubeRegion`, `CubeKeyValue`, `CubeValue`, `KeySet`, `DataKey`, `DataKeyValue`) were already supported in SDMX-JSON (PR #468).

## Changes

The changes have been made using the [SDMX XML schemas](https://github.com/Meaningful-Data/sdmx-schemas/tree/main/src/sdmxschemas/xml) as reference.

### Reader (`__structure_aux_reader.py`)

The reader now recognises `ContentConstraint` elements (2.1) and `DataConstraint` elements (3.0) and maps both to the existing `DataConstraint` model class. Both formats are registered in `STRUCTURES_MAPPING` to include them in the structure processing.

Parsing is done by private helper methods:

- `__parse_data_provider`: resolves the `DataProvider` reference, handling the SDMX 2.1 `<Ref>` element style and the SDMX 3.0 direct URN style.
- `__parse_references`: generic helper used to extract and normalise references to dataflows, data structures, and provision agreements into URN strings.
- `__format_constraint_attachment`: combines the above to produce a `ConstraintAttachment` object.
- `__format_cube_region`: walks the `CubeRegion` element and builds the nested `CubeRegion` / `CubeKeyValue` / `CubeValue` objects.
- `__format_key_set`: walks the `DataKeySet` element and builds the nested `KeySet` / `DataKey` / `DataKeyValue` objects.
- `__format_constraint`: top-level method called for each constraint element; it orchestrates the methods above and returns a dict ready to be passed to the `DataConstraint` constructor. Raises `NotImplementedError` if a parsed constraint has `role="Actual"`.

### Writer (`__structure_aux_writer.py`)

`DataConstraint` is written in the 2.1 type list (as `"Constraints"`) and in the 3.0 type list (as `"DataConstraints"`).

The serialisation is done by `__write_data_constraint`, which decides to emit a `<str:ContentConstraint>` (2.1) or a `<str:DataConstraint>` (3.0) element, and then delegates to a set of focused helpers:

- `__write_constraint_attachment`: writes the `<ConstraintAttachment>` and calls the appropriate reference helper for each attached artefact (`__write_data_provider`, `__write_data_structure`, `__write_dataflow`, `__write_provision_agreement`). Each of these handles the format difference: 3.0 writes a plain URN as text content, while 2.1 writes a `<Ref>` child element with individual attributes.
- `__write_cube_region`: serialises a `CubeRegion` with its `KeyValue`/`Value` children. The namespace prefix differs per format (`str:` in 3.0, `com:` in 2.1).
- `__write_key_set`: serialises a `DataKeySet` with its `Key`/`KeyValue`/`Value` children, following the same namespace convention.

### Fix: Group URN generation in XML writer (`__structure_aux_writer.py`)

When `Group` elements were created from JSON sources (which don't include URNs), the XML writer would output `urn=None`, producing invalid XML. The `__write_groups` function now generates a proper URN from the parent DSD context (`agency`, `id`, `version`) when the group's URN is not set, using the format `urn:sdmx:org.sdmx.infomodel.datastructure.GroupDimensionDescriptor={agency}:{dsd_id}({version}).{group_id}`.

### Fix: Optional `constraintAttachment` in SDMX-JSON (`constraint.py`)

The `JsonDataConstraint.to_model()` method now handles `None` `constraintAttachment` gracefully instead of raising an `AttributeError`.

## Tests

New sample XML files and test cases are added:

- Constraint with `CubeRegion` attached to a `Dataflow`
- Constraint with `DataKeySet`
- Constraint attached to a `DataStructure`
- Constraint attached to a `DataProvider`
- Constraint attached to a `ProvisionAgreement`
- Constraint without `ConstraintAttachment`
- Group without URN written to SDMX-ML 2.1, 3.0, and 3.1 (validates generated URN and round-trips through reader)
- Constraint deserialization from SDMX-JSON without `constraintAttachment`

All writer tests validate the output by round-tripping through the reader (`read`/`validate=True`) before asserting against the expected XML sample.

## Out of Scope

- Added writer for `ProvisionAgreement` and reader/writer for `DataProvider`