### PR TITLE
Add writer and reader support for Time Series formats (STRTS / GENTS)

### DIFF
--- a/docs/api/io/general_reader.rst
+++ b/docs/api/io/general_reader.rst
@@ -23,7 +23,9 @@ List of formats and versions supported by the general reader:
 
 - :ref:`SDMX-ML<sdmx_ml>`
     - :ref:`SDMX-ML 2.1 Generic <sdmx_ml_21_gen_reader>`
+    - :ref:`SDMX-ML 2.1 Generic Time Series <sdmx_ml_21_gents_reader>`
     - :ref:`SDMX-ML 2.1 Structure Specific <sdmx_ml_21_spe_reader>`
+    - :ref:`SDMX-ML 2.1 Structure Specific Time Series <sdmx_ml_21_spets_reader>`
     - :ref:`SDMX-ML 2.1 Structure <sdmx_ml_21_structure_reader>`
     - :ref:`SDMX-ML 3.0 Structure Specific <sdmx_ml_30_spe_reader>`
     - :ref:`SDMX-ML 3.0 Structure <sdmx_ml_30_structure_reader>`

--- a/docs/api/io/general_writer.rst
+++ b/docs/api/io/general_writer.rst
@@ -23,7 +23,9 @@ List of formats and versions supported by the general writer:
 
 - :ref:`SDMX-ML<sdmx_ml>`
     - :ref:`SDMX-ML 2.1 Generic <sdmx_ml_21_gen_writer>`
+    - :ref:`SDMX-ML 2.1 Generic Time Series <sdmx_ml_21_gents_writer>`
     - :ref:`SDMX-ML 2.1 Structure Specific <sdmx_ml_21_spe_writer>`
+    - :ref:`SDMX-ML 2.1 Structure Specific Time Series <sdmx_ml_21_spets_writer>`
     - :ref:`SDMX-ML 2.1 Structure <sdmx_ml_21_structure_writer>`
     - :ref:`SDMX-ML 3.0 Structure Specific <sdmx_ml_30_spe_writer>`
     - :ref:`SDMX-ML 3.0 Structure <sdmx_ml_30_structure_writer>`

--- a/docs/api/io/sdmx_ml.rst
+++ b/docs/api/io/sdmx_ml.rst
@@ -88,11 +88,23 @@ specific writers for SDMX-ML are also available:
 
 .. autofunction:: pysdmx.io.xml.sdmx21.writer.generic.write
 
+.. _sdmx_ml_21_gents_writer:
+
+- DATA_SDMX_ML_2_1_GENTS -> pysdmx.io.xml.sdmx21.writer.generic_ts
+
+.. autofunction:: pysdmx.io.xml.sdmx21.writer.generic_ts.write
+
 .. _sdmx_ml_21_spe_writer:
 
 - DATA_SDMX_ML_2_1_STR -> pysdmx.io.xml.sdmx21.writer.structure_specific
 
 .. autofunction:: pysdmx.io.xml.sdmx21.writer.structure_specific.write
+
+.. _sdmx_ml_21_spets_writer:
+
+- DATA_SDMX_ML_2_1_STRTS -> pysdmx.io.xml.sdmx21.writer.structure_specific_ts
+
+.. autofunction:: pysdmx.io.xml.sdmx21.writer.structure_specific_ts.write
 
 .. _sdmx_ml_21_structure_writer:
 

--- a/docs/api/io/sdmx_ml.rst
+++ b/docs/api/io/sdmx_ml.rst
@@ -36,11 +36,19 @@ specific readers for SDMX-ML are also available:
 
 .. autofunction:: pysdmx.io.xml.sdmx21.reader.generic.read
 
+.. _sdmx_ml_21_gents_reader:
+
+- DATA_SDMX_ML_2_1_GENTS -> pysdmx.io.xml.sdmx21.reader.generic (same reader as Generic)
+
 .. _sdmx_ml_21_spe_reader:
 
 - DATA_SDMX_ML_2_1_STR -> pysdmx.io.xml.sdmx21.reader.structure_specific
 
 .. autofunction:: pysdmx.io.xml.sdmx21.reader.structure_specific.read
+
+.. _sdmx_ml_21_spets_reader:
+
+- DATA_SDMX_ML_2_1_STRTS -> pysdmx.io.xml.sdmx21.reader.structure_specific (same reader as Structure Specific)
 
 .. _sdmx_ml_21_structure_reader:
 

--- a/docs/howto/io_data.rst
+++ b/docs/howto/io_data.rst
@@ -133,6 +133,15 @@ Additional arguments are available for SDMX-ML to:
 - Specify the dimension at observation level (using the `dimension_at_observation` argument). This is needed for Time Series
   data formats.
 
