### PR TITLE
Accept string for dimension_at_observation parameter

### DIFF
--- a/docs/howto/io_data.rst
+++ b/docs/howto/io_data.rst
@@ -175,7 +175,7 @@ A typical example to write data in Time Series with a custom header (pretty prin
         dimension_at_observation={"Dataflow=MD:TEST_DF(1.0)": "TIME_PERIOD"},
     )
 
-When all datasets share the same dimension at observation, a string shorthand can be used:
+When all datasets can use the same dimension at observation, a string shorthand can be used:
 
 .. code-block:: python
 

--- a/docs/howto/io_data.rst
+++ b/docs/howto/io_data.rst
@@ -175,6 +175,19 @@ A typical example to write data in Time Series with a custom header (pretty prin
         dimension_at_observation={"Dataflow=MD:TEST_DF(1.0)": "TIME_PERIOD"},
     )
 
+When all datasets share the same dimension at observation, a string shorthand can be used:
+
+.. code-block:: python
+
+    write_sdmx(
+        dataset,
+        output_path="output.xml",
+        sdmx_format=Format.DATA_SDMX_ML_3_0,
+        prettyprint=True,
+        header=header,
+        dimension_at_observation="TIME_PERIOD",
+    )
+
 .. _data-io-convert-tutorial:
 
 Convert between formats

