### PR TITLE
Remove 3.9 from CI matrix

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -177,7 +177,7 @@ Raises:
 
 ### CI Pipeline (3 OS × 5 Python versions)
 
-- **Matrix**: ubuntu-latest, windows-latest, macos-latest × Python 3.9, 3.10, 3.11, 3.12, 3.13
+- **Matrix**: ubuntu-latest, windows-latest, macos-latest × Python 3.10, 3.11, 3.12, 3.13
 - **Steps**: ruff format check → ruff check → mypy → pytest (100% coverage) → coverage report
 - **Fail-fast**: disabled (all matrix combinations run)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -177,7 +177,7 @@ Raises:
 
 ### CI Pipeline (3 OS × 5 Python versions)
 
-- **Matrix**: ubuntu-latest, windows-latest, macos-latest × Python 3.9, 3.10, 3.11, 3.12, 3.13
+- **Matrix**: ubuntu-latest, windows-latest, macos-latest × Python 3.10, 3.11, 3.12, 3.13
 - **Steps**: ruff format check → ruff check → mypy → pytest (100% coverage) → coverage report
 - **Fail-fast**: disabled (all matrix combinations run)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
As agreed with @javihern98, 3.14 will be added at a later stage.

Close #571 