+For SDMX-ML 2.1, dedicated Time Series formats are available:
+
+- ``Format.DATA_SDMX_ML_2_1_GENTS`` — Generic Time Series (defaults ``dimension_at_observation`` to ``TIME_PERIOD``)
+- ``Format.DATA_SDMX_ML_2_1_STRTS`` — Structure Specific Time Series (defaults ``dimension_at_observation`` to ``TIME_PERIOD``)
+
+These formats produce the same output as their non-TS counterparts (``DATA_SDMX_ML_2_1_GEN`` / ``DATA_SDMX_ML_2_1_STR``
+with ``dimension_at_observation`` set to ``TIME_PERIOD``), but use the SDMX-ML 2.1 Time Series message types
+(``GenericTimeSeriesData`` / ``StructureSpecificTimeSeriesData``).
+
 
 A typical example to write data in Time Series with a custom header (pretty printed):
 

--- a/src/pysdmx/io/input_processor.py
+++ b/src/pysdmx/io/input_processor.py
@@ -56,25 +56,42 @@ def __check_json(input_str: str) -> bool:
         return False
 
 
+def __get_sdmx_ml_version(
+    flavour_check: str,
+    v21: Format,
+    v30: Format,
+    v31: Format,
+) -> Format:
+    if SCHEMA_ROOT_30 in flavour_check:
+        return v30
+    elif SCHEMA_ROOT_31 in flavour_check:
+        return v31
+    return v21
+
+
 def __get_sdmx_ml_flavour(input_str: str) -> Tuple[str, Format]:
     flavour_check = input_str[:1000].lower()
+    if ":generictimeseriesdata" in flavour_check:
+        return input_str, Format.DATA_SDMX_ML_2_1_GENTS
     if ":generic" in flavour_check:
         return input_str, Format.DATA_SDMX_ML_2_1_GEN
 
+    if ":structurespecifictimeseriesdata" in flavour_check:
+        return input_str, Format.DATA_SDMX_ML_2_1_STRTS
     if ":structurespecificdata" in flavour_check:
-        if SCHEMA_ROOT_30 in flavour_check:
-            return input_str, Format.DATA_SDMX_ML_3_0
-        elif SCHEMA_ROOT_31 in flavour_check:
-            return input_str, Format.DATA_SDMX_ML_3_1
-        else:
-            return input_str, Format.DATA_SDMX_ML_2_1_STR
+        return input_str, __get_sdmx_ml_version(
+            flavour_check,
+            Format.DATA_SDMX_ML_2_1_STR,
+            Format.DATA_SDMX_ML_3_0,
+            Format.DATA_SDMX_ML_3_1,
+        )
     if ":structure" in flavour_check:
-        if SCHEMA_ROOT_30 in flavour_check:
-            return input_str, Format.STRUCTURE_SDMX_ML_3_0
-        elif SCHEMA_ROOT_31 in flavour_check:
-            return input_str, Format.STRUCTURE_SDMX_ML_3_1
-        else:
-            return input_str, Format.STRUCTURE_SDMX_ML_2_1
+        return input_str, __get_sdmx_ml_version(
+            flavour_check,
+            Format.STRUCTURE_SDMX_ML_2_1,
+            Format.STRUCTURE_SDMX_ML_3_0,
+            Format.STRUCTURE_SDMX_ML_3_1,
+        )
     if ":registryinterface" in flavour_check:
         return input_str, Format.REGISTRY_SDMX_ML_2_1
     if ":error" in flavour_check:

