### PR TITLE
Strip default AgencyScheme fields in XML reader

### DIFF
--- a/src/pysdmx/io/xml/__structure_aux_reader.py
+++ b/src/pysdmx/io/xml/__structure_aux_reader.py
@@ -513,6 +513,7 @@ class StructureParser(Struct):
         orgs: Dict[str, Any] = {}
         json_list = add_list(json_orgs)
         for e in json_list:
+            self.__strip_agency_scheme_defaults(e)
             ag_sch = self.__format_scheme(
                 e,
                 AGENCY_SCHEME,
@@ -520,6 +521,24 @@ class StructureParser(Struct):
             )
             orgs = {**orgs, **ag_sch}
         return orgs
+
+    @staticmethod
+    def __strip_agency_scheme_defaults(
+        element: Dict[str, Any],
+    ) -> None:
+        """Remove default AgencyScheme fields before construction.
+
+        The SDMX standard defines fixed values for AgencyScheme id,
+        name, and version. Stripping them when they match the defaults
+        aligns the XML reader with the JSON reader behavior.
+        """
+        for s in add_list(element[AGENCY_SCHEME]):
+            for k, v in [("id", "AGENCIES"), ("version", "1.0")]:
+                if s.get(k) == v:
+                    del s[k]
+            name = s.get(NAME)
+            if name is not None and _extract_text(name) == "AGENCIES":
+                del s[NAME]
 
     def __format_representation(
         self, json_rep: Dict[str, Any], json_obj: Dict[str, Any]

--- a/tests/io/xml/sdmx21/reader/samples/agencies_defaults.xml
+++ b/tests/io/xml/sdmx21/reader/samples/agencies_defaults.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<message:Structure xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+                   xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure"
+                   xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">
+    <message:Header>
+        <message:ID>test</message:ID>
+        <message:Test>true</message:Test>
+        <message:Prepared>2025-01-01T00:00:00Z</message:Prepared>
+        <message:Sender id="TEST"/>
+    </message:Header>
+    <message:Structures>
+        <str:OrganisationSchemes>
+            <str:AgencyScheme isExternalReference="false" agencyID="SDMX" id="AGENCIES" isFinal="false" version="1.0">
+                <com:Name xml:lang="en">AGENCIES</com:Name>
+                <str:Agency id="BIS">
+                    <com:Name xml:lang="en">Bank for International Settlements</com:Name>
+                </str:Agency>
+            </str:AgencyScheme>
+        </str:OrganisationSchemes>
+    </message:Structures>
+</message:Structure>

--- a/tests/io/xml/sdmx21/reader/test_reader.py
+++ b/tests/io/xml/sdmx21/reader/test_reader.py
@@ -146,6 +146,36 @@ def test_agency_scheme_read(agency_scheme_path):
     assert agency_sdmx.name == "SDMX"
 
 
+def test_agency_scheme_defaults_omitted(samples_folder):
+    data_path = samples_folder / "agencies_defaults.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_2_1
+    result = read_structure(input_str, validate=True)
+
+    agency_scheme = result[0]
+    assert isinstance(agency_scheme, AgencyScheme)
+
+    # When id, name, and version match the SDMX standard defaults,
+    # they should use model defaults (not be explicitly set from XML),
+    # aligning XML reader behavior with JSON reader behavior.
+    assert agency_scheme.id == "AGENCIES"
+    assert agency_scheme.name == "AGENCIES"
+    assert agency_scheme.version == "1.0"
+    assert agency_scheme.agency == "SDMX"
+
+    expected = AgencyScheme(
+        is_final=agency_scheme.is_final,
+        is_external_reference=agency_scheme.is_external_reference,
+        agency="SDMX",
+        items=agency_scheme.items,
+    )
+    assert agency_scheme == expected
+    assert repr(agency_scheme) == repr(expected)
+
+    assert len(agency_scheme.items) == 1
+    assert agency_scheme.items[0].id == "BIS"
+
+
 def test_code_list_read(codelist_path):
     input_str, read_format = process_string_to_read(codelist_path)
     assert read_format == Format.STRUCTURE_SDMX_ML_2_1

--- a/tests/io/xml/sdmx30/reader/samples/agencies_defaults.xml
+++ b/tests/io/xml/sdmx30/reader/samples/agencies_defaults.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<message:Structure xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common">
+  <message:Header>
+    <message:ID>test</message:ID>
+    <message:Test>true</message:Test>
+    <message:Prepared>2025-01-01T00:00:00Z</message:Prepared>
+    <message:Sender id="TEST"/>
+    <message:Receiver id="not_supplied"/>
+  </message:Header>
+  <message:Structures>
+    <str:AgencySchemes>
+      <str:AgencyScheme isExternalReference="false" agencyID="SDMX" id="AGENCIES">
+        <com:Name xml:lang="en">AGENCIES</com:Name>
+        <str:Agency id="BIS">
+          <com:Name xml:lang="en">Bank for International Settlements</com:Name>
+        </str:Agency>
+      </str:AgencyScheme>
+    </str:AgencySchemes>
+  </message:Structures>
+</message:Structure>

--- a/tests/io/xml/sdmx30/reader/test_reader.py
+++ b/tests/io/xml/sdmx30/reader/test_reader.py
@@ -143,6 +143,38 @@ def test_agency_scheme_read(samples_folder):
 
 
 @pytest.mark.xml
+def test_agency_scheme_defaults_omitted(samples_folder):
+    data_path = samples_folder / "agencies_defaults.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_0
+    result = read_structure(input_str, validate=True)
+
+    agency_scheme = result[0]
+    assert isinstance(agency_scheme, AgencyScheme)
+
+    # When id, name, and version match the SDMX standard defaults,
+    # they should use model defaults (not be explicitly set from XML),
+    # aligning XML reader behavior with JSON reader behavior.
+    assert agency_scheme.id == "AGENCIES"
+    assert agency_scheme.name == "AGENCIES"
+    assert agency_scheme.version == "1.0"
+    assert agency_scheme.agency == "SDMX"
+
+    expected = AgencyScheme(
+        is_final=agency_scheme.is_final,
+        is_external_reference=agency_scheme.is_external_reference,
+        agency="SDMX",
+        items=agency_scheme.items,
+    )
+    assert agency_scheme == expected
+    assert repr(agency_scheme) == repr(expected)
+
+    assert len(agency_scheme.items) == 1
+    assert agency_scheme.items[0].id == "BIS"
+    assert agency_scheme.items[0].name == "Bank for International Settlements"
+
+
+@pytest.mark.xml
 def test_code_list_read(samples_folder):
     data_path = samples_folder / "codelists.xml"
     input_str, read_format = process_string_to_read(data_path)


### PR DESCRIPTION
## Summary
- XML reader now strips `id`, `name`, and `version` from `AgencyScheme` when they match the SDMX standard defaults (`AGENCIES`, `AGENCIES`, `1.0`), aligning behavior with the JSON reader
- Added `__strip_agency_scheme_defaults()` method in the structure auxiliary reader, called before AgencyScheme construction
- Added tests for both SDMX 2.1 and 3.0 readers with sample XML files using default values

Closes #545

## Test plan
- [x] New `test_agency_scheme_defaults_omitted` tests for SDMX 2.1 and 3.0 readers
- [x] Existing `test_agency_scheme_read` tests still pass (non-default name preserved)
- [x] Full test suite passes (4557 tests)
- [x] 100% code coverage maintained
- [x] ruff format, ruff check, and mypy all pass