### PR TITLE
Add support for exclusive keysets

### DIFF
--- a/src/pysdmx/io/json/fusion/messages/constraint.py
+++ b/src/pysdmx/io/json/fusion/messages/constraint.py
@@ -23,18 +23,32 @@ class FusionContentConstraint(Struct, frozen=True):
 
     includeCube: Dict[str, FusionKeyValue] = {}
     includeSeries: Optional[FusionKeySet] = None
+    excludeSeries: Optional[FusionKeySet] = None
 
     def to_map(self) -> Dict[str, Sequence[str]]:
         """Gets the list of allowed values for a component."""
         return {k: v.values for k, v in self.includeCube.items()}
 
-    def get_series(self, dimensions: List[str]) -> Sequence[str]:
-        """Get the list of series defined in the keyset."""
+    def get_included_series(self, dimensions: List[str]) -> Sequence[str]:
+        """Get the list of included series defined in the keyset."""
         if self.includeSeries:
             series = []
             for r in self.includeSeries.rows:
                 s = dict.fromkeys(dimensions, "*")
                 for idx, cd in enumerate(self.includeSeries.dims):
+                    s[cd] = r[idx]
+                series.append(".".join(s.values()))
+            return series
+        else:
+            return []
+
+    def get_excluded_series(self, dimensions: List[str]) -> Sequence[str]:
+        """Get the list of excluded series defined in the keyset."""
+        if self.excludeSeries:
+            series = []
+            for r in self.excludeSeries.rows:
+                s = dict.fromkeys(dimensions, "*")
+                for idx, cd in enumerate(self.excludeSeries.dims):
                     s[cd] = r[idx]
                 series.append(".".join(s.values()))
             return series

--- a/src/pysdmx/io/json/fusion/messages/schema.py
+++ b/src/pysdmx/io/json/fusion/messages/schema.py
@@ -66,17 +66,18 @@ class FusionSchemaMessage(msgspec.Struct, frozen=True):
             Group(g.id, dimensions=g.dimensionReferences) for g in grps
         ]
         keys: List[str] = []
+        excluded_keys: List[str] = []
         for dc in self.DataConstraint:
-            keys.extend(
-                dc.get_series(
-                    [
-                        d.id
-                        for d in self.DataStructure[0].dimensionList.dimensions
-                        if not d.isTimeDimension
-                    ]
-                )
-            )
+            dims = [
+                d.id
+                for d in self.DataStructure[0].dimensionList.dimensions
+                if not d.isTimeDimension
+            ]
+            keys.extend(dc.get_included_series(dims))
+            excluded_keys.extend(dc.get_excluded_series(dims))
+
         keys = list(set(keys)) if keys else None  # type: ignore[assignment]
+        excluded_keys = list(set(excluded_keys)) if excluded_keys else None  # type: ignore[assignment]
         return Schema(
             context,
             agency,
@@ -86,4 +87,5 @@ class FusionSchemaMessage(msgspec.Struct, frozen=True):
             urns,
             groups=mapped_grps,
             keys=keys,
+            excluded_keys=excluded_keys,
         )

--- a/src/pysdmx/io/json/sdmxjson2/messages/schema.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/schema.py
@@ -48,16 +48,13 @@ class JsonSchemas(msgspec.Struct, frozen=True, omit_defaults=True):
     def __extract_keys_dict(
         self, keysets: Sequence[JsonKeySet], included: bool = True
     ) -> Sequence[Dict[str, str]]:
-        inc_cond = lambda ks: ks.isIncluded
-        exc_cond = lambda ks: not ks.isIncluded
-        cond = inc_cond if included else exc_cond
         keys = []
         for ks in keysets:
             keys.extend(
                 [
                     {kv.id: kv.value for kv in k.keyValues}
                     for k in ks.keys
-                    if cond(ks)
+                    if (ks.isIncluded if included else not ks.isIncluded)
                 ]
             )
         return keys

--- a/src/pysdmx/model/dataflow.py
+++ b/src/pysdmx/model/dataflow.py
@@ -511,7 +511,7 @@ class Schema(Struct, frozen=True, omit_defaults=True, repr_omit_defaults=True):
     name: Optional[str] = None
     groups: Optional[Sequence[Group]] = None
     keys: Optional[Sequence[str]] = None
-    excluded_keys: Optional[Sequence[str]] = None 
+    excluded_keys: Optional[Sequence[str]] = None
 
     def __str__(self) -> str:
         """Custom string representation without the class name."""

--- a/src/pysdmx/model/dataflow.py
+++ b/src/pysdmx/model/dataflow.py
@@ -490,9 +490,13 @@ class Schema(Struct, frozen=True, omit_defaults=True, repr_omit_defaults=True):
         name: The schema name.
         groups: The list of groups defined in the data structure.
         keys: The list of allowed series. This is the equivalent
