### PR TITLE
Fix PandasDataset typing for get_datasets

### DIFF
--- a/src/pysdmx/io/reader.py
+++ b/src/pysdmx/io/reader.py
@@ -8,6 +8,7 @@ from typing import (
     Optional,
     Sequence,
     Union,
+    cast,
     overload,
 )
 
@@ -308,11 +309,11 @@ def get_datasets(
         raise Invalid("No data found in the data message")
 
     if structure is None:
-        return data_msg.data  # type: ignore[return-value]
+        return cast("Sequence[PandasDataset]", data_msg.data)
     structure_msg = read_sdmx(structure, validate=validate, pem=pem)
     if structure_msg.structures is None:
         raise Invalid("No structure found in the structure message")
 
     __assign_structure_to_dataset(data_msg.data, structure_msg)
 
-    return data_msg.data  # type: ignore[return-value]
+    return cast("Sequence[PandasDataset]", data_msg.data)

--- a/src/pysdmx/io/reader.py
+++ b/src/pysdmx/io/reader.py
@@ -2,11 +2,12 @@
 
 from io import BytesIO
 from pathlib import Path
-from typing import Dict, Optional, Sequence, Union
+from typing import Dict, Optional, Sequence, Union, overload
 
 from pysdmx.errors import Invalid
 from pysdmx.io.format import Format
 from pysdmx.io.input_processor import process_string_to_read
+from pysdmx.io.pd import PandasDataset
 from pysdmx.model import Schema
 from pysdmx.model.__base import MaintainableArtefact
 from pysdmx.model.dataset import Dataset
@@ -49,7 +50,7 @@ def read_sdmx(  # noqa: C901
     input_str, read_format = process_string_to_read(sdmx_document, pem=pem)
 
     header = None
-    result_data: Sequence[Dataset] = []
+    result_data: Sequence[PandasDataset] = []
     result_structures: Sequence[MaintainableArtefact] = []
     result_submission: Sequence[SubmissionResult] = []
     reports: Sequence[MetadataReport] = []
@@ -226,16 +227,34 @@ def __assign_structure_to_dataset(
         __manage_dataset_level_attributes(dataset)
 
 
+@overload
+def get_datasets(  # pragma: no cover
+    data: Union[str, Path, BytesIO],
+    structure: None = None,
+    validate: bool = True,
+    pem: Optional[Union[str, Path]] = None,
+) -> Sequence[PandasDataset]: ...
+
+
+@overload
+def get_datasets(  # pragma: no cover
+    data: Union[str, Path, BytesIO],
+    structure: Union[str, Path, BytesIO] = ...,
+    validate: bool = True,
+    pem: Optional[Union[str, Path]] = None,
+) -> Sequence[PandasDataset]: ...
+
+
 def get_datasets(
     data: Union[str, Path, BytesIO],
     structure: Optional[Union[str, Path, BytesIO]] = None,
     validate: bool = True,
     pem: Optional[Union[str, Path]] = None,
-) -> Sequence[Dataset]:
+) -> Sequence[PandasDataset]:
     """Reads a data message and a structure message and returns a dataset.
 
     This method reads a data message and an optional structure message,
-    and returns a sequence of Datasets.
+    and returns a sequence of PandasDatasets.
     Check the :ref:`formats supported <io-reader-formats-supported>`
 
     The resulting datasets will have their structure assigned,
@@ -280,11 +299,11 @@ def get_datasets(
         raise Invalid("No data found in the data message")
 
     if structure is None:
-        return data_msg.data
+        return data_msg.data  # type: ignore[return-value]
     structure_msg = read_sdmx(structure, validate=validate, pem=pem)
     if structure_msg.structures is None:
         raise Invalid("No structure found in the structure message")
 
     __assign_structure_to_dataset(data_msg.data, structure_msg)
 
-    return data_msg.data
+    return data_msg.data  # type: ignore[return-value]

--- a/src/pysdmx/io/reader.py
+++ b/src/pysdmx/io/reader.py
@@ -2,12 +2,21 @@
 
 from io import BytesIO
 from pathlib import Path
-from typing import Dict, Optional, Sequence, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Optional,
+    Sequence,
+    Union,
+    overload,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pysdmx.io.pd import PandasDataset
 
 from pysdmx.errors import Invalid
 from pysdmx.io.format import Format
 from pysdmx.io.input_processor import process_string_to_read
-from pysdmx.io.pd import PandasDataset
 from pysdmx.model import Schema
 from pysdmx.model.__base import MaintainableArtefact
 from pysdmx.model.dataset import Dataset
@@ -50,7 +59,7 @@ def read_sdmx(  # noqa: C901
     input_str, read_format = process_string_to_read(sdmx_document, pem=pem)
 
     header = None
-    result_data: Sequence[PandasDataset] = []
+    result_data: Sequence[Dataset] = []
     result_structures: Sequence[MaintainableArtefact] = []
     result_submission: Sequence[SubmissionResult] = []
     reports: Sequence[MetadataReport] = []
@@ -233,7 +242,7 @@ def get_datasets(  # pragma: no cover
     structure: None = None,
     validate: bool = True,
     pem: Optional[Union[str, Path]] = None,
-) -> Sequence[PandasDataset]: ...
+) -> "Sequence[PandasDataset]": ...
 
 
 @overload
@@ -242,7 +251,7 @@ def get_datasets(  # pragma: no cover
     structure: Union[str, Path, BytesIO] = ...,
     validate: bool = True,
     pem: Optional[Union[str, Path]] = None,
-) -> Sequence[PandasDataset]: ...
+) -> "Sequence[PandasDataset]": ...
 
 
 def get_datasets(
@@ -250,7 +259,7 @@ def get_datasets(
     structure: Optional[Union[str, Path, BytesIO]] = None,
     validate: bool = True,
     pem: Optional[Union[str, Path]] = None,
-) -> Sequence[PandasDataset]:
+) -> "Sequence[PandasDataset]":
     """Reads a data message and a structure message and returns a dataset.
 
     This method reads a data message and an optional structure message,

--- a/src/pysdmx/model/message.py
+++ b/src/pysdmx/model/message.py
@@ -14,7 +14,20 @@ Classes:
 
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Sequence, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    Union,
+    cast,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pysdmx.io.pd import PandasDataset
 
 from msgspec import Struct
 
@@ -413,21 +426,21 @@ class Message(StructureMessage, frozen=True):
                         "Check the docs for the proper structure on data.",
                     )
 
-    def get_datasets(self) -> Sequence[Dataset]:
+    def get_datasets(self) -> "Sequence[PandasDataset]":
         """Returns the Datasets."""
         if self.data is not None:
-            return self.data
+            return cast("Sequence[PandasDataset]", self.data)
         raise NotFound(
             "No Datasets found in data.",
             "Could not find any Datasets in content.",
         )
 
-    def get_dataset(self, short_urn: str) -> Dataset:
+    def get_dataset(self, short_urn: str) -> "PandasDataset":
         """Returns a specific Dataset."""
         if self.data is not None:
             for dataset in self.data:
                 if dataset.short_urn == short_urn:
-                    return dataset
+                    return cast("PandasDataset", dataset)
         raise NotFound(
             f"No Dataset with Short URN {short_urn} found in data.",
             "Could not find the requested Dataset.",


### PR DESCRIPTION
## Summary
- Change return types of `Message.get_datasets()`, `Message.get_dataset()`, and `io.get_datasets()` from `Dataset` to `PandasDataset`
- Add `@overload` decorators to `io.get_datasets()` dispatched on the `structure` parameter
- Users now get proper IDE autocompletion for `PandasDataset.data` (`pd.DataFrame`)

Closes #543

## Test plan
- [x] All 4555 existing tests pass
- [x] 100% branch coverage maintained
- [x] mypy strict mode passes
- [x] ruff format and ruff check pass