--- a/src/pysdmx/io/reader.py
+++ b/src/pysdmx/io/reader.py
@@ -104,14 +104,20 @@ def read_sdmx(  # noqa: C901
         ref_msg = read_refmeta(input_str, validate=validate)
         header = ref_msg.header
         reports = ref_msg.get_reports()
-    elif read_format == Format.DATA_SDMX_ML_2_1_GEN:
+    elif read_format in (
+        Format.DATA_SDMX_ML_2_1_GEN,
+        Format.DATA_SDMX_ML_2_1_GENTS,
+    ):
         from pysdmx.io.xml.header import read as read_header
         from pysdmx.io.xml.sdmx21.reader.generic import read as read_generic
 
         header = read_header(input_str, validate=validate)
-        # SDMX-ML 2.1 Generic Data
+        # SDMX-ML 2.1 Generic / Generic Time Series Data
         result_data = read_generic(input_str, validate=validate)
-    elif read_format == Format.DATA_SDMX_ML_2_1_STR:
+    elif read_format in (
+        Format.DATA_SDMX_ML_2_1_STR,
+        Format.DATA_SDMX_ML_2_1_STRTS,
+    ):
         from pysdmx.io.xml.header import read as read_header
         from pysdmx.io.xml.sdmx21.reader.structure_specific import (
             read as read_str_spe,
@@ -171,7 +177,9 @@ def read_sdmx(  # noqa: C901
         Format.DATA_SDMX_CSV_2_0_0,
         Format.DATA_SDMX_CSV_2_1_0,
         Format.DATA_SDMX_ML_2_1_GEN,
+        Format.DATA_SDMX_ML_2_1_GENTS,
         Format.DATA_SDMX_ML_2_1_STR,
+        Format.DATA_SDMX_ML_2_1_STRTS,
         Format.DATA_SDMX_ML_3_0,
         Format.DATA_SDMX_ML_3_1,
     ):

--- a/src/pysdmx/io/writer.py
+++ b/src/pysdmx/io/writer.py
@@ -16,8 +16,11 @@ WRITERS = {
     Format.DATA_SDMX_CSV_2_0_0: "pysdmx.io.csv.sdmx20.writer",
     Format.DATA_SDMX_CSV_2_1_0: "pysdmx.io.csv.sdmx21.writer",
     Format.DATA_SDMX_ML_2_1_GEN: "pysdmx.io.xml.sdmx21.writer.generic",
+    Format.DATA_SDMX_ML_2_1_GENTS: "pysdmx.io.xml.sdmx21.writer.generic_ts",
     Format.DATA_SDMX_ML_2_1_STR: "pysdmx.io.xml.sdmx21.writer."
     "structure_specific",
+    Format.DATA_SDMX_ML_2_1_STRTS: "pysdmx.io.xml.sdmx21.writer."
+    "structure_specific_ts",
     Format.STRUCTURE_SDMX_ML_2_1: "pysdmx.io.xml.sdmx21.writer.structure",
     Format.DATA_SDMX_ML_3_0: "pysdmx.io.xml.sdmx30.writer.structure_specific",
     Format.STRUCTURE_SDMX_ML_3_0: "pysdmx.io.xml.sdmx30.writer.structure",

--- a/src/pysdmx/io/xml/__tokens.py
+++ b/src/pysdmx/io/xml/__tokens.py
@@ -17,7 +17,9 @@ DATA_PROV = "DataProvider"
 
 # Structure Specific
 STR_SPE = "StructureSpecificData"
+STR_SPE_TS = "StructureSpecificTimeSeriesData"
 GENERIC = "GenericData"
+GENERIC_TS = "GenericTimeSeriesData"
 SERIES_KEY = "SeriesKey"
 GROUP_KEY = "GroupKey"
 ATTRIBUTES = "Attributes"

--- a/src/pysdmx/io/xml/__write_aux.py
+++ b/src/pysdmx/io/xml/__write_aux.py
@@ -44,7 +44,9 @@ from pysdmx.util import parse_short_urn
 
 MESSAGE_TYPE_MAPPING = {
     Format.DATA_SDMX_ML_2_1_GEN: "GenericData",
+    Format.DATA_SDMX_ML_2_1_GENTS: "GenericTimeSeriesData",
     Format.DATA_SDMX_ML_2_1_STR: "StructureSpecificData",
+    Format.DATA_SDMX_ML_2_1_STRTS: "StructureSpecificTimeSeriesData",
     Format.STRUCTURE_SDMX_ML_2_1: "Structure",
     Format.ERROR_SDMX_ML_2_1: "Error",
     Format.REGISTRY_SDMX_ML_2_1: "RegistryInterface",
@@ -128,9 +130,15 @@ def __namespaces_from_type(type_: Format) -> str:
     """
     if type_ == Format.STRUCTURE_SDMX_ML_2_1:
         return f"xmlns:{ABBR_STR}={NAMESPACES_21[ABBR_STR]!r} "
-    elif type_ == Format.DATA_SDMX_ML_2_1_STR:
+    elif type_ in (
+        Format.DATA_SDMX_ML_2_1_STR,
+        Format.DATA_SDMX_ML_2_1_STRTS,
+    ):
         return f"xmlns:{ABBR_SPE}={NAMESPACES_21[ABBR_SPE]!r} "
-    elif type_ == Format.DATA_SDMX_ML_2_1_GEN:
+    elif type_ in (
+        Format.DATA_SDMX_ML_2_1_GEN,
+        Format.DATA_SDMX_ML_2_1_GENTS,
+    ):
         return f"xmlns:{ABBR_GEN}={NAMESPACES_21[ABBR_GEN]!r} "
     elif type_ == Format.DATA_SDMX_ML_3_0:
         return f"xmlns:{ABBR_SPE}={NAMESPACES_30[ABBR_SPE]!r} "

--- a/src/pysdmx/io/xml/header.py
+++ b/src/pysdmx/io/xml/header.py
@@ -13,6 +13,7 @@ from pysdmx.io.xml.__tokens import (
     DIM_OBS,
     DSD,
     GENERIC,
+    GENERIC_TS,
     HEADER,
     HEADER_ID,
     ID,
@@ -25,6 +26,7 @@ from pysdmx.io.xml.__tokens import (
     SENDER,
     SOURCE,
     STR_SPE,
+    STR_SPE_TS,
     STR_USAGE,
     STRUCTURE,
     TEST,
@@ -203,7 +205,7 @@ def read(
         The header of the SDMX message.
     """
     dict_info = parse_xml(input_str, validate)
-    possible_keys = [STR_SPE, GENERIC, STRUCTURE]
+    possible_keys = [STR_SPE, STR_SPE_TS, GENERIC, GENERIC_TS, STRUCTURE]
     selected_key = next((key for key in possible_keys if key in dict_info))
     if HEADER not in dict_info[selected_key]:
         return None

--- a/src/pysdmx/io/xml/sdmx21/reader/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/generic.py
@@ -14,6 +14,7 @@ from pysdmx.io.xml.__parse_xml import parse_xml
 from pysdmx.io.xml.__tokens import (
     ATTRIBUTES,
     GENERIC,
+    GENERIC_TS,
     GROUP,
     GROUP_KEY,
     ID,
@@ -180,9 +181,10 @@ def read(input_str: str, validate: bool = True) -> Sequence[PandasDataset]:
         validate: If True, the XML data will be validated against the XSD.
     """
     dict_info = parse_xml(input_str, validate=validate)
-    if GENERIC not in dict_info:
+    msg_key = next((k for k in (GENERIC, GENERIC_TS) if k in dict_info), None)
+    if msg_key is None:
         raise Invalid("This SDMX document is not SDMX-ML 2.1 Generic.")
-    dataset_info, str_info = get_data_objects(dict_info[GENERIC])
+    dataset_info, str_info = get_data_objects(dict_info[msg_key])
 
     datasets = []
     for dataset in dataset_info:

--- a/src/pysdmx/io/xml/sdmx21/reader/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/structure_specific.py
@@ -14,6 +14,7 @@ from pysdmx.io.xml.__ss_aux_reader import (
 from pysdmx.io.xml.__tokens import (
     STR_REF,
     STR_SPE,
+    STR_SPE_TS,
 )
 
 
@@ -25,11 +26,12 @@ def read(input_str: str, validate: bool = True) -> Sequence[PandasDataset]:
         validate: If True, the XML data will be validated against the XSD.
     """
     dict_info = parse_xml(input_str, validate=validate)
-    if STR_SPE not in dict_info:
+    msg_key = next((k for k in (STR_SPE, STR_SPE_TS) if k in dict_info), None)
+    if msg_key is None:
         raise Invalid(
             "This SDMX document is not an SDMX-ML StructureSpecificData."
         )
-    dataset_info, str_info = get_data_objects(dict_info[STR_SPE])
+    dataset_info, str_info = get_data_objects(dict_info[msg_key])
     datasets = []
     for dataset in dataset_info:
         ds = _parse_structure_specific_data(

--- a/src/pysdmx/io/xml/sdmx21/writer/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/generic.py
@@ -457,6 +457,7 @@ def write(
     prettyprint: bool = True,
     header: Optional[Header] = None,
     dimension_at_observation: Optional[Dict[str, str]] = None,
+    sdmx_format: Optional[Format] = None,
 ) -> Optional[str]:
     """Write data to SDMX-ML 2.1 Generic format.
 
@@ -467,11 +468,12 @@ def write(
         header: The header to be used (generated if None).
         dimension_at_observation:
           The mapping between the dataset and the dimension at observation.
+        sdmx_format: The SDMX format to use (defaults to Generic).
 
     Returns:
         The XML string if path is empty, None otherwise.
     """
-    type_ = Format.DATA_SDMX_ML_2_1_GEN
+    type_ = sdmx_format or Format.DATA_SDMX_ML_2_1_GEN
 
     # Checking if we have datasets,
     # we need to ensure we can write them correctly

--- a/src/pysdmx/io/xml/sdmx21/writer/generic_ts.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/generic_ts.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from typing import Dict, Optional, Sequence, Union
 
+from pysdmx.errors import Invalid
 from pysdmx.io.format import Format
 from pysdmx.io.pd import PandasDataset
 from pysdmx.io.xml.sdmx21.writer.generic import write as _base_write
@@ -39,6 +40,18 @@ def write(
         dimension_at_observation = {
             ds.short_urn: "TIME_PERIOD" for ds in datasets
         }
+    else:
+        invalid_dims = {
+            k: v
+            for k, v in dimension_at_observation.items()
+            if v != "TIME_PERIOD"
+        }
+        if invalid_dims:
+            raise Invalid(
+                "Time Series formats require "
+                "dimensionAtObservation=TIME_PERIOD",
+                ", ".join(f"{k}={v}" for k, v in invalid_dims.items()),
+            )
 
     return _base_write(
         datasets=datasets,

--- a/src/pysdmx/io/xml/sdmx21/writer/generic_ts.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/generic_ts.py
@@ -1,0 +1,50 @@
+# mypy: disable-error-code="union-attr"
+"""Module for writing SDMX-ML 2.1 Generic Time Series data messages."""
+
+from pathlib import Path
+from typing import Dict, Optional, Sequence, Union
+
+from pysdmx.io.format import Format
+from pysdmx.io.pd import PandasDataset
+from pysdmx.io.xml.sdmx21.writer.generic import write as _base_write
+from pysdmx.model.message import Header
+
+
+def write(
+    datasets: Sequence[PandasDataset],
+    output_path: Optional[Union[str, Path]] = None,
+    prettyprint: bool = True,
+    header: Optional[Header] = None,
+    dimension_at_observation: Optional[Dict[str, str]] = None,
+) -> Optional[str]:
+    """Write data to SDMX-ML 2.1 Generic Time Series format.
+
+    This is a thin wrapper around the generic writer that defaults
+    ``dimension_at_observation`` to ``TIME_PERIOD`` for all datasets
+    and uses the Generic Time Series message type.
+
+    Args:
+        datasets: The datasets to be written.
+        output_path: The path to save the file.
+        prettyprint: Prettyprint or not.
+        header: The header to be used (generated if None).
+        dimension_at_observation:
+          The mapping between the dataset and the dimension at observation.
+          Defaults to TIME_PERIOD for all datasets.
+
+    Returns:
+        The XML string if path is empty, None otherwise.
+    """
+    if dimension_at_observation is None:
+        dimension_at_observation = {
+            ds.short_urn: "TIME_PERIOD" for ds in datasets
+        }
+
+    return _base_write(
+        datasets=datasets,
+        output_path=output_path,
+        prettyprint=prettyprint,
+        header=header,
+        dimension_at_observation=dimension_at_observation,
+        sdmx_format=Format.DATA_SDMX_ML_2_1_GENTS,
+    )

--- a/src/pysdmx/io/xml/sdmx21/writer/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/structure_specific.py
@@ -27,6 +27,7 @@ def write(
     prettyprint: bool = True,
     header: Optional[Header] = None,
     dimension_at_observation: Optional[Dict[str, str]] = None,
+    sdmx_format: Optional[Format] = None,
 ) -> Optional[str]:
     """Write data to SDMX-ML 2.1 Structure Specific format.
 
@@ -37,12 +38,13 @@ def write(
         header: The header to be used (generated if None).
         dimension_at_observation:
           The mapping between the dataset and the dimension at observation.
+        sdmx_format: The SDMX format to use (defaults to Structure Specific).
 
     Returns:
         The XML string if path is empty, None otherwise.
     """
     ss_namespaces = ""
-    type_ = Format.DATA_SDMX_ML_2_1_STR
+    type_ = sdmx_format or Format.DATA_SDMX_ML_2_1_STR
 
     # Checking if we have datasets,
     # we need to ensure we can write them correctly

--- a/src/pysdmx/io/xml/sdmx21/writer/structure_specific_ts.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/structure_specific_ts.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from typing import Dict, Optional, Sequence, Union
 
+from pysdmx.errors import Invalid
 from pysdmx.io.format import Format
 from pysdmx.io.pd import PandasDataset
 from pysdmx.io.xml.sdmx21.writer.structure_specific import (
@@ -41,6 +42,18 @@ def write(
         dimension_at_observation = {
             ds.short_urn: "TIME_PERIOD" for ds in datasets
         }
+    else:
+        invalid_dims = {
+            k: v
+            for k, v in dimension_at_observation.items()
+            if v != "TIME_PERIOD"
+        }
+        if invalid_dims:
+            raise Invalid(
+                "Time Series formats require "
+                "dimensionAtObservation=TIME_PERIOD",
+                ", ".join(f"{k}={v}" for k, v in invalid_dims.items()),
+            )
 
     return _base_write(
         datasets=datasets,

--- a/src/pysdmx/io/xml/sdmx21/writer/structure_specific_ts.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/structure_specific_ts.py
@@ -1,0 +1,52 @@
+# mypy: disable-error-code="union-attr"
+"""Module for writing SDMX-ML 2.1 Structure Specific Time Series messages."""
+
+from pathlib import Path
+from typing import Dict, Optional, Sequence, Union
+
+from pysdmx.io.format import Format
+from pysdmx.io.pd import PandasDataset
+from pysdmx.io.xml.sdmx21.writer.structure_specific import (
+    write as _base_write,
+)
+from pysdmx.model.message import Header
+
+
+def write(
+    datasets: Sequence[PandasDataset],
+    output_path: Optional[Union[str, Path]] = None,
+    prettyprint: bool = True,
+    header: Optional[Header] = None,
+    dimension_at_observation: Optional[Dict[str, str]] = None,
+) -> Optional[str]:
+    """Write data to SDMX-ML 2.1 Structure Specific Time Series format.
+
+    This is a thin wrapper around the structure-specific writer that
+    defaults ``dimension_at_observation`` to ``TIME_PERIOD`` for all
+    datasets and uses the Structure Specific Time Series message type.
+
+    Args:
+        datasets: The datasets to be written.
+        output_path: The path to save the file.
+        prettyprint: Prettyprint or not.
+        header: The header to be used (generated if None).
+        dimension_at_observation:
+          The mapping between the dataset and the dimension at observation.
+          Defaults to TIME_PERIOD for all datasets.
+
+    Returns:
+        The XML string if path is empty, None otherwise.
+    """
+    if dimension_at_observation is None:
+        dimension_at_observation = {
+            ds.short_urn: "TIME_PERIOD" for ds in datasets
+        }
+
+    return _base_write(
+        datasets=datasets,
+        output_path=output_path,
+        prettyprint=prettyprint,
+        header=header,
+        dimension_at_observation=dimension_at_observation,
+        sdmx_format=Format.DATA_SDMX_ML_2_1_STRTS,
+    )

--- a/tests/io/xml/sdmx21/writer/test_data_writing_ts.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing_ts.py
@@ -1,0 +1,177 @@
+from datetime import datetime
+
+import pandas as pd
+import pytest
+
+from pysdmx.io import read_sdmx, write_sdmx
+from pysdmx.io.format import Format
+from pysdmx.io.pd import PandasDataset
+from pysdmx.io.xml.sdmx21.writer.generic_ts import write as write_gen_ts
+from pysdmx.io.xml.sdmx21.writer.structure_specific_ts import (
+    write as write_str_ts,
+)
+from pysdmx.model import (
+    Component,
+    Components,
+    Concept,
+    Organisation,
+    Role,
+    Schema,
+)
+from pysdmx.model.message import Header
+
+
+@pytest.fixture
+def header():
+    return Header(
+        id="ID",
+        prepared=datetime.strptime("2021-01-01", "%Y-%m-%d"),
+        sender=Organisation(id="SENDER"),
+        receiver=Organisation(id="RECEIVER"),
+        source="PySDMX",
+    )
+
+
+@pytest.fixture
+def ts_content():
+    ds = PandasDataset(
+        data=pd.DataFrame(
+            {
+                "FREQ": ["A", "A", "A"],
+                "REF_AREA": ["US", "US", "GB"],
+                "TIME_PERIOD": ["2020", "2021", "2020"],
+                "OBS_VALUE": [100.0, 200.0, 300.0],
+            }
+        ),
+        structure=Schema(
+            context="datastructure",
+            id="TEST_TS",
+            agency="MD",
+            version="1.0",
+            components=Components(
+                [
+                    Component(
+                        id="FREQ",
+                        role=Role.DIMENSION,
+                        concept=Concept(id="FREQ"),
+                        required=True,
+                    ),
+                    Component(
+                        id="REF_AREA",
+                        role=Role.DIMENSION,
+                        concept=Concept(id="REF_AREA"),
+                        required=True,
+                    ),
+                    Component(
+                        id="TIME_PERIOD",
+                        role=Role.DIMENSION,
+                        concept=Concept(id="TIME_PERIOD"),
+                        required=True,
+                    ),
+                    Component(
+                        id="OBS_VALUE",
+                        role=Role.MEASURE,
+                        concept=Concept(id="OBS_VALUE"),
+                        required=True,
+                    ),
+                ]
+            ),
+        ),
+    )
+    return [ds]
+
+
+def test_generic_ts_root_element(header, ts_content):
+    result = write_gen_ts(ts_content, header=header)
+    assert result.startswith(
+        '<?xml version="1.0" encoding="UTF-8"?>\n<mes:GenericTimeSeriesData'
+    )
+    assert result.strip().endswith("</mes:GenericTimeSeriesData>")
+
+
+def test_structure_specific_ts_root_element(header, ts_content):
+    result = write_str_ts(ts_content, header=header)
+    assert result.startswith(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        "<mes:StructureSpecificTimeSeriesData"
+    )
+    assert result.strip().endswith("</mes:StructureSpecificTimeSeriesData>")
+
+
+def test_generic_ts_defaults_time_period(header, ts_content):
+    result = write_gen_ts(ts_content, header=header)
+    assert 'dimensionAtObservation="TIME_PERIOD"' in result
+
+
+def test_structure_specific_ts_defaults_time_period(header, ts_content):
+    result = write_str_ts(ts_content, header=header)
+    assert 'dimensionAtObservation="TIME_PERIOD"' in result
+
+
+def test_generic_ts_explicit_dim_at_obs(header, ts_content):
+    dim_mapping = {"DataStructure=MD:TEST_TS(1.0)": "FREQ"}
+    result = write_gen_ts(
+        ts_content,
+        header=header,
+        dimension_at_observation=dim_mapping,
+    )
+    assert 'dimensionAtObservation="FREQ"' in result
+
+
+def test_structure_specific_ts_explicit_dim_at_obs(header, ts_content):
+    dim_mapping = {"DataStructure=MD:TEST_TS(1.0)": "FREQ"}
+    result = write_str_ts(
+        ts_content,
+        header=header,
+        dimension_at_observation=dim_mapping,
+    )
+    assert 'dimensionAtObservation="FREQ"' in result
+
+
+def test_generic_ts_round_trip(header, ts_content):
+    result = write_gen_ts(ts_content, header=header)
+    msg = read_sdmx(result, validate=True)
+    assert msg.data is not None
+    assert len(msg.data) == 1
+    assert msg.data[0].data.shape == (3, 4)
+
+
+def test_structure_specific_ts_round_trip(header, ts_content):
+    result = write_str_ts(ts_content, header=header)
+    msg = read_sdmx(result, validate=True)
+    assert msg.data is not None
+    assert len(msg.data) == 1
+    assert msg.data[0].data.shape == (3, 4)
+
+
+@pytest.mark.parametrize(
+    "fmt",
+    [
+        Format.DATA_SDMX_ML_2_1_GENTS,
+        Format.DATA_SDMX_ML_2_1_STRTS,
+    ],
+)
+def test_write_sdmx_ts_formats(header, ts_content, fmt):
+    result = write_sdmx(
+        ts_content,
+        sdmx_format=fmt,
+        header=header,
+    )
+    assert result is not None
+    msg = read_sdmx(result, validate=True)
+    assert msg.data is not None
+    assert len(msg.data) == 1
+    assert 'dimensionAtObservation="TIME_PERIOD"' in result
+
+
+def test_generic_ts_series_structure(header, ts_content):
+    result = write_gen_ts(ts_content, header=header)
+    assert "<gen:Series>" in result
+    assert "<gen:SeriesKey>" in result
+    assert "<gen:ObsDimension" in result
+
+
+def test_structure_specific_ts_series_structure(header, ts_content):
+    result = write_str_ts(ts_content, header=header)
+    assert "<Series" in result
+    assert "TIME_PERIOD=" in result

--- a/tests/io/xml/sdmx21/writer/test_data_writing_ts.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing_ts.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pandas as pd
 import pytest
 
+from pysdmx.errors import Invalid
 from pysdmx.io import read_sdmx, write_sdmx
 from pysdmx.io.format import Format
 from pysdmx.io.pd import PandasDataset
@@ -108,24 +109,44 @@ def test_structure_specific_ts_defaults_time_period(header, ts_content):
     assert 'dimensionAtObservation="TIME_PERIOD"' in result
 
 
-def test_generic_ts_explicit_dim_at_obs(header, ts_content):
-    dim_mapping = {"DataStructure=MD:TEST_TS(1.0)": "FREQ"}
+def test_generic_ts_explicit_time_period(header, ts_content):
+    dim_mapping = {"DataStructure=MD:TEST_TS(1.0)": "TIME_PERIOD"}
     result = write_gen_ts(
         ts_content,
         header=header,
         dimension_at_observation=dim_mapping,
     )
-    assert 'dimensionAtObservation="FREQ"' in result
+    assert 'dimensionAtObservation="TIME_PERIOD"' in result
 
 
-def test_structure_specific_ts_explicit_dim_at_obs(header, ts_content):
-    dim_mapping = {"DataStructure=MD:TEST_TS(1.0)": "FREQ"}
+def test_structure_specific_ts_explicit_time_period(header, ts_content):
+    dim_mapping = {"DataStructure=MD:TEST_TS(1.0)": "TIME_PERIOD"}
     result = write_str_ts(
         ts_content,
         header=header,
         dimension_at_observation=dim_mapping,
     )
-    assert 'dimensionAtObservation="FREQ"' in result
+    assert 'dimensionAtObservation="TIME_PERIOD"' in result
+
+
+def test_generic_ts_rejects_non_time_period(header, ts_content):
+    dim_mapping = {"DataStructure=MD:TEST_TS(1.0)": "FREQ"}
+    with pytest.raises(Invalid):
+        write_gen_ts(
+            ts_content,
+            header=header,
+            dimension_at_observation=dim_mapping,
+        )
+
+
+def test_structure_specific_ts_rejects_non_time_period(header, ts_content):
+    dim_mapping = {"DataStructure=MD:TEST_TS(1.0)": "FREQ"}
+    with pytest.raises(Invalid):
+        write_str_ts(
+            ts_content,
+            header=header,
+            dimension_at_observation=dim_mapping,
+        )
 
 
 def test_generic_ts_round_trip(header, ts_content):

--- a/tests/io/xml/sdmx21/writer/test_data_writing_ts.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing_ts.py
@@ -131,7 +131,7 @@ def test_structure_specific_ts_explicit_time_period(header, ts_content):
 
 def test_generic_ts_rejects_non_time_period(header, ts_content):
     dim_mapping = {"DataStructure=MD:TEST_TS(1.0)": "FREQ"}
-    with pytest.raises(Invalid):
+    with pytest.raises(Invalid, match="dimensionAtObservation=TIME_PERIOD"):
         write_gen_ts(
             ts_content,
             header=header,
@@ -141,7 +141,7 @@ def test_generic_ts_rejects_non_time_period(header, ts_content):
 
 def test_structure_specific_ts_rejects_non_time_period(header, ts_content):
     dim_mapping = {"DataStructure=MD:TEST_TS(1.0)": "FREQ"}
-    with pytest.raises(Invalid):
+    with pytest.raises(Invalid, match="dimensionAtObservation=TIME_PERIOD"):
         write_str_ts(
             ts_content,
             header=header,
@@ -154,7 +154,10 @@ def test_generic_ts_round_trip(header, ts_content):
     msg = read_sdmx(result, validate=True)
     assert msg.data is not None
     assert len(msg.data) == 1
-    assert msg.data[0].data.shape == (3, 4)
+    df = msg.data[0].data
+    assert df.shape == (3, 4)
+    assert set(df.columns) == {"FREQ", "REF_AREA", "TIME_PERIOD", "OBS_VALUE"}
+    assert set(df["REF_AREA"]) == {"US", "GB"}
 
 
 def test_structure_specific_ts_round_trip(header, ts_content):
@@ -162,7 +165,10 @@ def test_structure_specific_ts_round_trip(header, ts_content):
     msg = read_sdmx(result, validate=True)
     assert msg.data is not None
     assert len(msg.data) == 1
-    assert msg.data[0].data.shape == (3, 4)
+    df = msg.data[0].data
+    assert df.shape == (3, 4)
+    assert set(df.columns) == {"FREQ", "REF_AREA", "TIME_PERIOD", "OBS_VALUE"}
+    assert set(df["REF_AREA"]) == {"US", "GB"}
 
 
 @pytest.mark.parametrize(
@@ -179,20 +185,24 @@ def test_write_sdmx_ts_formats(header, ts_content, fmt):
         header=header,
     )
     assert result is not None
+    assert 'dimensionAtObservation="TIME_PERIOD"' in result
     msg = read_sdmx(result, validate=True)
     assert msg.data is not None
     assert len(msg.data) == 1
-    assert 'dimensionAtObservation="TIME_PERIOD"' in result
+    assert msg.data[0].data.shape == (3, 4)
 
 
-def test_generic_ts_series_structure(header, ts_content):
+def test_generic_ts_series_key_values(header, ts_content):
     result = write_gen_ts(ts_content, header=header)
-    assert "<gen:Series>" in result
     assert "<gen:SeriesKey>" in result
-    assert "<gen:ObsDimension" in result
+    assert '<gen:Value id="FREQ" value="A"/>' in result
+    assert '<gen:Value id="REF_AREA" value="US"/>' in result
+    assert '<gen:ObsDimension value="2020"/>' in result
 
 
-def test_structure_specific_ts_series_structure(header, ts_content):
+def test_structure_specific_ts_series_attributes(header, ts_content):
     result = write_str_ts(ts_content, header=header)
-    assert "<Series" in result
-    assert "TIME_PERIOD=" in result
+    assert 'FREQ="A"' in result
+    assert 'REF_AREA="US"' in result
+    assert 'TIME_PERIOD="2020"' in result
+    assert 'OBS_VALUE="100' in result


### PR DESCRIPTION
## Summary

Closes #540

- Register `DATA_SDMX_ML_2_1_GENTS` and `DATA_SDMX_ML_2_1_STRTS` in both the writer and reader pipelines
- Reuse existing generic and structure-specific writers/readers — TS wrappers default `dimension_at_observation` to `TIME_PERIOD` and use the correct SDMX-ML 2.1 Time Series message types (`GenericTimeSeriesData` / `StructureSpecificTimeSeriesData`)
- Add format auto-detection for TS messages in the reader
- Update documentation (`general_writer.rst`, `sdmx_ml.rst`, `io_data.rst`)

## Test plan

- [x] 12 new tests covering root element names, TIME_PERIOD defaults, explicit overrides, round-trip write/read, and `write_sdmx()` integration
- [x] Full test suite passes (4567 tests, 100% coverage)
- [x] ruff format, ruff check, mypy all clean