### PR TITLE
Accept string shortcut for dimension_at_observation in TS writers

### DIFF
--- a/src/pysdmx/io/xml/sdmx21/writer/generic_ts.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/generic_ts.py
@@ -16,7 +16,7 @@ def write(
     output_path: Optional[Union[str, Path]] = None,
     prettyprint: bool = True,
     header: Optional[Header] = None,
-    dimension_at_observation: Optional[Dict[str, str]] = None,
+    dimension_at_observation: Optional[Union[str, Dict[str, str]]] = None,
 ) -> Optional[str]:
     """Write data to SDMX-ML 2.1 Generic Time Series format.
 
@@ -30,8 +30,9 @@ def write(
         prettyprint: Prettyprint or not.
         header: The header to be used (generated if None).
         dimension_at_observation:
-          The mapping between the dataset and the dimension at observation.
-          Defaults to TIME_PERIOD for all datasets.
+          The dimension at observation, either as a string applied to all
+          datasets or a dict mapping short URNs to dimension IDs. Defaults
+          to TIME_PERIOD for all datasets.
 
     Returns:
         The XML string if path is empty, None otherwise.
@@ -40,18 +41,19 @@ def write(
         dimension_at_observation = {
             ds.short_urn: "TIME_PERIOD" for ds in datasets
         }
-    else:
-        invalid_dims = {
-            k: v
-            for k, v in dimension_at_observation.items()
-            if v != "TIME_PERIOD"
+    elif isinstance(dimension_at_observation, str):
+        dimension_at_observation = {
+            ds.short_urn: dimension_at_observation for ds in datasets
         }
-        if invalid_dims:
-            raise Invalid(
-                "Time Series formats require "
-                "dimensionAtObservation=TIME_PERIOD",
-                ", ".join(f"{k}={v}" for k, v in invalid_dims.items()),
-            )
+
+    invalid_dims = {
+        k: v for k, v in dimension_at_observation.items() if v != "TIME_PERIOD"
+    }
+    if invalid_dims:
+        raise Invalid(
+            "Time Series formats require dimensionAtObservation=TIME_PERIOD",
+            ", ".join(f"{k}={v}" for k, v in invalid_dims.items()),
+        )
 
     return _base_write(
         datasets=datasets,

--- a/src/pysdmx/io/xml/sdmx21/writer/structure_specific_ts.py
+++ b/src/pysdmx/io/xml/sdmx21/writer/structure_specific_ts.py
@@ -18,7 +18,7 @@ def write(
     output_path: Optional[Union[str, Path]] = None,
     prettyprint: bool = True,
     header: Optional[Header] = None,
-    dimension_at_observation: Optional[Dict[str, str]] = None,
+    dimension_at_observation: Optional[Union[str, Dict[str, str]]] = None,
 ) -> Optional[str]:
     """Write data to SDMX-ML 2.1 Structure Specific Time Series format.
 