--- a/src/pysdmx/io/writer.py
+++ b/src/pysdmx/io/writer.py
@@ -89,11 +89,14 @@ def write_sdmx(
         header: Custom :class:`Header <pysdmx.model.message.Header>` to
           include in the SDMX Message (only for SDMX-ML)
         dimension_at_observation: Mapping for dimension at observation
-          (only for SDMX-ML Data formats). This is a dictionary where
-          the keys are short URNs and the values are the dimension IDs
-          that should be used as the dimension at observation for that
-          structure in the output. For example,
-          ``{"Dataflow=MD:TEST_MD(1.0)": "TIME_PERIOD"}``.
+          (only for SDMX-ML Data formats). Can be either:
+
+          - A **string** with the dimension ID to apply to all datasets
+            (e.g., ``"TIME_PERIOD"``).
+          - A **dictionary** where the keys are short URNs and the values
+            are the dimension IDs for each structure
+            (e.g., ``{"Dataflow=MD:TEST_MD(1.0)": "TIME_PERIOD"}``).
+
           Overrides the header.structure
           (if a custom header is provided).
 

--- a/src/pysdmx/io/xml/__write_data_aux.py
+++ b/src/pysdmx/io/xml/__write_data_aux.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence, Union
 
 from pysdmx.errors import Invalid
 from pysdmx.io.pd import PandasDataset
@@ -14,13 +14,19 @@ def check_content_dataset(content: Sequence[PandasDataset]) -> None:
 
 def check_dimension_at_observation(
     datasets: Dict[str, PandasDataset],
-    dimension_at_observation: Optional[Dict[str, str]],
+    dimension_at_observation: Optional[Union[str, Dict[str, str]]],
 ) -> Dict[str, str]:
     """This function checks if the dimension at observation is valid."""
     # If dimension_at_observation is None, set it to ALL_DIM
     if dimension_at_observation is None:
         dimension_at_observation = dict.fromkeys(datasets, ALL_DIM)
         return dimension_at_observation
+
+    # If a string is passed, expand it to all datasets
+    if isinstance(dimension_at_observation, str):
+        dimension_at_observation = dict.fromkeys(
+            datasets, dimension_at_observation
+        )
 
     # Check the datasets and their dimensions are present
     for key, value in dimension_at_observation.items():

--- a/src/pysdmx/io/xml/sdmx21/writer/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/generic.py
@@ -466,7 +466,8 @@ def write(
         prettyprint: Prettyprint or not.
         header: The header to be used (generated if None).
         dimension_at_observation:
-          The mapping between the dataset and the dimension at observation.
+          The dimension at observation, either as a string applied to all
+          datasets or a dict mapping short URNs to dimension IDs.
 
     Returns:
         The XML string if path is empty, None otherwise.

--- a/src/pysdmx/io/xml/sdmx21/writer/generic.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/generic.py
@@ -456,7 +456,7 @@ def write(
     output_path: Optional[Union[str, Path]] = None,
     prettyprint: bool = True,
     header: Optional[Header] = None,
-    dimension_at_observation: Optional[Dict[str, str]] = None,
+    dimension_at_observation: Optional[Union[str, Dict[str, str]]] = None,
 ) -> Optional[str]:
     """Write data to SDMX-ML 2.1 Generic format.
 

--- a/src/pysdmx/io/xml/sdmx21/writer/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/structure_specific.py
@@ -36,7 +36,8 @@ def write(
         prettyprint: Prettyprint or not.
         header: The header to be used (generated if None).
         dimension_at_observation:
-          The mapping between the dataset and the dimension at observation.
+          The dimension at observation, either as a string applied to all
+          datasets or a dict mapping short URNs to dimension IDs.
 
     Returns:
         The XML string if path is empty, None otherwise.

--- a/src/pysdmx/io/xml/sdmx21/writer/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/structure_specific.py
@@ -26,7 +26,7 @@ def write(
     output_path: Optional[Union[str, Path]] = None,
     prettyprint: bool = True,
     header: Optional[Header] = None,
-    dimension_at_observation: Optional[Dict[str, str]] = None,
+    dimension_at_observation: Optional[Union[str, Dict[str, str]]] = None,
 ) -> Optional[str]:
     """Write data to SDMX-ML 2.1 Structure Specific format.
 

--- a/src/pysdmx/io/xml/sdmx30/writer/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx30/writer/structure_specific.py
@@ -42,7 +42,8 @@ def write(
         prettyprint: Prettyprint or not.
         header: The header to be used (generated if None).
         dimension_at_observation:
-          The mapping between the dataset and the dimension at observation.
+          The dimension at observation, either as a string applied to all
+          datasets or a dict mapping short URNs to dimension IDs.
 
     Returns:
         The XML string if path is empty, None otherwise.

--- a/src/pysdmx/io/xml/sdmx30/writer/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx30/writer/structure_specific.py
@@ -32,7 +32,7 @@ def write(
     output_path: Optional[Union[str, Path]] = None,
     prettyprint: bool = True,
     header: Optional[Header] = None,
-    dimension_at_observation: Optional[Dict[str, str]] = None,
+    dimension_at_observation: Optional[Union[str, Dict[str, str]]] = None,
 ) -> Optional[str]:
     """Write data to SDMX-ML 3.0 Structure Specific format.
 

--- a/src/pysdmx/io/xml/sdmx31/writer/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx31/writer/structure_specific.py
@@ -32,7 +32,7 @@ def write(
     output_path: Optional[Union[str, Path]] = None,
     prettyprint: bool = True,
     header: Optional[Header] = None,
-    dimension_at_observation: Optional[Dict[str, str]] = None,
+    dimension_at_observation: Optional[Union[str, Dict[str, str]]] = None,
 ) -> Optional[str]:
     """Write data to SDMX-ML 3.1 Structure Specific format.
 

--- a/src/pysdmx/io/xml/sdmx31/writer/structure_specific.py
+++ b/src/pysdmx/io/xml/sdmx31/writer/structure_specific.py
@@ -42,7 +42,8 @@ def write(
         prettyprint: Prettyprint or not.
         header: The header to be used (generated if None).
         dimension_at_observation:
-          The mapping between the dataset and the dimension at observation.
+          The dimension at observation, either as a string applied to all
+          datasets or a dict mapping short URNs to dimension IDs.
 
     Returns:
         The XML string if path is empty, None otherwise.

--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -223,6 +223,8 @@ def ds_with_group():
         ),
         (Format.DATA_SDMX_ML_2_1_GEN, "gen_ser.xml", "DIM1"),
         (Format.DATA_SDMX_ML_2_1_STR, "str_ser.xml", "DIM1"),
+        (Format.DATA_SDMX_ML_2_1_GEN, "gen_all.xml", "AllDimensions"),
+        (Format.DATA_SDMX_ML_2_1_STR, "str_all.xml", "AllDimensions"),
     ],
 )
 def test_data_write_read(

--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -388,12 +388,16 @@ def test_invalid_dimension_key(content):
 
 def test_invalid_string_dimension_at_observation(content):
     content = list(content.values())
-    with pytest.raises(Invalid):
+    with pytest.raises(
+        Invalid, match="Dimension at observation NONEXISTENT not found"
+    ):
         write_gen(
             content,
             dimension_at_observation="NONEXISTENT",
         )
-    with pytest.raises(Invalid):
+    with pytest.raises(
+        Invalid, match="Dimension at observation NONEXISTENT not found"
+    ):
         write_str_spec(
             content,
             dimension_at_observation="NONEXISTENT",

--- a/tests/io/xml/sdmx21/writer/test_data_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing.py
@@ -221,6 +221,8 @@ def ds_with_group():
             "str_all.xml",
             {"DataStructure=MD:TEST(1.0)": "AllDimensions"},
         ),
+        (Format.DATA_SDMX_ML_2_1_GEN, "gen_ser.xml", "DIM1"),
+        (Format.DATA_SDMX_ML_2_1_STR, "str_ser.xml", "DIM1"),
     ],
 )
 def test_data_write_read(
@@ -381,6 +383,20 @@ def test_invalid_dimension_key(content):
         write_str_spec(
             content,
             dimension_at_observation=dim_mapping,
+        )
+
+
+def test_invalid_string_dimension_at_observation(content):
+    content = list(content.values())
+    with pytest.raises(Invalid):
+        write_gen(
+            content,
+            dimension_at_observation="NONEXISTENT",
+        )
+    with pytest.raises(Invalid):
+        write_str_spec(
+            content,
+            dimension_at_observation="NONEXISTENT",
         )
 
 


### PR DESCRIPTION
## Summary
- Accept a plain string (e.g. `"TIME_PERIOD"`) for `dimension_at_observation`, expanding it to `{short_urn: value}` for all datasets in the message
- Raise `Invalid` if the dimension specified as string is not present in any dataset
- Update docstrings and documentation to describe the string shorthand

Closes #542

## Test plan
- [x] Parametrized write/read tests with string `"DIM1"` for both Generic and Structure Specific formats
- [x] Error test for invalid string dimension
- [x] All 4558 tests pass with 100% coverage
- [x] ruff and mypy clean