### PR TITLE
Remove incorrect is_final inference from XML 3.0 reader

### DIFF
--- a/src/pysdmx/io/json/sdmxjson2/messages/agency.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/agency.py
@@ -11,6 +11,7 @@ from pysdmx.io.json.sdmxjson2.messages.core import (
 )
 from pysdmx.io.json.sdmxjson2.messages.dataflow import JsonDataflow
 from pysdmx.model import Agency, AgencyScheme, DataflowRef
+from pysdmx.util import is_final
 
 
 def _sanitize_agency(agency: Agency, is_sdmx_scheme: bool) -> Agency:
@@ -56,6 +57,7 @@ class JsonAgencyScheme(ItemSchemeType, frozen=True, omit_defaults=True):
             items=agencies,
             annotations=tuple([a.to_model() for a in self.annotations]),
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             is_partial=self.isPartial,
             valid_from=self.validFrom,
             valid_to=self.validTo,

--- a/src/pysdmx/io/json/sdmxjson2/messages/category.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/category.py
@@ -23,7 +23,7 @@ from pysdmx.model import (
     ItemReference,
     Reference,
 )
-from pysdmx.util import find_by_urn, parse_urn
+from pysdmx.util import find_by_urn, is_final, parse_urn
 
 
 class JsonCategorisation(
@@ -48,6 +48,7 @@ class JsonCategorisation(
             name=self.name,
             description=self.description,
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             valid_from=self.validFrom,
             valid_to=self.validTo,
             annotations=[a.to_model() for a in self.annotations],
@@ -197,6 +198,7 @@ class JsonCategoryScheme(
             version=self.version,
             items=[c.to_model(cat_flows, cat_other) for c in self.categories],
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             is_partial=self.isPartial,
             valid_from=self.validFrom,
             valid_to=self.validTo,

--- a/src/pysdmx/io/json/sdmxjson2/messages/code.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/code.py
@@ -23,7 +23,7 @@ from pysdmx.model import (
     Hierarchy,
     HierarchyAssociation,
 )
-from pysdmx.util import find_by_urn, parse_item_urn
+from pysdmx.util import find_by_urn, is_final, parse_item_urn
 
 _VAL_FMT = "%Y-%m-%dT%H:%M:%S%z"
 
@@ -145,6 +145,7 @@ class JsonCodelist(ItemSchemeType, frozen=True, omit_defaults=True):
             annotations=tuple([a.to_model() for a in self.annotations]),
             is_external_reference=self.isExternalReference,
             is_partial=self.isPartial,
+            is_final=is_final(self.version),
             valid_from=self.validFrom,
             valid_to=self.validTo,
         )
@@ -194,6 +195,7 @@ class JsonValuelist(ItemSchemeType, frozen=True, omit_defaults=True):
             annotations=[a.to_model() for a in self.annotations],
             is_external_reference=self.isExternalReference,
             is_partial=self.isPartial,
+            is_final=is_final(self.version),
             valid_from=self.validFrom,
             valid_to=self.validTo,
             sdmx_type="valuelist",
@@ -353,6 +355,7 @@ class JsonHierarchy(ItemSchemeType, frozen=True, omit_defaults=True):
             annotations=tuple([a.to_model() for a in self.annotations]),
             is_external_reference=self.isExternalReference,
             is_partial=self.isPartial,
+            is_final=is_final(self.version),
             valid_from=self.validFrom,
             valid_to=self.validTo,
             codes=[i.to_model(cls) for i in self.hierarchicalCodes],
@@ -436,6 +439,7 @@ class JsonHierarchyAssociation(
             version=self.version,
             annotations=[a.to_model() for a in self.annotations],
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             valid_from=self.validFrom,
             valid_to=self.validTo,
             operator=lnk[0].urn if lnk else None,

--- a/src/pysdmx/io/json/sdmxjson2/messages/concept.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/concept.py
@@ -14,6 +14,7 @@ from pysdmx.io.json.sdmxjson2.messages.core import (
     NameableType,
 )
 from pysdmx.model import Agency, Codelist, Concept, ConceptScheme, DataType
+from pysdmx.util import is_final
 
 
 class IsoConceptReference(msgspec.Struct, frozen=True, omit_defaults=True):
@@ -110,6 +111,7 @@ class JsonConceptScheme(ItemSchemeType, frozen=True, omit_defaults=True):
             agency=self.agency,
             description=self.description,
             version=self.version,
+            is_final=is_final(self.version),
             items=concepts,
             annotations=[a.to_model() for a in self.annotations],
             is_external_reference=self.isExternalReference,

--- a/src/pysdmx/io/json/sdmxjson2/messages/constraint.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/constraint.py
@@ -21,6 +21,7 @@ from pysdmx.model import (
     DataKeyValue,
     KeySet,
 )
+from pysdmx.util import is_final
 
 
 class JsonValue(Struct, frozen=True, omit_defaults=True):
@@ -196,6 +197,7 @@ class JsonDataConstraint(MaintainableType, frozen=True, omit_defaults=True):
             version=self.version,
             annotations=tuple([a.to_model() for a in self.annotations]),
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             valid_from=self.validFrom,
             valid_to=self.validTo,
             constraint_attachment=at,

--- a/src/pysdmx/io/json/sdmxjson2/messages/dataflow.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/dataflow.py
@@ -22,7 +22,7 @@ from pysdmx.model import (
     DataStructureDefinition,
 )
 from pysdmx.model.dataflow import Group
-from pysdmx.util import parse_urn
+from pysdmx.util import is_final, parse_urn
 
 
 class JsonDataflow(MaintainableType, frozen=True, omit_defaults=True):
@@ -57,6 +57,7 @@ class JsonDataflow(MaintainableType, frozen=True, omit_defaults=True):
             name=self.name,
             description=self.description,
             version=self.version,
+            is_final=is_final(self.version),
             structure=dsd,
             annotations=[a.to_model() for a in self.annotations],
             is_external_reference=self.isExternalReference,

--- a/src/pysdmx/io/json/sdmxjson2/messages/dsd.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/dsd.py
@@ -31,7 +31,7 @@ from pysdmx.model import (
     Role,
 )
 from pysdmx.model.dataflow import Group
-from pysdmx.util import parse_item_urn
+from pysdmx.util import is_final, parse_item_urn
 
 
 def _find_concept(
@@ -554,6 +554,7 @@ class JsonDataStructure(MaintainableType, frozen=True, omit_defaults=True):
             agency=self.agency,
             description=self.description,
             version=self.version,
+            is_final=is_final(self.version),
             annotations=[a.to_model() for a in self.annotations],
             is_external_reference=self.isExternalReference,
             valid_from=self.validFrom,

--- a/src/pysdmx/io/json/sdmxjson2/messages/map.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/map.py
@@ -25,7 +25,7 @@ from pysdmx.model import (
     StructureMap,
     ValueMap,
 )
-from pysdmx.util import find_by_urn
+from pysdmx.util import find_by_urn, is_final
 
 
 class JsonSourceValue(Struct, frozen=True, omit_defaults=True):
@@ -134,6 +134,7 @@ class JsonRepresentationMap(MaintainableType, frozen=True, omit_defaults=True):
                 maps=mrs,  # type: ignore[arg-type]
                 description=self.description,
                 version=self.version,
+                is_final=is_final(self.version),
             )
         else:
             return RepresentationMap(
@@ -145,6 +146,7 @@ class JsonRepresentationMap(MaintainableType, frozen=True, omit_defaults=True):
                 maps=mrs,  # type: ignore[arg-type]
                 description=self.description,
                 version=self.version,
+                is_final=is_final(self.version),
             )
 
     @classmethod
@@ -365,6 +367,7 @@ class JsonStructureMap(MaintainableType, frozen=True, omit_defaults=True):
             version=self.version,
             annotations=[a.to_model() for a in self.annotations],
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             valid_from=self.validFrom,
             valid_to=self.validTo,
         )

--- a/src/pysdmx/io/json/sdmxjson2/messages/metadataflow.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/metadataflow.py
@@ -10,6 +10,7 @@ from pysdmx.io.json.sdmxjson2.messages.core import (
     MaintainableType,
 )
 from pysdmx.model import Agency, Metadataflow, MetadataStructure
+from pysdmx.util import is_final
 
 
 class JsonMetadataflow(MaintainableType, frozen=True, omit_defaults=True):
@@ -30,6 +31,7 @@ class JsonMetadataflow(MaintainableType, frozen=True, omit_defaults=True):
             targets=self.targets,
             annotations=[a.to_model() for a in self.annotations],
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             valid_from=self.validFrom,
             valid_to=self.validTo,
         )

--- a/src/pysdmx/io/json/sdmxjson2/messages/mpa.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/mpa.py
@@ -10,6 +10,7 @@ from pysdmx.io.json.sdmxjson2.messages.core import (
     MaintainableType,
 )
 from pysdmx.model import Agency, MetadataProvisionAgreement
+from pysdmx.util import is_final
 
 
 class JsonMetadataProvisionAgreement(
@@ -34,6 +35,7 @@ class JsonMetadataProvisionAgreement(
             metadata_provider=self.metadataProvider,
             annotations=tuple([a.to_model() for a in self.annotations]),
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
         )
 
     @classmethod

--- a/src/pysdmx/io/json/sdmxjson2/messages/msd.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/msd.py
@@ -24,7 +24,7 @@ from pysdmx.model import (
     MetadataComponent,
     MetadataStructure,
 )
-from pysdmx.util import parse_item_urn
+from pysdmx.util import is_final, parse_item_urn
 
 
 def _get_attr_repr(comp: MetadataComponent) -> Optional[JsonRepresentation]:
@@ -185,6 +185,7 @@ class JsonMetadataStructure(MaintainableType, frozen=True, omit_defaults=True):
             version=self.version,
             annotations=[a.to_model() for a in self.annotations],
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             valid_from=self.validFrom,
             valid_to=self.validTo,
             components=c,

--- a/src/pysdmx/io/json/sdmxjson2/messages/pa.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/pa.py
@@ -10,6 +10,7 @@ from pysdmx.io.json.sdmxjson2.messages.core import (
     MaintainableType,
 )
 from pysdmx.model import Agency, ProvisionAgreement
+from pysdmx.util import is_final
 
 
 class JsonProvisionAgreement(
@@ -34,6 +35,7 @@ class JsonProvisionAgreement(
             provider=self.dataProvider,
             annotations=tuple([a.to_model() for a in self.annotations]),
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
         )
 
     @classmethod

--- a/src/pysdmx/io/json/sdmxjson2/messages/provider.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/provider.py
@@ -21,7 +21,7 @@ from pysdmx.model import (
     MetadataProvider,
     MetadataProviderScheme,
 )
-from pysdmx.util import parse_item_urn, parse_urn
+from pysdmx.util import is_final, parse_item_urn, parse_urn
 
 
 class JsonDataProviderScheme(ItemSchemeType, frozen=True, omit_defaults=True):
@@ -75,6 +75,7 @@ class JsonDataProviderScheme(ItemSchemeType, frozen=True, omit_defaults=True):
             items=provs,
             annotations=[a.to_model() for a in self.annotations],
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             is_partial=self.isPartial,
             valid_from=self.validFrom,
             valid_to=self.validTo,
@@ -179,6 +180,7 @@ class JsonMetadataProviderScheme(
             items=provs,
             annotations=[a.to_model() for a in self.annotations],
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             is_partial=self.isPartial,
             valid_from=self.validFrom,
             valid_to=self.validTo,

--- a/src/pysdmx/io/json/sdmxjson2/messages/vtl.py
+++ b/src/pysdmx/io/json/sdmxjson2/messages/vtl.py
@@ -30,7 +30,7 @@ from pysdmx.model.vtl import (
     VtlMapping,
     VtlMappingScheme,
 )
-from pysdmx.util import parse_urn
+from pysdmx.util import is_final, parse_urn
 
 
 class JsonCustomType(NameableType, frozen=True, omit_defaults=True):
@@ -97,6 +97,7 @@ class JsonCustomTypeScheme(ItemSchemeType, frozen=True, omit_defaults=True):
             valid_from=self.validFrom,
             valid_to=self.validTo,
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             agency=self.agency,
             items=items,
             is_partial=self.isPartial,
@@ -195,6 +196,7 @@ class JsonNamePersonalisationScheme(
             valid_from=self.validFrom,
             valid_to=self.validTo,
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             agency=self.agency,
             items=items,
             is_partial=self.isPartial,
@@ -291,6 +293,7 @@ class JsonUserDefinedOperatorScheme(
             valid_from=self.validFrom,
             valid_to=self.validTo,
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             agency=self.agency,
             items=items,
             is_partial=self.isPartial,
@@ -446,6 +449,7 @@ class JsonRulesetScheme(ItemSchemeType, frozen=True, omit_defaults=True):
             valid_from=self.validFrom,
             valid_to=self.validTo,
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             agency=self.agency,
             items=items,
             is_partial=self.isPartial,
@@ -713,6 +717,7 @@ class JsonVtlMappingScheme(ItemSchemeType, frozen=True, omit_defaults=True):
             valid_from=self.validFrom,
             valid_to=self.validTo,
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             agency=self.agency,
             items=items,
             is_partial=self.isPartial,
@@ -838,6 +843,7 @@ class JsonTransformationScheme(
             valid_from=self.validFrom,
             valid_to=self.validTo,
             is_external_reference=self.isExternalReference,
+            is_final=is_final(self.version),
             agency=self.agency,
             items=items,
             is_partial=self.isPartial,

--- a/src/pysdmx/io/xml/__structure_aux_reader.py
+++ b/src/pysdmx/io/xml/__structure_aux_reader.py
@@ -1244,18 +1244,6 @@ class StructureParser(Struct):
                 del element[DSD_COMPS][GROUP]
         return element
 
-    def __format_is_final_30(
-        self, json_elem: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        if self.is_sdmx_30:
-            # Default version value is 1.0, in SDMX-ML 3.0 we need to set
-            # is_final as True if the version does not have an EXTENSION
-            # (see Technical Notes SDMX 3.0)
-            json_elem[IS_FINAL_LOW] = (
-                "-" not in json_elem[VERSION] if VERSION in json_elem else True
-            )
-        return json_elem
-
     def __build_component_map(
         self, child_dict: Dict[str, Any]
     ) -> Union[ComponentMap, MultiComponentMap, ImplicitComponentMap]:
@@ -1414,7 +1402,6 @@ class StructureParser(Struct):
             # Dynamic creation with specific class
             if scheme == VALUE_LIST:
                 element["sdmx_type"] = VALUE_LIST_LOW
-            element = self.__format_is_final_30(element)
             result: ItemScheme = STRUCTURES_MAPPING[scheme](**element)
             elements[result.short_urn] = result
 
@@ -1495,7 +1482,6 @@ class StructureParser(Struct):
                     structure[COMPS] = Components(structure[COMPS])
                 else:
                     structure[COMPS] = Components([])
-            structure = self.__format_is_final_30(structure)
             schemas[short_urn] = STRUCTURES_MAPPING[schema](**structure)
 
         return schemas

--- a/src/pysdmx/io/xml/__structure_aux_reader.py
+++ b/src/pysdmx/io/xml/__structure_aux_reader.py
@@ -233,7 +233,7 @@ from pysdmx.model.vtl import (
     VtlDataflowMapping,
     VtlMappingScheme,
 )
-from pysdmx.util import find_by_urn, parse_urn
+from pysdmx.util import find_by_urn, is_final, parse_urn
 
 STRUCTURES_MAPPING = {
     CL: Codelist,
@@ -1399,6 +1399,8 @@ class StructureParser(Struct):
                 )
             if IS_FINAL in element:
                 element[IS_FINAL_LOW] = element.pop(IS_FINAL) == "true"
+            elif self.is_sdmx_30 and VERSION in element:
+                element[IS_FINAL_LOW] = is_final(element[VERSION])
             if IS_PARTIAL in element:
                 element[IS_PARTIAL_LOW] = element.pop(IS_PARTIAL) == "true"
             items = []
@@ -1479,6 +1481,8 @@ class StructureParser(Struct):
                 element[IS_FINAL_LOW] = (
                     str(element[IS_FINAL_LOW]).lower() == "true"
                 )
+            elif self.is_sdmx_30 and VERSION in element:
+                element[IS_FINAL_LOW] = is_final(element[VERSION])
 
             if item == DFW:
                 if isinstance(element[STRUCTURE], str):

--- a/src/pysdmx/util/__init__.py
+++ b/src/pysdmx/util/__init__.py
@@ -15,9 +15,7 @@ item_urn_pattern = re.compile(r"^.*\.(.*)=(.*):(.*)\((.*)\)\.(.*)$")
 short_urn_pattern = re.compile(r"^(.*)=(.*):(.*)\((.*)\)$")
 short_item_urn_pattern = re.compile(r"^(.*)=(.*):(.*)\((.*)\)\.(.*)$")
 _SEMVER_NUM = r"(0|[1-9]\d*)"
-semver_final_pattern = re.compile(
-    rf"^[1-9]\d*\.{_SEMVER_NUM}\.{_SEMVER_NUM}$"
-)
+semver_final_pattern = re.compile(rf"^[1-9]\d*\.{_SEMVER_NUM}\.{_SEMVER_NUM}$")
 
 
 def parse_urn(urn: str) -> Union[ItemReference, Reference]:

--- a/src/pysdmx/util/__init__.py
+++ b/src/pysdmx/util/__init__.py
@@ -14,6 +14,10 @@ maintainable_urn_pattern = re.compile(r"^.*\.(.*)=(.*):(.*)\((.*)\)$")
 item_urn_pattern = re.compile(r"^.*\.(.*)=(.*):(.*)\((.*)\)\.(.*)$")
 short_urn_pattern = re.compile(r"^(.*)=(.*):(.*)\((.*)\)$")
 short_item_urn_pattern = re.compile(r"^(.*)=(.*):(.*)\((.*)\)\.(.*)$")
+_SEMVER_NUM = r"(0|[1-9]\d*)"
+semver_final_pattern = re.compile(
+    rf"^[1-9]\d*\.{_SEMVER_NUM}\.{_SEMVER_NUM}$"
+)
 
 
 def parse_urn(urn: str) -> Union[ItemReference, Reference]:
@@ -93,6 +97,24 @@ def parse_short_item_urn(urn: str) -> ItemReference:
         raise Invalid(NF, f"{urn} does not match {short_item_urn_pattern}.")
 
 
+def is_final(version: str) -> bool:
+    """Infers finality from an SDMX 3.0 semantic version string.
+
+    In SDMX 3.0+, the isFinal attribute no longer exists. Instead,
+    a version with three numeric segments and no hyphen extension
+    (e.g. 1.0.0) is considered final, while versions with a hyphen
+    extension (e.g. 1.0.0-draft) or only two segments (e.g. 1.0)
+    are not final.
+
+    Args:
+        version: The version string to evaluate.
+
+    Returns:
+        True if the version indicates a final artefact.
+    """
+    return bool(semver_final_pattern.match(version))
+
+
 def find_by_urn(artefacts: Sequence[Any], urn: str) -> Any:
     """Returns the maintainable artefact matching the supplied urn."""
     r = parse_urn(urn)
@@ -128,6 +150,7 @@ def find_by_urn(artefacts: Sequence[Any], urn: str) -> Any:
 __all__ = [
     "convert_dpm",
     "find_by_urn",
+    "is_final",
     "parse_item_urn",
     "parse_maintainable_urn",
     "parse_urn",

--- a/tests/io/xml/sdmx21/reader/test_reader.py
+++ b/tests/io/xml/sdmx21/reader/test_reader.py
@@ -162,6 +162,26 @@ def test_code_list_read(codelist_path):
     assert codelist_sdmx.items[0].name == "Units"
 
 
+def test_codelist_with_explicit_is_final(codelist_path):
+    """SDMX 2.1 supports isFinal; CL_FREQ has isFinal='true'."""
+    input_str, read_format = process_string_to_read(codelist_path)
+    codelists = read_structure(input_str, validate=True)
+
+    cl_freq = [cl for cl in codelists if cl.id == "CL_FREQ"][0]
+    assert isinstance(cl_freq, Codelist)
+    assert cl_freq.is_final is True
+
+
+def test_codelist_without_explicit_is_final(codelist_path):
+    """SDMX 2.1 without isFinal defaults to False."""
+    input_str, read_format = process_string_to_read(codelist_path)
+    codelists = read_structure(input_str, validate=True)
+
+    cl_unit = [cl for cl in codelists if cl.id == "CL_UNIT_MULT"][0]
+    assert isinstance(cl_unit, Codelist)
+    assert cl_unit.is_final is False
+
+
 def test_item_scheme_read(item_scheme_path):
     input_str, read_format = process_string_to_read(item_scheme_path)
     assert read_format == Format.STRUCTURE_SDMX_ML_2_1

--- a/tests/io/xml/sdmx30/reader/samples/codelists_semver.xml
+++ b/tests/io/xml/sdmx30/reader/samples/codelists_semver.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message"
+    xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure"
+    xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common"
+    xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message ../../schemas/SDMXMessage.xsd">
+    <mes:Header>
+        <mes:ID>IREF257793</mes:ID>
+        <mes:Test>false</mes:Test>
+        <mes:Prepared>2021-03-08T17:49:35Z</mes:Prepared>
+        <mes:Sender id="Unknown" />
+        <mes:Receiver id="not_supplied" />
+    </mes:Header>
+    <mes:Structures>
+        <str:Codelists>
+            <str:Codelist urn="urn:sdmx:org.sdmx.infomodel.codelist.Codelist=SDMX:CL_AGE(1.0)"
+                structureURL="https://registry.sdmx.org/FusionRegistry/ws/rest/codelist/SDMX/CL_AGE/1.0"
+                isExternalReference="false" agencyID="SDMX" id="CL_AGE" version="1.0.0">
+                <com:Name xml:lang="en">Age</com:Name>
+                <str:Code urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=SDMX:CL_AGE(1.0).Y" id="Y">
+                    <com:Name xml:lang="en">Year(s)</com:Name>
+                </str:Code>
+                <str:Code urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=SDMX:CL_AGE(1.0).M" id="M">
+                    <com:Name xml:lang="en">Month(s)</com:Name>
+                </str:Code>
+                <str:Code urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=SDMX:CL_AGE(1.0).W" id="W">
+                    <com:Name xml:lang="en">Week(s)</com:Name>
+                </str:Code>
+                <str:Code urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=SDMX:CL_AGE(1.0).D" id="D">
+                    <com:Name xml:lang="en">Day(s)</com:Name>
+                </str:Code>
+                <str:Code urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=SDMX:CL_AGE(1.0).H" id="H">
+                    <com:Name xml:lang="en">Hour(s)</com:Name>
+                </str:Code>
+            </str:Codelist>
+        </str:Codelists>
+    </mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/reader/samples/codelists_semver_nf.xml
+++ b/tests/io/xml/sdmx30/reader/samples/codelists_semver_nf.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message"
+    xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure"
+    xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common"
+    xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message ../../schemas/SDMXMessage.xsd">
+    <mes:Header>
+        <mes:ID>IREF257793</mes:ID>
+        <mes:Test>false</mes:Test>
+        <mes:Prepared>2021-03-08T17:49:35Z</mes:Prepared>
+        <mes:Sender id="Unknown" />
+        <mes:Receiver id="not_supplied" />
+    </mes:Header>
+    <mes:Structures>
+        <str:Codelists>
+            <str:Codelist urn="urn:sdmx:org.sdmx.infomodel.codelist.Codelist=SDMX:CL_AGE(1.0)"
+                structureURL="https://registry.sdmx.org/FusionRegistry/ws/rest/codelist/SDMX/CL_AGE/1.0"
+                isExternalReference="false" agencyID="SDMX" id="CL_AGE" version="1.0.0-draft">
+                <com:Name xml:lang="en">Age</com:Name>
+                <str:Code urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=SDMX:CL_AGE(1.0).Y" id="Y">
+                    <com:Name xml:lang="en">Year(s)</com:Name>
+                </str:Code>
+                <str:Code urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=SDMX:CL_AGE(1.0).M" id="M">
+                    <com:Name xml:lang="en">Month(s)</com:Name>
+                </str:Code>
+                <str:Code urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=SDMX:CL_AGE(1.0).W" id="W">
+                    <com:Name xml:lang="en">Week(s)</com:Name>
+                </str:Code>
+                <str:Code urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=SDMX:CL_AGE(1.0).D" id="D">
+                    <com:Name xml:lang="en">Day(s)</com:Name>
+                </str:Code>
+                <str:Code urn="urn:sdmx:org.sdmx.infomodel.codelist.Code=SDMX:CL_AGE(1.0).H" id="H">
+                    <com:Name xml:lang="en">Hour(s)</com:Name>
+                </str:Code>
+            </str:Codelist>
+        </str:Codelists>
+    </mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/reader/test_reader.py
+++ b/tests/io/xml/sdmx30/reader/test_reader.py
@@ -199,6 +199,58 @@ def test_code_list_read(samples_folder):
     assert codelist.items[1].name == "Month(s)"
 
 
+@pytest.mark.xml
+def test_code_list_semver_final_read(samples_folder):
+    data_path = samples_folder / "codelists_semver.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_0
+    result = read_structure(input_str, validate=True)
+    assert result is not None
+    assert len(result) == 1
+
+    assert isinstance(result[0], Codelist)
+    codelist = result[0]
+    assert codelist.agency == "SDMX"
+    assert codelist.id == "CL_AGE"
+    assert codelist.name == "Age"
+    assert codelist.short_urn == "Codelist=SDMX:CL_AGE(1.0.0)"
+    assert codelist.version == "1.0.0"
+    assert codelist.is_final is True
+
+    assert len(codelist.items) == 5
+    assert isinstance(codelist.items[0], Code)
+    assert codelist.items[0].id == "Y"
+    assert codelist.items[0].name == "Year(s)"
+    assert codelist.items[1].id == "M"
+    assert codelist.items[1].name == "Month(s)"
+
+
+@pytest.mark.xml
+def test_code_list_semver_non_final_read(samples_folder):
+    data_path = samples_folder / "codelists_semver_nf.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_0
+    result = read_structure(input_str, validate=True)
+    assert result is not None
+    assert len(result) == 1
+
+    assert isinstance(result[0], Codelist)
+    codelist = result[0]
+    assert codelist.agency == "SDMX"
+    assert codelist.id == "CL_AGE"
+    assert codelist.name == "Age"
+    assert codelist.short_urn == "Codelist=SDMX:CL_AGE(1.0.0-draft)"
+    assert codelist.version == "1.0.0-draft"
+    assert codelist.is_final is False
+
+    assert len(codelist.items) == 5
+    assert isinstance(codelist.items[0], Code)
+    assert codelist.items[0].id == "Y"
+    assert codelist.items[0].name == "Year(s)"
+    assert codelist.items[1].id == "M"
+    assert codelist.items[1].name == "Month(s)"
+
+
 def test_codelist_read_draft(samples_folder):
     data_path = samples_folder / "codelist_draft_version.xml"
     input_str, read_format = process_string_to_read(data_path)

--- a/tests/io/xml/sdmx30/reader/test_reader.py
+++ b/tests/io/xml/sdmx30/reader/test_reader.py
@@ -185,6 +185,28 @@ def test_codelist_read_draft(samples_folder):
     assert len(codelist.codes) == 0
 
 
+def test_codelist_without_is_final_defaults_false(samples_folder):
+    """SDMX 3.0 has no isFinal attribute; is_final defaults to False."""
+    data_path = samples_folder / "codelists.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    result = read_structure(input_str, validate=True)
+
+    codelist = result[0]
+    assert isinstance(codelist, Codelist)
+    assert codelist.is_final is False
+
+
+def test_dataflow_without_is_final_defaults_false(samples_folder):
+    """SDMX 3.0 has no isFinal attribute; is_final defaults to False."""
+    data_path = samples_folder / "dataflow_final_version.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    result = read_structure(input_str, validate=True)
+
+    dataflow = result[0]
+    assert isinstance(dataflow, Dataflow)
+    assert dataflow.is_final is False
+
+
 def test_dataflow_read_final(samples_folder):
     data_path = samples_folder / "dataflow_final_version.xml"
     input_str, read_format = process_string_to_read(data_path)

--- a/tests/io/xml/sdmx30/reader/test_reader.py
+++ b/tests/io/xml/sdmx30/reader/test_reader.py
@@ -157,7 +157,7 @@ def test_code_list_read(samples_folder):
     assert codelist.name == "Age"
     assert codelist.short_urn == "Codelist=SDMX:CL_AGE(1.0)"
     assert codelist.version == "1.0"
-    assert codelist.is_final is True
+    assert codelist.is_final is False
 
     assert len(codelist.items) == 5
     assert isinstance(codelist.items[0], Code)
@@ -200,7 +200,7 @@ def test_dataflow_read_final(samples_folder):
     assert dataflow.name == "NAMAIN_IDC_N df"
     assert dataflow.short_urn == "Dataflow=SDMX:NAMAIN_IDC_N(1.0)"
     assert dataflow.version == "1.0"
-    assert dataflow.is_final is True
+    assert dataflow.is_final is False
     assert dataflow.is_external_reference is False
     assert "DataStructure=ESTAT:NA_MAIN(1.6)" in dataflow.structure
 

--- a/tests/util/test_is_final.py
+++ b/tests/util/test_is_final.py
@@ -1,0 +1,29 @@
+import pytest
+
+from pysdmx.util import is_final
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("1.0.0", True),
+        ("2.3.1", True),
+        ("0.0.1", False),
+        ("10.20.30", True),
+        ("1.0.0-draft", False),
+        ("1.0.0-rc1", False),
+        ("1.0.0-beta", False),
+        ("1.0.0-alpha.1", False),
+        ("1.0.0-0.3.7", False),
+        ("1.0.0-draft.1", False),
+        ("01.0.0", False),
+        ("1.01.0", False),
+        ("1.0.01", False),
+        ("1.0", False),
+        ("1", False),
+        ("", False),
+        ("1.0.0.0", False),
+    ],
+)
+def test_is_final(version, expected):
+    assert is_final(version) is expected


### PR DESCRIPTION
## Summary
- Removed `__format_is_final_30()` from the SDMX-ML 3.0 reader, which incorrectly inferred `is_final=True` from version strings without a `-` extension
- `is_final` is now only set to `True` when the `isFinal` attribute is explicitly present in the XML source
- Fixes the discrepancy where reading the same artefact from SDMX-JSON and SDMX-ML 3.0 produced different `is_final` values

Closes #544