@@ -32,8 +32,9 @@ def write(
         prettyprint: Prettyprint or not.
         header: The header to be used (generated if None).
         dimension_at_observation:
-          The mapping between the dataset and the dimension at observation.
-          Defaults to TIME_PERIOD for all datasets.
+          The dimension at observation, either as a string applied to all
+          datasets or a dict mapping short URNs to dimension IDs. Defaults
+          to TIME_PERIOD for all datasets.
 
     Returns:
         The XML string if path is empty, None otherwise.
@@ -42,18 +43,19 @@ def write(
         dimension_at_observation = {
             ds.short_urn: "TIME_PERIOD" for ds in datasets
         }
-    else:
-        invalid_dims = {
-            k: v
-            for k, v in dimension_at_observation.items()
-            if v != "TIME_PERIOD"
+    elif isinstance(dimension_at_observation, str):
+        dimension_at_observation = {
+            ds.short_urn: dimension_at_observation for ds in datasets
         }
-        if invalid_dims:
-            raise Invalid(
-                "Time Series formats require "
-                "dimensionAtObservation=TIME_PERIOD",
-                ", ".join(f"{k}={v}" for k, v in invalid_dims.items()),
-            )
+
+    invalid_dims = {
+        k: v for k, v in dimension_at_observation.items() if v != "TIME_PERIOD"
+    }
+    if invalid_dims:
+        raise Invalid(
+            "Time Series formats require dimensionAtObservation=TIME_PERIOD",
+            ", ".join(f"{k}={v}" for k, v in invalid_dims.items()),
+        )
 
     return _base_write(
         datasets=datasets,

--- a/tests/io/xml/sdmx21/writer/test_data_writing_ts.py
+++ b/tests/io/xml/sdmx21/writer/test_data_writing_ts.py
@@ -149,6 +149,48 @@ def test_structure_specific_ts_rejects_non_time_period(header, ts_content):
         )
 
 
+def test_generic_ts_accepts_time_period_string(header, ts_content):
+    """Issue #589: string shortcut "TIME_PERIOD" must be accepted."""
+    result = write_gen_ts(
+        ts_content,
+        header=header,
+        dimension_at_observation="TIME_PERIOD",
+    )
+    assert 'dimensionAtObservation="TIME_PERIOD"' in result
+
+
+def test_structure_specific_ts_accepts_time_period_string(header, ts_content):
+    """Issue #589: string shortcut "TIME_PERIOD" must be accepted."""
+    result = write_str_ts(
+        ts_content,
+        header=header,
+        dimension_at_observation="TIME_PERIOD",
+    )
+    assert 'dimensionAtObservation="TIME_PERIOD"' in result
+
+
+def test_generic_ts_rejects_non_time_period_string(header, ts_content):
+    """Issue #589: string shortcut other than TIME_PERIOD must raise."""
+    with pytest.raises(Invalid, match="dimensionAtObservation=TIME_PERIOD"):
+        write_gen_ts(
+            ts_content,
+            header=header,
+            dimension_at_observation="FREQ",
+        )
+
+
+def test_structure_specific_ts_rejects_non_time_period_string(
+    header, ts_content
+):
+    """Issue #589: string shortcut other than TIME_PERIOD must raise."""
+    with pytest.raises(Invalid, match="dimensionAtObservation=TIME_PERIOD"):
+        write_str_ts(
+            ts_content,
+            header=header,
+            dimension_at_observation="FREQ",
+        )
+
+
 def test_generic_ts_round_trip(header, ts_content):
     result = write_gen_ts(ts_content, header=header)
     msg = read_sdmx(result, validate=True)


### PR DESCRIPTION
Closes #589.

The SDMX-ML 2.1 Time Series writers (STRTS, GENTS) inherited a stricter
`dimension_at_observation: Optional[Dict[str, str]]` signature from when
they were added in #557 (cr-540), and were not updated when #558 (cr-542)
introduced the string shortcut for the non-TS writers. Passing a plain
string crashed both with `AttributeError: 'str' object has no attribute
'items'`.

## Changes

- **`src/pysdmx/io/xml/sdmx21/writer/structure_specific_ts.py`** and
  **`src/pysdmx/io/xml/sdmx21/writer/generic_ts.py`** — widen the type
  hint to `Optional[Union[str, Dict[str, str]]]` and add an
  `elif isinstance(..., str)` branch that expands the string to a
  per-dataset dict (the same shape the `None` branch already produces).
  The existing "must be TIME_PERIOD" validation then runs unchanged, so
  passing `"FREQ"` still raises `Invalid` with the same message.

The fix is intentionally minimal: it keeps the TS wrapper's
responsibilities small and matches its existing structure rather than
delegating to `check_dimension_at_observation()` (which expects a
`Dict[str, PandasDataset]` and adds a "dimension must exist" check the
TS wrapper does not currently perform).

## Tests

Added four regression tests to
`tests/io/xml/sdmx21/writer/test_data_writing_ts.py`, all of which
fail on `develop` HEAD with the original `AttributeError`:

- `test_generic_ts_accepts_time_period_string` — happy path for GENTS
- `test_structure_specific_ts_accepts_time_period_string` — happy path for STRTS
- `test_generic_ts_rejects_non_time_period_string` — non-TIME_PERIOD string raises `Invalid`
- `test_structure_specific_ts_rejects_non_time_period_string` — same for STRTS

Existing regression guards keep passing: `test_generic_ts_defaults_time_period`,
`test_generic_ts_explicit_time_period`, `test_generic_ts_rejects_non_time_period`,
their STRTS counterparts, the round-trip tests, and the `write_sdmx` parametrized
format test.