### PR TITLE
fix: handle DSD instances in schema_generator (#534)

### DIFF
--- a/src/pysdmx/util/_model_utils.py
+++ b/src/pysdmx/util/_model_utils.py
@@ -67,8 +67,7 @@ def schema_generator(
             dsd = message.get_data_structure_definition(str(dataset_ref))
         except NotFound:
             raise Invalid(
-                f"Missing DataStructure {dataset_ref} "
-                f"in structures message.",
+                f"Missing DataStructure {dataset_ref} in structures message.",
             ) from None
         return dsd.to_schema()
     elif context == "dataflow":
@@ -100,8 +99,7 @@ def schema_generator(
             dataflow = message.get_dataflow(str(dfw_ref))
         except NotFound:
             raise Invalid(
-                f"Missing Dataflow in {dataset_ref} "
-                f"structures message.",
+                f"Missing Dataflow in {dataset_ref} structures message.",
             ) from None
         dsd = _resolve_dsd(
             dataflow, message, dataset_ref, "Provision Agreement"

--- a/src/pysdmx/util/_model_utils.py
+++ b/src/pysdmx/util/_model_utils.py
@@ -1,11 +1,65 @@
 from pysdmx.errors import Invalid, NotFound
 from pysdmx.model import Reference
-from pysdmx.model.dataflow import Schema
+from pysdmx.model.dataflow import (
+    Dataflow,
+    DataStructureDefinition,
+    Schema,
+)
 from pysdmx.model.message import Message
 from pysdmx.util import parse_urn
 
 
-def schema_generator(message: Message, dataset_ref: Reference) -> Schema:  # noqa: C901
+def _resolve_dsd(
+    dataflow: Dataflow,
+    message: Message,
+    dataset_ref: Reference,
+    source: str,
+) -> DataStructureDefinition:
+    """Resolve the DSD from a Dataflow's structure reference."""
+    if dataflow.structure is None:
+        raise Invalid(
+            f"Dataflow {dataset_ref} does not have a structure defined.",
+        )
+    if isinstance(dataflow.structure, DataStructureDefinition):
+        return dataflow.structure
+    dsd_ref = parse_urn(dataflow.structure)
+    try:
+        return message.get_data_structure_definition(str(dsd_ref))
+    except NotFound:
+        hint = ""
+        if source == "Dataflow":
+            hint = (
+                " Please send the structures message using "
+                "references=children to include the "
+                "DataStructureDefinition."
+            )
+        raise Invalid(
+            f"Not found referenced DataStructure {dsd_ref}"
+            f" from {source} {dataset_ref}.{hint}",
+        ) from None
+
+
+def _build_schema(
+    context: str,
+    dataset_ref: Reference,
+    dsd: DataStructureDefinition,
+) -> Schema:
+    """Build a Schema from a resolved DSD."""
+    return Schema(
+        context=context,  # type: ignore[arg-type]
+        id=dataset_ref.id,
+        version=dataset_ref.version,
+        agency=dataset_ref.agency,
+        groups=dsd.groups,
+        components=dsd.components,
+        artefacts=dsd.to_schema().artefacts,
+    )
+
+
+def schema_generator(
+    message: Message,
+    dataset_ref: Reference,
+) -> Schema:
     """Generates a Schema by resolving the short_urn in the message."""
     context = dataset_ref.sdmx_type.lower()
     if context == "datastructure":
@@ -13,7 +67,8 @@ def schema_generator(message: Message, dataset_ref: Reference) -> Schema:  # noq
             dsd = message.get_data_structure_definition(str(dataset_ref))
         except NotFound:
             raise Invalid(
-                f"Missing DataStructure {dataset_ref} in structures message.",
+                f"Missing DataStructure {dataset_ref} "
+                f"in structures message.",
             ) from None
         return dsd.to_schema()
     elif context == "dataflow":
@@ -23,32 +78,13 @@ def schema_generator(message: Message, dataset_ref: Reference) -> Schema:  # noq
             raise Invalid(
                 f"Missing Dataflow {dataset_ref} in structures message.",
             ) from None
-        if dataflow.structure is None:
-            raise Invalid(
-                f"Dataflow {dataset_ref} does not have a structure defined.",
-            )
-        dsd_ref = parse_urn(dataflow.structure)  # type: ignore[arg-type]
-        try:
-            dsd = message.get_data_structure_definition(str(dsd_ref))
-        except NotFound:
-            raise Invalid(
-                f"Not found referenced DataStructure {dsd_ref}"
-                f"from Dataflow {dataset_ref}. "
-                f"Please send the structures message using "
-                f"references=children to include the DataStructureDefinition.",
-            ) from None
-        return Schema(
-            context=context,  # type: ignore[arg-type]
-            id=dataset_ref.id,
-            version=dataset_ref.version,
-            agency=dataset_ref.agency,
-            groups=dsd.groups,
-            components=dsd.components,
-            artefacts=dsd.to_schema().artefacts,
-        )
+        dsd = _resolve_dsd(dataflow, message, dataset_ref, "Dataflow")
+        return _build_schema(context, dataset_ref, dsd)
     elif context == "provisionagreement":
         try:
-            prov_agree = message.get_provision_agreement(str(dataset_ref))
+            prov_agree = message.get_provision_agreement(
+                str(dataset_ref),
+            )
         except NotFound:
             raise Invalid(
                 f"Missing Provision Agreement {dataset_ref} "
@@ -64,29 +100,13 @@ def schema_generator(message: Message, dataset_ref: Reference) -> Schema:  # noq
             dataflow = message.get_dataflow(str(dfw_ref))
         except NotFound:
             raise Invalid(
-                f"Missing Dataflow in {dataset_ref} structures message.",
+                f"Missing Dataflow in {dataset_ref} "
+                f"structures message.",
             ) from None
-        if dataflow.structure is None:
-            raise Invalid(
-                f"Dataflow {dataset_ref} does not have a structure defined.",
-            )
-        dsd_ref = parse_urn(dataflow.structure)  # type: ignore[arg-type]
-        try:
-            dsd = message.get_data_structure_definition(str(dsd_ref))
-        except NotFound:
-            raise Invalid(
-                f"Not found referenced DataStructure {dsd_ref}"
-                f" from Provision Agreement {dataset_ref}.",
-            ) from None
-        return Schema(
-            context=context,  # type: ignore[arg-type]
-            id=dataset_ref.id,
-            version=dataset_ref.version,
-            agency=dataset_ref.agency,
-            groups=dsd.groups,
-            components=dsd.components,
-            artefacts=dsd.to_schema().artefacts,
+        dsd = _resolve_dsd(
+            dataflow, message, dataset_ref, "Provision Agreement"
         )
+        return _build_schema(context, dataset_ref, dsd)
     else:
         raise Invalid(
             f"Unknown context: {context}",

--- a/tests/util/test_schema_generation.py
+++ b/tests/util/test_schema_generation.py
@@ -3,7 +3,16 @@ import re
 import pytest
 
 from pysdmx.errors import Invalid
-from pysdmx.model import Codelist, Dataflow, ProvisionAgreement
+from pysdmx.model import (
+    Codelist,
+    Component,
+    Components,
+    Concept,
+    Dataflow,
+    ProvisionAgreement,
+    Role,
+)
+from pysdmx.model.dataflow import DataStructureDefinition
 from pysdmx.model.message import Message
 from pysdmx.util import parse_short_urn, parse_urn
 from pysdmx.util._model_utils import schema_generator
@@ -113,3 +122,62 @@ def test_schema_generation_prov_agre_dfw_missing_structure():
         ),
     ):
         schema_generator(message, prov_agree_ref)
+
+
+def _build_dsd():
+    return DataStructureDefinition(
+        id="TEST_DSD",
+        agency="MD",
+        version="1.0",
+        components=Components(
+            [
+                Component(
+                    id="DIM1",
+                    role=Role.DIMENSION,
+                    concept=Concept(id="DIM1"),
+                    required=True,
+                ),
+                Component(
+                    id="OBS_VALUE",
+                    role=Role.MEASURE,
+                    concept=Concept(id="OBS_VALUE"),
+                    required=True,
+                ),
+            ]
+        ),
+    )
+
+
+def test_schema_generation_dataflow_with_dsd_instance():
+    dsd = _build_dsd()
+    dataflow = Dataflow(
+        id="TEST_DF", agency="MD", version="1.0", structure=dsd
+    )
+    message = Message(structures=[dataflow])
+    dataflow_ref = parse_short_urn(dataflow.short_urn)
+    schema = schema_generator(message, dataflow_ref)
+    assert schema.context == "dataflow"
+    assert schema.id == "TEST_DF"
+    assert len(schema.components.dimensions) == 1
+    assert len(schema.components.measures) == 1
+
+
+def test_schema_generation_prov_agre_dfw_with_dsd_instance():
+    dsd = _build_dsd()
+    dataflow = Dataflow(
+        id="TEST_DF", agency="MD", version="1.0", structure=dsd
+    )
+    prov_agree = ProvisionAgreement(
+        provider="DataProvider=MD:DATA_PROVIDERS(1.0).MD",
+        dataflow="Dataflow=MD:TEST_DF(1.0)",
+        id="TEST_PA",
+        agency="MD",
+        version="1.0",
+    )
+    message = Message(structures=[prov_agree, dataflow])
+    prov_agree_ref = parse_short_urn(prov_agree.short_urn)
+    schema = schema_generator(message, prov_agree_ref)
+    assert schema.context == "provisionagreement"
+    assert schema.id == "TEST_PA"
+    assert len(schema.components.dimensions) == 1
+    assert len(schema.components.measures) == 1


### PR DESCRIPTION
## Summary
- Fix `TypeError` when `Dataflow.structure` is already a `DataStructureDefinition` instance instead of a URN string, which caused `parse_urn` to fail
- Add `isinstance` check for both `dataflow` and `provisionagreement` branches
- Extract `_resolve_dsd` and `_build_schema` helpers to eliminate duplicated DSD resolution and Schema construction logic
- Remove `# noqa: C901` complexity override