-            of an SDMX KeySet. KeySets allow finer
-            restrictions than when components only (i.e. SDMX
+            of an SDMX inclusive KeySet. KeySets allow finer
+            restrictions than when using components only (i.e. SDMX
             CubeRegions). The values in the sequence follow
+            the SDMX-REST conventions for series wildcarding
+            (e.g. *.USD.CHF.*).
+        excluded_keys: The list of excluded series. This is the equivalent
+            of an SDMX exclusive KeySet. The values in the sequence follow
             the SDMX-REST conventions for series wildcarding
             (e.g. *.USD.CHF.*).
     """
@@ -507,6 +511,7 @@ class Schema(Struct, frozen=True, omit_defaults=True, repr_omit_defaults=True):
     name: Optional[str] = None
     groups: Optional[Sequence[Group]] = None
     keys: Optional[Sequence[str]] = None
+    excluded_keys: Optional[Sequence[str]] = None 
 
     def __str__(self) -> str:
         """Custom string representation without the class name."""

--- a/tests/api/fmr/fusion/test_schemas.py
+++ b/tests/api/fmr/fusion/test_schemas.py
@@ -128,6 +128,14 @@ def keyset_body():
 
 
 @pytest.fixture
+def excl_keyset_body():
+    with open(
+        "tests/api/fmr/samples/df/excl_keyset_schema.fusion.json", "rb"
+    ) as f:
+        return f.read()
+
+
+@pytest.fixture
 def body_from_pra():
     with open("tests/api/fmr/samples/pra/schema.fusion.json", "rb") as f:
         return f.read()
@@ -205,21 +213,30 @@ def no_hca_pra_body():
         return f.read()
 
 
-def test_returns_validation_context(
+def test_returns_schema(
     respx_mock, fmr, query, no_hca_query, body, no_hca_body
 ):
-    """get_validation_context() should return a schema."""
+    """get_schema() should return a schema."""
     checks.check_schema(
         respx_mock, fmr, query, no_hca_query, body, no_hca_body, True
     )
 
 
-def test_returns_keyset_context(
+def test_returns_inclusive_keyset(
     respx_mock, fmr, query, no_hca_query, keyset_body, no_hca_body
 ):
-    """get_validation_context() should return a schema."""
+    """get_schema() returns a schema, with an inclusive keyset."""
     checks.check_keyset_schema(
         respx_mock, fmr, query, no_hca_query, keyset_body, no_hca_body
+    )
+
+
+def test_returns_exclusive_keyset(
+    respx_mock, fmr, query, no_hca_query, excl_keyset_body, no_hca_body
+):
+    """get_schema() should return a schema, with an exclusive keyset."""
+    checks.check_exclusive_keyset_schema(
+        respx_mock, fmr, query, no_hca_query, excl_keyset_body, no_hca_body
     )
 
 
@@ -231,7 +248,7 @@ def test_returns_pra_validation_context(
     body_from_pra,
     no_hca_pra_body,
 ):
-    """get_validation_context() should return a schema."""
+    """get_schema() should return a schema for provision agreement."""
     checks.check_schema_from_pra(
         respx_mock,
         fmr,

--- a/tests/api/fmr/samples/df/excl_keyset_schema.fusion.json
+++ b/tests/api/fmr/samples/df/excl_keyset_schema.fusion.json
@@ -1,0 +1,1258 @@
+{
+    "meta": {
+        "id": "IREF909102",
+        "test": false,
+        "prepared": "2023-07-31T08:08:32Z",
+        "contentLanguages": [
+            "en"
+        ],
+        "sender": {
+            "id": "FusionRegistry"
+        },
+        "links": [
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS.CBS:CBS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=BIS:BIS_CBS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.registry.DataConstraint=BIS:CBS_CPC(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.registry.DataConstraint=BIS.CBS:CBS_CONSTRAINTS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.base.AgencyScheme=SDMX:AGENCIES(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.ValueList=BIS:CL_AVAILABILITY(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_BIS_IF_REF_AREA(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CBS_BASIS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_COLLECTION(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CONF_STATUS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CURRENCY_3POS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_DECIMALS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_FREQ(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_ISSUE_MAT(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_INSTR(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_POSITION(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_SECTOR(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_OBS_STATUS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_ORG_VISIBILITY(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_STOCK_FLOW(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_TIME_FORMAT(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_UNIT_MULT(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=BIS:STANDALONE_CONCEPT_SCHEME(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.registry.DataConstraint=BIS:BIS_CBS(1.0)"
+            }
+        ]
+    },
+    "AgencyScheme": [
+        {
+            "id": "AGENCIES",
+            "urn": "urn:sdmx:org.sdmx.infomodel.base.AgencyScheme=SDMX:AGENCIES(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "SDMX Agency Scheme"
+                }
+            ],
+            "agencyId": "SDMX",
+            "version": "1.0",
+            "isPartial": true,
+            "items": [
+                {
+                    "id": "BIS",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.base.Agency=SDMX:AGENCIES(1.0).BIS",
+                    "annotations": [
+                        {
+                            "title": "xx000000",
+                            "type": "contact_uid"
+                        }
+                    ],
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Bank for International Settlements"
+                        }
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "Bank for International Settlements"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "ValueList": [
+        {
+            "id": "CL_AVAILABILITY",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.ValueList=BIS:CL_AVAILABILITY(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Availability"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": false,
+            "items": [
+                {
+                    "id": "A",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "All users"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "Codelist": [
+        {
+            "id": "CL_BIS_IF_REF_AREA",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_BIS_IF_REF_AREA(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Reference Area Code for BIS-IFS"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "1C",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_BIS_IF_REF_AREA(1.0).1C",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "International organisations"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_CBS_BASIS",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CBS_BASIS(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "CBS basis"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "F",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_CBS_BASIS(1.0).F",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Immediate counterparty basis"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_COLLECTION",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_COLLECTION(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Collection"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "E",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_COLLECTION(1.0).E",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "End of period"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_CONF_STATUS",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CONF_STATUS(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Observation confidentiality code list"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "F",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_CONF_STATUS(1.0).F",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Free"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_CURRENCY_3POS",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CURRENCY_3POS(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Currency"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "FC1",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_CURRENCY_3POS(1.0).FC1",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Foreign currency"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_DECIMALS",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_DECIMALS(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Decimals codelist (BIS, ECB)"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "6",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_DECIMALS(1.0).6",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Six"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_FREQ",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_FREQ(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Code list for Frequency (FREQ)"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "Q",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).Q",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Quarterly"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_ISSUE_MAT",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_ISSUE_MAT(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Issue maturity code list"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "A",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_ISSUE_MAT(1.0).A",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Total (all maturities)"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_L_INSTR",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_INSTR(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Instrument"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "A",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_L_INSTR(1.0).A",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "All instruments"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_L_POSITION",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_POSITION(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Position type"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "B",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_L_POSITION(1.0).B",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Local claims"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_L_SECTOR",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_SECTOR(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Counterparty Sector"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "A",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_L_SECTOR(1.0).A",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "All sectors"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_OBS_STATUS",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_OBS_STATUS(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Observation status codelist (BIS, ECB, Eurostat-BoP)"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": false,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "A",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_OBS_STATUS(1.0).A",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Normal value"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_ORG_VISIBILITY",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_ORG_VISIBILITY(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Visibility"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": false,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "A",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_ORG_VISIBILITY(1.0).A",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "CBs, ESRB and IMF"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_STOCK_FLOW",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_STOCK_FLOW(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Stock, flow"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "S",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_STOCK_FLOW(1.0).S",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Amounts outstanding / Stocks"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "CL_UNIT_MULT",
+            "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_UNIT_MULT(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Unit Multiplier"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "6",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_UNIT_MULT(1.0).6",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Millions"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "ConceptScheme": [
+        {
+            "id": "STANDALONE_CONCEPT_SCHEME",
+            "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=BIS:STANDALONE_CONCEPT_SCHEME(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Default Scheme"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "isPartial": true,
+            "validityType": "standard",
+            "items": [
+                {
+                    "id": "AVAILABILITY",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).AVAILABILITY",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Availability"
+                        }
+                    ]
+                },
+                {
+                    "id": "CBS_BANK_TYPE",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).CBS_BANK_TYPE",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "CBS bank type"
+                        }
+                    ]
+                },
+                {
+                    "id": "CBS_BASIS",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).CBS_BASIS",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "CBS reporting basis"
+                        }
+                    ]
+                },
+                {
+                    "id": "COLLECTION",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).COLLECTION",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Collection Indicator"
+                        }
+                    ]
+                },
+                {
+                    "id": "CURR_TYPE_BOOK",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).CURR_TYPE_BOOK",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Currency type of booking location"
+                        }
+                    ]
+                },
+                {
+                    "id": "DECIMALS",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).DECIMALS",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Decimals"
+                        }
+                    ],
+                    "representation": {
+                        "textFormat": {
+                            "textType": "BigInteger",
+                            "minLength": 1,
+                            "maxLength": 2
+                        },
+                        "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_DECIMALS(1.0)"
+                    }
+                },
+                {
+                    "id": "FREQ",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).FREQ",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Frequency"
+                        }
+                    ]
+                },
+                {
+                    "id": "L_CP_COUNTRY",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_CP_COUNTRY",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Counterparty country"
+                        }
+                    ]
+                },
+                {
+                    "id": "L_CP_SECTOR",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_CP_SECTOR",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Counterparty sector"
+                        }
+                    ]
+                },
+                {
+                    "id": "L_INSTR",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_INSTR",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Type of instruments"
+                        }
+                    ]
+                },
+                {
+                    "id": "L_MEASURE",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_MEASURE",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Measure"
+                        }
+                    ]
+                },
+                {
+                    "id": "L_POSITION",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_POSITION",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Balance sheet position"
+                        }
+                    ]
+                },
+                {
+                    "id": "L_REP_CTY",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_REP_CTY",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Reporting country"
+                        }
+                    ]
+                },
+                {
+                    "id": "OBS_CONF",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_CONF",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Observation Confidentiality"
+                        }
+                    ]
+                },
+                {
+                    "id": "OBS_PRE_BREAK",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_PRE_BREAK",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Pre-Break Observation"
+                        }
+                    ]
+                },
+                {
+                    "id": "OBS_STATUS",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_STATUS",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Observation Status"
+                        }
+                    ]
+                },
+                {
+                    "id": "OBS_VALUE",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_VALUE",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Observation Value"
+                        }
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "Description for a measure"
+                        }
+                    ]
+                },
+                {
+                    "id": "ORG_VISIBILITY",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).ORG_VISIBILITY",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Organisation visibility"
+                        }
+                    ]
+                },
+                {
+                    "id": "REM_MATURITY",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).REM_MATURITY",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Remaining maturity"
+                        }
+                    ]
+                },
+                {
+                    "id": "TIME_PERIOD",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).TIME_PERIOD",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Time period or range"
+                        }
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "Description for a dimension"
+                        }
+                    ]
+                },
+                {
+                    "id": "TITLE_GRP",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).TITLE_GRP",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Title"
+                        }
+                    ]
+                },
+                {
+                    "id": "UNIT_MEASURE",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).UNIT_MEASURE",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Unit of measure"
+                        }
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "Description for an attribute"
+                        }
+                    ]
+                },
+                {
+                    "id": "UNIT_MULT",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).UNIT_MULT",
+                    "names": [
+                        {
+                            "locale": "en",
+                            "value": "Unit Multiplier"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "DataStructure": [
+        {
+            "id": "BIS_CBS",
+            "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=BIS:BIS_CBS(1.0)",
+            "links": [
+                {
+                    "rel": "metadata",
+                    "href": "https://mms-med-fmr-dev.apps.ocp-dev.opz.bisinfo.org/sdmx/v2/metadata/metadataset/BIS.MEDIT/STI_BIS_CBS/1.0",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataSet=BIS.MEDIT:STI_BIS_CBS(1.0)"
+                }
+            ],
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Consolidated Banking Statistics"
+                }
+            ],
+            "descriptions": [
+                {
+                    "locale": "en",
+                    "value": "This dataflow is associated to the BIS_CBS DSD. It implements the data requirement laid out in the July 2019 IBS Reporting Guidelines | PDF version: BIS_CBS_V2020.02.19"
+                }
+            ],
+            "agencyId": "BIS",
+            "version": "1.0",
+            "dimensionList": {
+                "dimensions": [
+                    {
+                        "id": "FREQ",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).FREQ",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 1,
+                                "maxLength": 1
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_FREQ(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).FREQ"
+                    },
+                    {
+                        "id": "L_MEASURE",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).L_MEASURE",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 1,
+                                "maxLength": 1
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_STOCK_FLOW(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_MEASURE"
+                    },
+                    {
+                        "id": "L_REP_CTY",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).L_REP_CTY",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 2,
+                                "maxLength": 2
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_BIS_IF_REF_AREA(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_REP_CTY"
+                    },
+                    {
+                        "id": "CBS_BANK_TYPE",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).CBS_BANK_TYPE",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 2,
+                                "maxLength": 2
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_BIS_IF_REF_AREA(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).CBS_BANK_TYPE"
+                    },
+                    {
+                        "id": "CBS_BASIS",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).CBS_BASIS",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 1,
+                                "maxLength": 1
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CBS_BASIS(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).CBS_BASIS"
+                    },
+                    {
+                        "id": "L_POSITION",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).L_POSITION",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 1,
+                                "maxLength": 1
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_POSITION(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_POSITION"
+                    },
+                    {
+                        "id": "L_INSTR",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).L_INSTR",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 1,
+                                "maxLength": 1
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_INSTR(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_INSTR"
+                    },
+                    {
+                        "id": "REM_MATURITY",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).REM_MATURITY",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 1,
+                                "maxLength": 1
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_ISSUE_MAT(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).REM_MATURITY"
+                    },
+                    {
+                        "id": "CURR_TYPE_BOOK",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).CURR_TYPE_BOOK",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 3,
+                                "maxLength": 3
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CURRENCY_3POS(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).CURR_TYPE_BOOK"
+                    },
+                    {
+                        "id": "L_CP_SECTOR",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).L_CP_SECTOR",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 1,
+                                "maxLength": 1
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_SECTOR(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_CP_SECTOR"
+                    },
+                    {
+                        "id": "L_CP_COUNTRY",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).L_CP_COUNTRY",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 2,
+                                "maxLength": 2
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_BIS_IF_REF_AREA(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_CP_COUNTRY"
+                    },
+                    {
+                        "id": "TIME_PERIOD",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.TimeDimension=BIS:BIS_CBS(1.0).TIME_PERIOD",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "ObservationalTimePeriod"
+                            }
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).TIME_PERIOD",
+                        "isTimeDimension": true
+                    }
+                ]
+            },
+            "attributeList": {
+                "attributes": [
+                    {
+                        "id": "OBS_STATUS",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).OBS_STATUS",
+                        "representation": {
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_OBS_STATUS(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_STATUS",
+                        "mandatory": true,
+                        "attachmentLevel": "OBSERVATION",
+                        "measureReferences": [
+                            "OBS_VALUE"
+                        ]
+                    },
+                    {
+                        "id": "OBS_CONF",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).OBS_CONF",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 1,
+                                "maxLength": 1
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CONF_STATUS(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_CONF",
+                        "mandatory": false,
+                        "attachmentLevel": "OBSERVATION",
+                        "measureReferences": [
+                            "OBS_VALUE"
+                        ]
+                    },
+                    {
+                        "id": "OBS_PRE_BREAK",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).OBS_PRE_BREAK",
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_PRE_BREAK",
+                        "mandatory": false,
+                        "attachmentLevel": "OBSERVATION",
+                        "measureReferences": [
+                            "OBS_VALUE"
+                        ]
+                    },
+                    {
+                        "id": "AVAILABILITY",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).AVAILABILITY",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 1,
+                                "maxLength": 1
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.ValueList=BIS:CL_AVAILABILITY(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).AVAILABILITY",
+                        "mandatory": true,
+                        "attachmentLevel": "GROUP",
+                        "attachmentGroup": "Sibling"
+                    },
+                    {
+                        "id": "COLLECTION",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).COLLECTION",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 1,
+                                "maxLength": 1
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_COLLECTION(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).COLLECTION",
+                        "mandatory": true,
+                        "attachmentLevel": "DIMENSION_GROUP",
+                        "dimensionReferences": [
+                            "FREQ",
+                            "L_MEASURE",
+                            "L_REP_CTY",
+                            "CBS_BANK_TYPE",
+                            "CBS_BASIS",
+                            "L_POSITION",
+                            "L_INSTR",
+                            "REM_MATURITY",
+                            "CURR_TYPE_BOOK",
+                            "L_CP_SECTOR",
+                            "L_CP_COUNTRY"
+                        ]
+                    },
+                    {
+                        "id": "DECIMALS",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).DECIMALS",
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).DECIMALS",
+                        "mandatory": true,
+                        "attachmentLevel": "DATA_SET"
+                    },
+                    {
+                        "id": "ORG_VISIBILITY",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).ORG_VISIBILITY",
+                        "representation": {
+                            "minOccurs": 1,
+                            "maxOccurs": 10,
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 1,
+                                "maxLength": 1
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_ORG_VISIBILITY(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).ORG_VISIBILITY",
+                        "mandatory": false,
+                        "attachmentLevel": "DIMENSION_GROUP",
+                        "dimensionReferences": [
+                            "FREQ",
+                            "L_MEASURE",
+                            "L_REP_CTY",
+                            "CBS_BANK_TYPE",
+                            "CBS_BASIS",
+                            "L_POSITION",
+                            "L_INSTR",
+                            "REM_MATURITY",
+                            "CURR_TYPE_BOOK",
+                            "L_CP_SECTOR",
+                            "L_CP_COUNTRY"
+                        ]
+                    },
+                    {
+                        "id": "TITLE_GRP",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).TITLE_GRP",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 1,
+                                "maxLength": 200
+                            }
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).TITLE_GRP",
+                        "mandatory": false,
+                        "attachmentLevel": "GROUP",
+                        "attachmentGroup": "Sibling"
+                    },
+                    {
+                        "id": "UNIT_MEASURE",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).UNIT_MEASURE",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "String",
+                                "minLength": 3,
+                                "maxLength": 3
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CURRENCY_3POS(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).UNIT_MEASURE",
+                        "mandatory": true,
+                        "attachmentLevel": "DATA_SET"
+                    },
+                    {
+                        "id": "UNIT_MULT",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).UNIT_MULT",
+                        "representation": {
+                            "textFormat": {
+                                "textType": "Integer",
+                                "minLength": 1,
+                                "maxLength": 2,
+                                "minValue": "-15",
+                                "maxValue": "15"
+                            },
+                            "representation": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_UNIT_MULT(1.0)"
+                        },
+                        "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).UNIT_MULT",
+                        "mandatory": true,
+                        "attachmentLevel": "DATA_SET"
+                    }
+                ]
+            },
+            "measures": [
+                {
+                    "id": "OBS_VALUE",
+                    "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Measure=BIS:BIS_CBS(1.0).OBS_VALUE",
+                    "representation": {
+                        "textFormat": {
+                            "textType": "String",
+                            "minLength": 1,
+                            "maxLength": 15
+                        }
+                    },
+                    "concept": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_VALUE",
+                    "mandatory": true
+                }
+            ],
+            "groups": [
+                {
+                    "id": "Sibling",
+                    "dimensionReferences": [
+                        "L_MEASURE",
+                        "L_REP_CTY",
+                        "CBS_BANK_TYPE",
+                        "CBS_BASIS",
+                        "L_POSITION",
+                        "L_INSTR",
+                        "REM_MATURITY",
+                        "CURR_TYPE_BOOK",
+                        "L_CP_SECTOR",
+                        "L_CP_COUNTRY"
+                    ]
+                }
+            ]
+        }
+    ],
+    "DataConstraint": [
+        {
+            "id": "ASSETSLIABILITIES",
+            "urn": "urn:sdmx:org.sdmx.infomodel.registry.DataConstraint=BIS.CBS:ASSETSLIABILITIES(1.0)",
+            "names": [
+                {
+                    "locale": "en",
+                    "value": "Constraints for the CBS Assets and Liabilities dataflow"
+                }
+            ],
+            "agencyId": "BIS.CBS",
+            "version": "1.0",
+            "isFinal": false,
+            "startDate": 1380585600000,
+            "definingDataPresent": false,
+            "type": "SeriesConstraint",
+            "attachments": [
+                "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS.CBS:CBS_AL(1.0)"
+            ],
+            "excludeSeries": {
+                "dims": [
+                    "CBS_BASIS",
+                    "L_POSITION",
+                    "L_INSTR",
+                    "REM_MATURITY",
+                    "CURR_TYPE_BOOK",
+                    "L_CP_SECTOR"
+                ],
+                "comps": [],
+                "rows": [
+                    [
+                        "F",
+                        "L",
+                        "A",
+                        "A",
+                        "TO1",
+                        "A"
+                    ],
+                    [
+                        "F",
+                        "L",
+                        "G",
+                        "A",
+                        "TO1",
+                        "A"
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/tests/api/fmr/samples/df/excl_keyset_schema.json
+++ b/tests/api/fmr/samples/df/excl_keyset_schema.json
@@ -1,0 +1,1937 @@
+{
+    "meta": {
+        "id": "IREF909102",
+        "test": false,
+        "schema": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+        "prepared": "2023-07-31T08:08:32Z",
+        "contentLanguages": [
+            "en"
+        ],
+        "sender": {
+            "id": "FusionRegistry"
+        },
+        "links": [
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS.CBS:CBS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=BIS:BIS_CBS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.registry.DataConstraint=BIS:CBS_CPC(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.registry.DataConstraint=BIS.CBS:CBS_CONSTRAINTS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.base.AgencyScheme=SDMX:AGENCIES(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.ValueList=BIS:CL_AVAILABILITY(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_BIS_IF_REF_AREA(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CBS_BASIS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_COLLECTION(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CONF_STATUS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CURRENCY_3POS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_DECIMALS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_FREQ(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_ISSUE_MAT(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_INSTR(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_POSITION(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_SECTOR(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_OBS_STATUS(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_ORG_VISIBILITY(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_STOCK_FLOW(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_TIME_FORMAT(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_UNIT_MULT(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=BIS:STANDALONE_CONCEPT_SCHEME(1.0)"
+            },
+            {
+                "urn": "urn:sdmx:org.sdmx.infomodel.registry.DataConstraint=BIS:BIS_CBS(1.0)"
+            }
+        ]
+    },
+    "data": {
+        "agencySchemes": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "agencyscheme",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.base.AgencyScheme=SDMX:AGENCIES(1.0)"
+                    }
+                ],
+                "id": "AGENCIES",
+                "name": "SDMX Agency Scheme",
+                "names": {
+                    "en": "SDMX Agency Scheme"
+                },
+                "version": "1.0",
+                "agencyID": "SDMX",
+                "isExternalReference": false,
+                "isPartial": true,
+                "agencies": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "agency",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.base.Agency=SDMX:AGENCIES(1.0).BIS"
+                            }
+                        ],
+                        "id": "BIS",
+                        "annotations": [
+                            {
+                                "title": "xx000000",
+                                "type": "contact_uid"
+                            }
+                        ],
+                        "name": "Bank for International Settlements",
+                        "names": {
+                            "en": "Bank for International Settlements"
+                        },
+                        "description": "Bank for International Settlements",
+                        "descriptions": {
+                            "en": "Bank for International Settlements"
+                        }
+                    }
+                ]
+            }
+        ],
+        "valuelists": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.ValueList=BIS:CL_AVAILABILITY(1.0)"
+                    }
+                ],
+                "id": "CL_AVAILABILITY",
+                "name": "Availability",
+                "names": {
+                    "en": "Availability"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": false,
+                "valueItems": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_AVAILABILITY(1.0).A"
+                            }
+                        ],
+                        "id": "A",
+                        "name": "All users",
+                        "names": {
+                            "en": "All users"
+                        }
+                    }
+                ]
+            }
+        ],
+        "codelists": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_BIS_IF_REF_AREA(1.0)"
+                    }
+                ],
+                "id": "CL_BIS_IF_REF_AREA",
+                "name": "Reference Area Code for BIS-IFS",
+                "names": {
+                    "en": "Reference Area Code for BIS-IFS"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_BIS_IF_REF_AREA(1.0).1C"
+                            }
+                        ],
+                        "id": "1C",
+                        "name": "International organisations",
+                        "names": {
+                            "en": "International organisations"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CBS_BASIS(1.0)"
+                    }
+                ],
+                "id": "CL_CBS_BASIS",
+                "name": "CBS basis",
+                "names": {
+                    "en": "CBS basis"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_CBS_BASIS(1.0).F"
+                            }
+                        ],
+                        "id": "F",
+                        "name": "Immediate counterparty basis",
+                        "names": {
+                            "en": "Immediate counterparty basis"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_COLLECTION(1.0)"
+                    }
+                ],
+                "id": "CL_COLLECTION",
+                "name": "Collection",
+                "names": {
+                    "en": "Collection"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_COLLECTION(1.0).E"
+                            }
+                        ],
+                        "id": "E",
+                        "name": "End of period",
+                        "names": {
+                            "en": "End of period"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CONF_STATUS(1.0)"
+                    }
+                ],
+                "id": "CL_CONF_STATUS",
+                "name": "Observation confidentiality code list",
+                "names": {
+                    "en": "Observation confidentiality code list"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_CONF_STATUS(1.0).F"
+                            }
+                        ],
+                        "id": "F",
+                        "name": "Free",
+                        "names": {
+                            "en": "Free"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CURRENCY_3POS(1.0)"
+                    }
+                ],
+                "id": "CL_CURRENCY_3POS",
+                "name": "Currency",
+                "names": {
+                    "en": "Currency"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_CURRENCY_3POS(1.0).FC1"
+                            }
+                        ],
+                        "id": "FC1",
+                        "name": "Foreign currency",
+                        "names": {
+                            "en": "Foreign currency"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_DECIMALS(1.0)"
+                    }
+                ],
+                "id": "CL_DECIMALS",
+                "name": "Decimals codelist (BIS, ECB)",
+                "names": {
+                    "en": "Decimals codelist (BIS, ECB)"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_DECIMALS(1.0).6"
+                            }
+                        ],
+                        "id": "6",
+                        "name": "Six",
+                        "names": {
+                            "en": "Six"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_FREQ(1.0)"
+                    }
+                ],
+                "id": "CL_FREQ",
+                "name": "Code list for Frequency (FREQ)",
+                "names": {
+                    "en": "Code list for Frequency (FREQ)"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).Q"
+                            }
+                        ],
+                        "id": "Q",
+                        "name": "Quarterly",
+                        "names": {
+                            "en": "Quarterly"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_ISSUE_MAT(1.0)"
+                    }
+                ],
+                "id": "CL_ISSUE_MAT",
+                "name": "Issue maturity code list",
+                "names": {
+                    "en": "Issue maturity code list"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_ISSUE_MAT(1.0).A"
+                            }
+                        ],
+                        "id": "A",
+                        "name": "Total (all maturities)",
+                        "names": {
+                            "en": "Total (all maturities)"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_INSTR(1.0)"
+                    }
+                ],
+                "id": "CL_L_INSTR",
+                "name": "Instrument",
+                "names": {
+                    "en": "Instrument"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_L_INSTR(1.0).A"
+                            }
+                        ],
+                        "id": "A",
+                        "name": "All instruments",
+                        "names": {
+                            "en": "All instruments"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_POSITION(1.0)"
+                    }
+                ],
+                "id": "CL_L_POSITION",
+                "name": "Position type",
+                "names": {
+                    "en": "Position type"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_L_POSITION(1.0).B"
+                            }
+                        ],
+                        "id": "B",
+                        "name": "Local claims",
+                        "names": {
+                            "en": "Local claims"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_SECTOR(1.0)"
+                    }
+                ],
+                "id": "CL_L_SECTOR",
+                "name": "Counterparty Sector",
+                "names": {
+                    "en": "Counterparty Sector"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_L_SECTOR(1.0).A"
+                            }
+                        ],
+                        "id": "A",
+                        "name": "All sectors",
+                        "names": {
+                            "en": "All sectors"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_OBS_STATUS(1.0)"
+                    }
+                ],
+                "id": "CL_OBS_STATUS",
+                "name": "Observation status codelist (BIS, ECB, Eurostat-BoP)",
+                "names": {
+                    "en": "Observation status codelist (BIS, ECB, Eurostat-BoP)"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": false,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_OBS_STATUS(1.0).A"
+                            }
+                        ],
+                        "id": "A",
+                        "name": "Normal value",
+                        "names": {
+                            "en": "Normal value"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_ORG_VISIBILITY(1.0)"
+                    }
+                ],
+                "id": "CL_ORG_VISIBILITY",
+                "name": "Visibility",
+                "names": {
+                    "en": "Visibility"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": false,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_ORG_VISIBILITY(1.0).A"
+                            }
+                        ],
+                        "id": "A",
+                        "name": "CBs, ESRB and IMF",
+                        "names": {
+                            "en": "CBs, ESRB and IMF"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_STOCK_FLOW(1.0)"
+                    }
+                ],
+                "id": "CL_STOCK_FLOW",
+                "name": "Stock, flow",
+                "names": {
+                    "en": "Stock, flow"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_STOCK_FLOW(1.0).S"
+                            }
+                        ],
+                        "id": "S",
+                        "name": "Amounts outstanding / Stocks",
+                        "names": {
+                            "en": "Amounts outstanding / Stocks"
+                        }
+                    }
+                ]
+            },
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "codelist",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_UNIT_MULT(1.0)"
+                    }
+                ],
+                "id": "CL_UNIT_MULT",
+                "name": "Unit Multiplier",
+                "names": {
+                    "en": "Unit Multiplier"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "codes": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "code",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_UNIT_MULT(1.0).6"
+                            }
+                        ],
+                        "id": "6",
+                        "name": "Millions",
+                        "names": {
+                            "en": "Millions"
+                        }
+                    }
+                ]
+            }
+        ],
+        "conceptSchemes": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "conceptscheme",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.ConceptScheme=BIS:STANDALONE_CONCEPT_SCHEME(1.0)"
+                    }
+                ],
+                "id": "STANDALONE_CONCEPT_SCHEME",
+                "name": "Default Scheme",
+                "names": {
+                    "en": "Default Scheme"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "isPartial": true,
+                "concepts": [
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).TIME_FORMAT"
+                            }
+                        ],
+                        "id": "TIME_FORMAT",
+                        "name": "Time Format",
+                        "names": {
+                            "en": "Time Format"
+                        },
+                        "coreRepresentation": {
+                            "enumerationFormat": {
+                                "maxLength": 3,
+                                "minLength": 3,
+                                "dataType": "String"
+                            },
+                            "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_TIME_FORMAT(1.0)"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).AVAILABILITY"
+                            }
+                        ],
+                        "id": "AVAILABILITY",
+                        "name": "Availability",
+                        "names": {
+                            "en": "Availability"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).CBS_BANK_TYPE"
+                            }
+                        ],
+                        "id": "CBS_BANK_TYPE",
+                        "name": "CBS bank type",
+                        "names": {
+                            "en": "CBS bank type"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).CBS_BASIS"
+                            }
+                        ],
+                        "id": "CBS_BASIS",
+                        "name": "CBS reporting basis",
+                        "names": {
+                            "en": "CBS reporting basis"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).COLLECTION"
+                            }
+                        ],
+                        "id": "COLLECTION",
+                        "name": "Collection Indicator",
+                        "names": {
+                            "en": "Collection Indicator"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).CURR_TYPE_BOOK"
+                            }
+                        ],
+                        "id": "CURR_TYPE_BOOK",
+                        "name": "Currency type of booking location",
+                        "names": {
+                            "en": "Currency type of booking location"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).DECIMALS"
+                            }
+                        ],
+                        "id": "DECIMALS",
+                        "name": "Decimals",
+                        "names": {
+                            "en": "Decimals"
+                        },
+                        "coreRepresentation": {
+                            "enumerationFormat": {
+                                "maxLength": 2,
+                                "minLength": 1,
+                                "dataType": "BigInteger"
+                            },
+                            "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_DECIMALS(1.0)"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).FREQ"
+                            }
+                        ],
+                        "id": "FREQ",
+                        "name": "Frequency",
+                        "names": {
+                            "en": "Frequency"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_CP_COUNTRY"
+                            }
+                        ],
+                        "id": "L_CP_COUNTRY",
+                        "name": "Counterparty country",
+                        "names": {
+                            "en": "Counterparty country"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_CP_SECTOR"
+                            }
+                        ],
+                        "id": "L_CP_SECTOR",
+                        "name": "Counterparty sector",
+                        "names": {
+                            "en": "Counterparty sector"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_INSTR"
+                            }
+                        ],
+                        "id": "L_INSTR",
+                        "name": "Type of instruments",
+                        "names": {
+                            "en": "Type of instruments"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_MEASURE"
+                            }
+                        ],
+                        "id": "L_MEASURE",
+                        "name": "Measure",
+                        "names": {
+                            "en": "Measure"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_POSITION"
+                            }
+                        ],
+                        "id": "L_POSITION",
+                        "name": "Balance sheet position",
+                        "names": {
+                            "en": "Balance sheet position"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_REP_CTY"
+                            }
+                        ],
+                        "id": "L_REP_CTY",
+                        "name": "Reporting country",
+                        "names": {
+                            "en": "Reporting country"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_CONF"
+                            }
+                        ],
+                        "id": "OBS_CONF",
+                        "name": "Observation Confidentiality",
+                        "names": {
+                            "en": "Observation Confidentiality"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_PRE_BREAK"
+                            }
+                        ],
+                        "id": "OBS_PRE_BREAK",
+                        "name": "Pre-Break Observation",
+                        "names": {
+                            "en": "Pre-Break Observation"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_STATUS"
+                            }
+                        ],
+                        "id": "OBS_STATUS",
+                        "name": "Observation Status",
+                        "names": {
+                            "en": "Observation Status"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_VALUE"
+                            }
+                        ],
+                        "id": "OBS_VALUE",
+                        "name": "Observation Value",
+                        "names": {
+                            "en": "Observation Value"
+                        },
+                        "description": "Description for a measure",
+                        "descriptions": {
+                            "en": "Description for a measure"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).ORG_VISIBILITY"
+                            }
+                        ],
+                        "id": "ORG_VISIBILITY",
+                        "name": "Organisation visibility",
+                        "names": {
+                            "en": "Organisation visibility"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).REM_MATURITY"
+                            }
+                        ],
+                        "id": "REM_MATURITY",
+                        "name": "Remaining maturity",
+                        "names": {
+                            "en": "Remaining maturity"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).TIME_PERIOD"
+                            }
+                        ],
+                        "id": "TIME_PERIOD",
+                        "name": "Time period or range",
+                        "names": {
+                            "en": "Time period or range"
+                        },
+                        "description": "Description for a dimension",
+                        "descriptions": {
+                            "en": "Description for a dimension"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).TITLE_GRP"
+                            }
+                        ],
+                        "id": "TITLE_GRP",
+                        "name": "Title",
+                        "names": {
+                            "en": "Title"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).UNIT_MEASURE"
+                            }
+                        ],
+                        "id": "UNIT_MEASURE",
+                        "name": "Unit of measure",
+                        "names": {
+                            "en": "Unit of measure"
+                        },
+                        "description": "Description for an attribute",
+                        "descriptions": {
+                            "en": "Description for an attribute"
+                        }
+                    },
+                    {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "concept",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/1.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).UNIT_MULT"
+                            }
+                        ],
+                        "id": "UNIT_MULT",
+                        "name": "Unit Multiplier",
+                        "names": {
+                            "en": "Unit Multiplier"
+                        }
+                    }
+                ]
+            }
+        ],
+        "dataStructures": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "datastructure",
+                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=BIS:BIS_CBS(1.0)"
+                    },
+                    {
+                        "rel": "metadata",
+                        "href": "https://mms-med-fmr-dev.apps.ocp-dev.opz.bisinfo.org/sdmx/v2/metadata/metadataset/BIS.MEDIT/STI_BIS_CBS/1.0",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.metadatastructure.MetadataSet=BIS.MEDIT:STI_BIS_CBS(1.0)"
+                    }
+                ],
+                "id": "BIS_CBS",
+                "name": "Consolidated Banking Statistics",
+                "names": {
+                    "en": "Consolidated Banking Statistics"
+                },
+                "description": "This dataflow is associated to the BIS_CBS DSD. It implements the data requirement laid out in the July 2019 IBS Reporting Guidelines | PDF version: BIS_CBS_V2020.02.19",
+                "descriptions": {
+                    "en": "This dataflow is associated to the BIS_CBS DSD. It implements the data requirement laid out in the July 2019 IBS Reporting Guidelines | PDF version: BIS_CBS_V2020.02.19"
+                },
+                "version": "1.0",
+                "agencyID": "BIS",
+                "isExternalReference": false,
+                "dataStructureComponents": {
+                    "attributeList": {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "attributedescriptor",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.AttributeDescriptor=BIS:BIS_CBS(1.0).AttributeDescriptor"
+                            }
+                        ],
+                        "id": "AttributeDescriptor",
+                        "attributes": [
+                            {
+                                "usage": "mandatory",
+                                "attributeRelationship": {
+                                    "observation": {}
+                                },
+                                "measureRelationship": [
+                                    "OBS_VALUE"
+                                ],
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).OBS_STATUS"
+                                    }
+                                ],
+                                "id": "OBS_STATUS",
+                                "localRepresentation": {
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_OBS_STATUS(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_STATUS"
+                            },
+                            {
+                                "usage": "optional",
+                                "attributeRelationship": {
+                                    "observation": {}
+                                },
+                                "measureRelationship": [
+                                    "OBS_VALUE"
+                                ],
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).OBS_CONF"
+                                    }
+                                ],
+                                "id": "OBS_CONF",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 1,
+                                        "minLength": 1,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CONF_STATUS(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_CONF"
+                            },
+                            {
+                                "usage": "optional",
+                                "attributeRelationship": {
+                                    "observation": {}
+                                },
+                                "measureRelationship": [
+                                    "OBS_VALUE"
+                                ],
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).OBS_PRE_BREAK"
+                                    }
+                                ],
+                                "id": "OBS_PRE_BREAK",
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_PRE_BREAK"
+                            },
+                            {
+                                "usage": "mandatory",
+                                "attributeRelationship": {
+                                    "group": "Sibling"
+                                },
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).AVAILABILITY"
+                                    }
+                                ],
+                                "id": "AVAILABILITY",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 1,
+                                        "minLength": 1,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.ValueList=BIS:CL_AVAILABILITY(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).AVAILABILITY"
+                            },
+                            {
+                                "usage": "mandatory",
+                                "attributeRelationship": {
+                                    "dimensions": [
+                                        "FREQ",
+                                        "L_MEASURE",
+                                        "L_REP_CTY",
+                                        "CBS_BANK_TYPE",
+                                        "CBS_BASIS",
+                                        "L_POSITION",
+                                        "L_INSTR",
+                                        "REM_MATURITY",
+                                        "CURR_TYPE_BOOK",
+                                        "L_CP_SECTOR",
+                                        "L_CP_COUNTRY"
+                                    ]
+                                },
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).COLLECTION"
+                                    }
+                                ],
+                                "id": "COLLECTION",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 1,
+                                        "minLength": 1,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_COLLECTION(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).COLLECTION"
+                            },
+                            {
+                                "usage": "mandatory",
+                                "attributeRelationship": {
+                                    "dataflow": {}
+                                },
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).DECIMALS"
+                                    }
+                                ],
+                                "id": "DECIMALS",
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).DECIMALS"
+                            },
+                            {
+                                "usage": "optional",
+                                "attributeRelationship": {
+                                    "dimensions": [
+                                        "FREQ",
+                                        "L_MEASURE",
+                                        "L_REP_CTY",
+                                        "CBS_BANK_TYPE",
+                                        "CBS_BASIS",
+                                        "L_POSITION",
+                                        "L_INSTR",
+                                        "REM_MATURITY",
+                                        "CURR_TYPE_BOOK",
+                                        "L_CP_SECTOR",
+                                        "L_CP_COUNTRY"
+                                    ]
+                                },
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).ORG_VISIBILITY"
+                                    }
+                                ],
+                                "id": "ORG_VISIBILITY",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 1,
+                                        "minLength": 1,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_ORG_VISIBILITY(1.0)",
+                                    "minOccurs": 1,
+                                    "maxOccurs": 10
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).ORG_VISIBILITY"
+                            },
+                            {
+                                "usage": "optional",
+                                "attributeRelationship": {
+                                    "group": "Sibling"
+                                },
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).TITLE_GRP"
+                                    }
+                                ],
+                                "id": "TITLE_GRP",
+                                "localRepresentation": {
+                                    "format": {
+                                        "maxLength": 1,
+                                        "minLength": 250,
+                                        "dataType": "String"
+                                    }
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).TITLE_GRP"
+                            },
+                            {
+                                "usage": "mandatory",
+                                "attributeRelationship": {
+                                    "dataflow": {}
+                                },
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).UNIT_MEASURE"
+                                    }
+                                ],
+                                "id": "UNIT_MEASURE",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 3,
+                                        "minLength": 3,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CURRENCY_3POS(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).UNIT_MEASURE"
+                            },
+                            {
+                                "usage": "mandatory",
+                                "attributeRelationship": {
+                                    "dataflow": {}
+                                },
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dataattribute",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DataAttribute=BIS:BIS_CBS(1.0).UNIT_MULT"
+                                    }
+                                ],
+                                "id": "UNIT_MULT",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 2,
+                                        "minLength": 1,
+                                        "minValue": -15,
+                                        "maxValue": 15,
+                                        "dataType": "Integer"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_UNIT_MULT(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).UNIT_MULT"
+                            }
+                        ]
+                    },
+                    "dimensionList": {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "dimensiondescriptor",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.DimensionDescriptor=BIS:BIS_CBS(1.0).DimensionDescriptor"
+                            }
+                        ],
+                        "id": "DimensionDescriptor",
+                        "dimensions": [
+                            {
+                                "position": 1,
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dimension",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).FREQ"
+                                    }
+                                ],
+                                "id": "FREQ",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 1,
+                                        "minLength": 1,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_FREQ(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).FREQ"
+                            },
+                            {
+                                "position": 2,
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dimension",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).L_MEASURE"
+                                    }
+                                ],
+                                "id": "L_MEASURE",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 1,
+                                        "minLength": 1,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_STOCK_FLOW(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_MEASURE"
+                            },
+                            {
+                                "position": 3,
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dimension",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).L_REP_CTY"
+                                    }
+                                ],
+                                "id": "L_REP_CTY",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 2,
+                                        "minLength": 2,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_BIS_IF_REF_AREA(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_REP_CTY"
+                            },
+                            {
+                                "position": 4,
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dimension",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).CBS_BANK_TYPE"
+                                    }
+                                ],
+                                "id": "CBS_BANK_TYPE",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 2,
+                                        "minLength": 2,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_BIS_IF_REF_AREA(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).CBS_BANK_TYPE"
+                            },
+                            {
+                                "position": 5,
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dimension",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).CBS_BASIS"
+                                    }
+                                ],
+                                "id": "CBS_BASIS",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 1,
+                                        "minLength": 1,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CBS_BASIS(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).CBS_BASIS"
+                            },
+                            {
+                                "position": 6,
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dimension",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).L_POSITION"
+                                    }
+                                ],
+                                "id": "L_POSITION",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 1,
+                                        "minLength": 1,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_POSITION(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_POSITION"
+                            },
+                            {
+                                "position": 7,
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dimension",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).L_INSTR"
+                                    }
+                                ],
+                                "id": "L_INSTR",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 1,
+                                        "minLength": 1,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_INSTR(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_INSTR"
+                            },
+                            {
+                                "position": 8,
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dimension",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).REM_MATURITY"
+                                    }
+                                ],
+                                "id": "REM_MATURITY",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 1,
+                                        "minLength": 1,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_ISSUE_MAT(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).REM_MATURITY"
+                            },
+                            {
+                                "position": 9,
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dimension",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).CURR_TYPE_BOOK"
+                                    }
+                                ],
+                                "id": "CURR_TYPE_BOOK",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 3,
+                                        "minLength": 3,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_CURRENCY_3POS(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).CURR_TYPE_BOOK"
+                            },
+                            {
+                                "position": 10,
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dimension",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).L_CP_SECTOR"
+                                    }
+                                ],
+                                "id": "L_CP_SECTOR",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 1,
+                                        "minLength": 1,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_L_SECTOR(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_CP_SECTOR"
+                            },
+                            {
+                                "position": 11,
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "dimension",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:BIS_CBS(1.0).L_CP_COUNTRY"
+                                    }
+                                ],
+                                "id": "L_CP_COUNTRY",
+                                "localRepresentation": {
+                                    "enumerationFormat": {
+                                        "maxLength": 2,
+                                        "minLength": 2,
+                                        "dataType": "String"
+                                    },
+                                    "enumeration": "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL_BIS_IF_REF_AREA(1.0)"
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).L_CP_COUNTRY"
+                            }
+                        ],
+                        "timeDimension": {
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "type": "timedimension",
+                                    "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                    "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.TimeDimension=BIS:BIS_CBS(1.0).TIME_PERIOD"
+                                }
+                            ],
+                            "id": "TIME_PERIOD",
+                            "localRepresentation": {
+                                "format": {
+                                    "dataType": "ObservationalTimePeriod"
+                                }
+                            },
+                            "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).TIME_PERIOD"
+                        }
+                    },
+                    "groups": [
+                        {
+                            "links": [
+                                {
+                                    "rel": "self",
+                                    "type": "groupdimensiondescriptor",
+                                    "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                    "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.GroupDimensionDescriptor=BIS:BIS_CBS(1.0).Sibling"
+                                }
+                            ],
+                            "id": "Sibling",
+                            "groupDimensions": [
+                                "L_MEASURE",
+                                "L_REP_CTY",
+                                "CBS_BANK_TYPE",
+                                "CBS_BASIS",
+                                "L_POSITION",
+                                "L_INSTR",
+                                "REM_MATURITY",
+                                "CURR_TYPE_BOOK",
+                                "L_CP_SECTOR",
+                                "L_CP_COUNTRY"
+                            ]
+                        }
+                    ],
+                    "measureList": {
+                        "links": [
+                            {
+                                "rel": "self",
+                                "type": "measuredescriptor",
+                                "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.MeasureDescriptor=BIS:BIS_CBS(1.0).MeasureDescriptor"
+                            }
+                        ],
+                        "id": "MeasureDescriptor",
+                        "measures": [
+                            {
+                                "usage": "mandatory",
+                                "links": [
+                                    {
+                                        "rel": "self",
+                                        "type": "primarymeasure",
+                                        "uri": "https://raw.githubusercontent.com/sdmx-twg/sdmx-json/develop/structure-message/tools/schemas/2.0.0/sdmx-json-structure-schema.json",
+                                        "urn": "urn:sdmx:org.sdmx.infomodel.datastructure.Measure=BIS:BIS_CBS(1.0).OBS_VALUE"
+                                    }
+                                ],
+                                "id": "OBS_VALUE",
+                                "localRepresentation": {
+                                    "format": {
+                                        "maxLength": 15,
+                                        "minLength": 1,
+                                        "dataType": "String"
+                                    }
+                                },
+                                "conceptIdentity": "urn:sdmx:org.sdmx.infomodel.conceptscheme.Concept=BIS:STANDALONE_CONCEPT_SCHEME(1.0).OBS_VALUE"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "dataConstraints": [
+            {
+                "links": [
+                    {
+                        "rel": "self",
+                        "type": "dataconstraint",
+                        "uri": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+                        "urn": "urn:sdmx:org.sdmx.infomodel.registry.DataConstraint=BIS.CBS:ASSETSLIABILITIES(1.0)"
+                    }
+                ],
+                "id": "ASSETSLIABILITIES",
+                "name": "Constraints for the CBS Assets and Liabilities dataflow",
+                "names": {
+                    "en": "Constraints for the CBS Assets and Liabilities dataflow"
+                },
+                "version": "1.0",
+                "agencyID": "BIS.CBS",
+                "isExternalReference": false,
+                "validFrom": "2013-10-01T00:00:00",
+                "role": "Allowed",
+                "constraintAttachment": {
+                    "dataflows": [
+                        "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS.CBS:CBS_AL(1.0)"
+                    ]
+                },
+                "dataKeySets": [
+                    {
+                        "isIncluded": false,
+                        "keys": [
+                            {
+                                "keyValues": [
+                                    {
+                                        "id": "CBS_BASIS",
+                                        "value": "F"
+                                    },
+                                    {
+                                        "id": "L_POSITION",
+                                        "value": "L"
+                                    },
+                                    {
+                                        "id": "L_INSTR",
+                                        "value": "A"
+                                    },
+                                    {
+                                        "id": "REM_MATURITY",
+                                        "value": "A"
+                                    },
+                                    {
+                                        "id": "CURR_TYPE_BOOK",
+                                        "value": "TO1"
+                                    },
+                                    {
+                                        "id": "L_CP_SECTOR",
+                                        "value": "A"
+                                    }
+                                ],
+                                "components": [
+                                    {
+                                        "id": "CBS_BASIS",
+                                        "values": [
+                                            {
+                                                "value": "F"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "L_POSITION",
+                                        "values": [
+                                            {
+                                                "value": "L"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "L_INSTR",
+                                        "values": [
+                                            {
+                                                "value": "A"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "REM_MATURITY",
+                                        "values": [
+                                            {
+                                                "value": "A"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "CURR_TYPE_BOOK",
+                                        "values": [
+                                            {
+                                                "value": "TO1"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "L_CP_SECTOR",
+                                        "values": [
+                                            {
+                                                "value": "A"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "keyValues": [
+                                    {
+                                        "id": "CBS_BASIS",
+                                        "value": "F"
+                                    },
+                                    {
+                                        "id": "L_POSITION",
+                                        "value": "L"
+                                    },
+                                    {
+                                        "id": "L_INSTR",
+                                        "value": "G"
+                                    },
+                                    {
+                                        "id": "REM_MATURITY",
+                                        "value": "A"
+                                    },
+                                    {
+                                        "id": "CURR_TYPE_BOOK",
+                                        "value": "TO1"
+                                    },
+                                    {
+                                        "id": "L_CP_SECTOR",
+                                        "value": "A"
+                                    }
+                                ],
+                                "components": [
+                                    {
+                                        "id": "CBS_BASIS",
+                                        "values": [
+                                            {
+                                                "value": "F"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "L_POSITION",
+                                        "values": [
+                                            {
+                                                "value": "L"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "L_INSTR",
+                                        "values": [
+                                            {
+                                                "value": "G"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "REM_MATURITY",
+                                        "values": [
+                                            {
+                                                "value": "A"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "CURR_TYPE_BOOK",
+                                        "values": [
+                                            {
+                                                "value": "TO1"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "id": "L_CP_SECTOR",
+                                        "values": [
+                                            {
+                                                "value": "A"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/api/fmr/schema_checks.py
+++ b/tests/api/fmr/schema_checks.py
@@ -88,7 +88,7 @@ def check_keyset_schema(
     body,
     hca_body,
 ):
-    """get_schema() should return a schema."""
+    """get_schema() should return a schema, with an inclusivekeyset."""
     mock.get(hca_query).mock(
         return_value=httpx.Response(200, content=hca_body)
     )
@@ -100,7 +100,33 @@ def check_keyset_schema(
 
     assert isinstance(vc, Schema)
     assert len(vc.keys) == 2
+    assert vc.excluded_keys is None
     for k in vc.keys:
+        assert k in ["*.*.*.*.F.L.A.A.TO1.A.*", "*.*.*.*.F.L.G.A.TO1.A.*"]
+
+
+def check_exclusive_keyset_schema(
+    mock,
+    fmr: RegistryClient,
+    query,
+    hca_query,
+    body,
+    hca_body,
+):
+    """get_schema() should return a schema, with an exclusive keyset."""
+    mock.get(hca_query).mock(
+        return_value=httpx.Response(200, content=hca_body)
+    )
+    mock.get(query).mock(return_value=httpx.Response(200, content=body))
+
+    vc = fmr.get_schema("dataflow", "BIS.CBS", "CBS", "1.0")
+
+    assert len(mock.calls) == 2  # We fetch hierarchies too in this case
+
+    assert isinstance(vc, Schema)
+    assert vc.keys is None
+    assert len(vc.excluded_keys) == 2
+    for k in vc.excluded_keys:
         assert k in ["*.*.*.*.F.L.A.A.TO1.A.*", "*.*.*.*.F.L.G.A.TO1.A.*"]
 
 

--- a/tests/api/fmr/sdmx/test_schemas.py
+++ b/tests/api/fmr/sdmx/test_schemas.py
@@ -82,6 +82,12 @@ def keyset_body():
 
 
 @pytest.fixture
+def excl_keyset_body():
+    with open("tests/api/fmr/samples/df/excl_keyset_schema.json", "rb") as f:
+        return f.read()
+
+
+@pytest.fixture
 def no_td_body():
     with open("tests/api/fmr/samples/df/no_td.json", "rb") as f:
         return f.read()
@@ -129,21 +135,30 @@ def no_hca_body():
         return f.read()
 
 
-def test_returns_validation_context(
+def test_returns_schema(
     respx_mock, fmr, query, no_hca_query, body, no_hca_body
 ):
-    """get_validation_context() should return a schema."""
+    """get_schema() should return a schema."""
     checks.check_schema(
         respx_mock, fmr, query, no_hca_query, body, no_hca_body
     )
 
 
-def test_returns_keyset_context(
+def test_returns_inclusive_keyset(
     respx_mock, fmr, query, no_hca_query, keyset_body, no_hca_body
 ):
-    """get_validation_context() should return a schema."""
+    """get_schema() should return a schema, with inclusive keyset."""
     checks.check_keyset_schema(
         respx_mock, fmr, query, no_hca_query, keyset_body, no_hca_body
+    )
+
+
+def test_returns_exclusive_keyset(
+    respx_mock, fmr, query, no_hca_query, excl_keyset_body, no_hca_body
+):
+    """get_schema() should return a schema, with exclusive keyset."""
+    checks.check_exclusive_keyset_schema(
+        respx_mock, fmr, query, no_hca_query, excl_keyset_body, no_hca_body
     )
 
 


### PR DESCRIPTION
This PR adds support for exclusive keysets to SDMX-JSON and Fusion-JSON.

While we initially thought this was more of an exotic use case, there is actually a need for this. 