### PR TITLE
Fix issue with DateTimeFilter not being supported in MultiFilter queries

### DIFF
--- a/src/pysdmx/api/qb/data.py
+++ b/src/pysdmx/api/qb/data.py
@@ -598,6 +598,12 @@ def __map_operator(op: Operator, value: Any) -> str:
     return out
 
 
+def _format_component_value(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat("T", "seconds")
+    return str(value)
+
+
 def _create_component_filter(
     flt: Union[BooleanFilter, DateTimeFilter, NumberFilter, TextFilter],
 ) -> str:
@@ -605,12 +611,15 @@ def _create_component_filter(
     val = flt.value
     if flt.operator in [Operator.LIKE, Operator.NOT_LIKE]:
         op = __map_operator(flt.operator, val)
-        val = str(val).replace("%", "")
+        val = _format_component_value(val).replace("%", "")
         return f"c[{fld}]={op}:{val}"
     elif flt.operator == Operator.IN:
-        return f"c[{fld}]={','.join(val)}"  # type: ignore[arg-type]
+        return f"c[{fld}]={','.join(_format_component_value(v) for v in val)}"
     elif flt.operator == Operator.BETWEEN:
-        return f"c[{fld}]=ge:{val[0]}+le:{val[1]}"  # type: ignore[index]
+        return (
+            f"c[{fld}]=ge:{_format_component_value(val[0])}"
+            f"+le:{_format_component_value(val[1])}"
+        )
     elif flt.operator in [
         Operator.EQUALS,
         Operator.NOT_EQUALS,
@@ -624,7 +633,7 @@ def _create_component_filter(
         op = __map_operator(flt.operator, val)
         if op:
             op += ":"
-        return f"c[{fld}]={op}{val}"
+        return f"c[{fld}]={op}{_format_component_value(val)}"
     else:
         raise Invalid(
             "Validation Error",

--- a/src/pysdmx/api/qb/data.py
+++ b/src/pysdmx/api/qb/data.py
@@ -614,11 +614,11 @@ def _create_component_filter(
         val = _format_component_value(val).replace("%", "")
         return f"c[{fld}]={op}:{val}"
     elif flt.operator == Operator.IN:
-        return f"c[{fld}]={','.join(_format_component_value(v) for v in val)}"
+        return f"c[{fld}]={','.join(_format_component_value(v) for v in val)}"  # type: ignore[union-attr]
     elif flt.operator == Operator.BETWEEN:
         return (
-            f"c[{fld}]=ge:{_format_component_value(val[0])}"
-            f"+le:{_format_component_value(val[1])}"
+            f"c[{fld}]=ge:{_format_component_value(val[0])}"  # type: ignore[index]
+            f"+le:{_format_component_value(val[1])}"  # type: ignore[index]
         )
     elif flt.operator in [
         Operator.EQUALS,

--- a/src/pysdmx/api/qb/data.py
+++ b/src/pysdmx/api/qb/data.py
@@ -202,7 +202,10 @@ class _CoreDataQuery(CoreQuery, frozen=True, omit_defaults=True):
                 )
             flts_by_comp = defaultdict(list)
             for f in components.filters:
-                if isinstance(f, (NumberFilter, TextFilter)):
+                if isinstance(
+                    f,
+                    (BooleanFilter, DateTimeFilter, NumberFilter, TextFilter),
+                ):
                     flts_by_comp[f.field].append(f)
                 else:
                     raise Invalid(

--- a/tests/api/qb/data/test_data_query_component.py
+++ b/tests/api/qb/data/test_data_query_component.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pysdmx.api.dc.query import (
+    DateTimeFilter,
     LogicalOperator,
     MultiFilter,
     NotFilter,
@@ -531,6 +532,92 @@ def test_one_number_between_since_2_2_0(api_version: ApiVersion):
     flt = NumberFilter("OBS_VALUE", Operator.BETWEEN, [2, 8])
     expected = (
         "/data/*/*/*/*/*?c[OBS_VALUE]=ge:2+le:8"
+        "&attributes=dsd&measures=all&includeHistory=false&offset=0"
+    )
+
+    q = DataQuery(components=flt)
+    url = q.get_url(api_version)
+
+    assert url == expected
+
+
+@pytest.mark.parametrize(
+    "api_version",
+    (
+        v
+        for v in ApiVersion
+        if v >= ApiVersion.V2_0_0 and v < ApiVersion.V2_2_0
+    ),
+)
+def test_one_datetime(api_version: ApiVersion):
+    flt = DateTimeFilter(
+        "TIME_PERIOD", Operator.GREATER_THAN, "2026-01-01T00:00:00Z"
+    )
+    expected = (
+        "/data/*/*/*/*/*?c[TIME_PERIOD]=gt:2026-01-01T00:00:00Z"
+        "&attributes=dsd&measures=all&includeHistory=false"
+    )
+
+    q = DataQuery(components=flt)
+    url = q.get_url(api_version)
+
+    assert url == expected
+
+
+@pytest.mark.parametrize(
+    "api_version", (v for v in ApiVersion if v >= ApiVersion.V2_2_0)
+)
+def test_one_datetime_since_2_2_0(api_version: ApiVersion):
+    flt = DateTimeFilter(
+        "TIME_PERIOD", Operator.GREATER_THAN, "2026-01-01T00:00:00Z"
+    )
+    expected = (
+        "/data/*/*/*/*/*?c[TIME_PERIOD]=gt:2026-01-01T00:00:00Z"
+        "&attributes=dsd&measures=all&includeHistory=false&offset=0"
+    )
+
+    q = DataQuery(components=flt)
+    url = q.get_url(api_version)
+
+    assert url == expected
+
+
+@pytest.mark.parametrize(
+    "api_version",
+    (
+        v
+        for v in ApiVersion
+        if v >= ApiVersion.V2_0_0 and v < ApiVersion.V2_2_0
+    ),
+)
+def test_datetime_between(api_version: ApiVersion):
+    flt = DateTimeFilter(
+        "TIME_PERIOD",
+        Operator.BETWEEN,
+        ["2026-01-01T00:00:00Z", "2026-12-31T23:59:59Z"],
+    )
+    expected = (
+        "/data/*/*/*/*/*?c[TIME_PERIOD]=ge:2026-01-01T00:00:00Z+le:2026-12-31T23:59:59Z"
+        "&attributes=dsd&measures=all&includeHistory=false"
+    )
+
+    q = DataQuery(components=flt)
+    url = q.get_url(api_version)
+
+    assert url == expected
+
+
+@pytest.mark.parametrize(
+    "api_version", (v for v in ApiVersion if v >= ApiVersion.V2_2_0)
+)
+def test_datetime_between_since_2_2_0(api_version: ApiVersion):
+    flt = DateTimeFilter(
+        "TIME_PERIOD",
+        Operator.BETWEEN,
+        ["2026-01-01T00:00:00Z", "2026-12-31T23:59:59Z"],
+    )
+    expected = (
+        "/data/*/*/*/*/*?c[TIME_PERIOD]=ge:2026-01-01T00:00:00Z+le:2026-12-31T23:59:59Z"
         "&attributes=dsd&measures=all&includeHistory=false&offset=0"
     )
 

--- a/tests/api/qb/data/test_data_query_component.py
+++ b/tests/api/qb/data/test_data_query_component.py
@@ -784,7 +784,7 @@ def test_bug_606():
     )
     expected = (
         "/data/dataflow/BIS/WS_CBPOL/1.0?"
-        "c[FREQ]=M&c[TIME_PERIOD]=ge:2018-01-01T23:59:59+00:00"
+        "c[FREQ]=M&c[LAST_UPDATED]=ge:2018-01-01T23:59:59+00:00"
     )
     url = dq.get_url(ApiVersion.V2_0_0, True)
 

--- a/tests/api/qb/data/test_data_query_component.py
+++ b/tests/api/qb/data/test_data_query_component.py
@@ -767,3 +767,25 @@ def test_bug_480():
     url = query.get_url(ApiVersion.V2_0_0, omit_defaults=True)
 
     assert url == expected
+
+
+def test_bug_606():
+    """Fix issue #606.
+
+    Reproduce condition when a DateTimeFilter query fails with an error but
+    shouldn't.
+    """
+    from pysdmx.api.dc.util import parse_query
+
+    qs = "FREQ = 'M' AND LAST_UPDATED >= '2018-01-01T23:59:59+00:00'"
+    flts = parse_query(qs)
+    dq = DataQuery(
+        DataContext.DATAFLOW, "BIS", "WS_CBPOL", "1.0", components=flts
+    )
+    expected = (
+        "/data/dataflow/BIS/WS_CBPOL/1.0?"
+        "c[FREQ]=M&c[TIME_PERIOD]=ge:2018-01-01T23:59:59+00:00"
+    )
+    url = dq.get_url(ApiVersion.V2_0_0, True)
+
+    assert url == expected

--- a/tests/api/qb/data/test_data_query_component.py
+++ b/tests/api/qb/data/test_data_query_component.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import pytest
 
 from pysdmx.api.dc.query import (
@@ -775,12 +777,16 @@ def test_bug_606():
     Reproduce condition when a DateTimeFilter query fails with an error but
     shouldn't.
     """
-    from pysdmx.api.dc.util import parse_query
+    f1 = TextFilter("FREQ", Operator.EQUALS, "M")
+    f2 = DateTimeFilter(
+        "LAST_UPDATED",
+        Operator.GREATER_THAN_OR_EQUAL,
+        datetime(2018, 1, 1, 23, 59, 59, tzinfo=timezone.utc),
+    )
+    mf = MultiFilter([f1, f2])
 
-    qs = "FREQ = 'M' AND LAST_UPDATED >= '2018-01-01T23:59:59+00:00'"
-    flts = parse_query(qs)
     dq = DataQuery(
-        DataContext.DATAFLOW, "BIS", "WS_CBPOL", "1.0", components=flts
+        DataContext.DATAFLOW, "BIS", "WS_CBPOL", "1.0", components=mf
     )
     expected = (
         "/data/dataflow/BIS/WS_CBPOL/1.0?"


### PR DESCRIPTION
This PR addresses two issues:

- `DateTimeFilter` was not supported in `DataQuery` when used as part of a `MultiFilter` query.
- The string representing the datetime was not compatible with ISO 8601.

Close #606 