### PR TITLE
Fix issue where representation maps can be created without source or target

### DIFF
--- a/src/pysdmx/model/map.py
+++ b/src/pysdmx/model/map.py
@@ -265,6 +265,51 @@ class MultiRepresentationMap(
     target: Sequence[str] = []
     maps: Sequence[MultiValueMap] = []
 
+    def __post_init__(self) -> None:
+        """Validate the multi representation map."""
+        super().__post_init__()
+
+        if not self.maps:
+            return
+
+        if not self.source:
+            raise Invalid(
+                "Validation Error",
+                (
+                    "MultiRepresentationMap source is required when "
+                    "maps are set."
+                ),
+            )
+
+        if not self.target:
+            raise Invalid(
+                "Validation Error",
+                (
+                    "MultiRepresentationMap target is required when "
+                    "maps are set."
+                ),
+            )
+
+        first_map = self.maps[0]
+
+        if len(self.source) != len(first_map.source):
+            raise Invalid(
+                "Validation Error",
+                (
+                    "MultiRepresentationMap source must contain the "
+                    "same number of entries as the first map source."
+                ),
+            )
+
+        if len(self.target) != len(first_map.target):
+            raise Invalid(
+                "Validation Error",
+                (
+                    "MultiRepresentationMap target must contain the "
+                    "same number of entries as the first map target."
+                ),
+            )
+
     @property
     def short_urn(self) -> str:
         """Returns the short URN for the MultiRepresentationMap."""

--- a/src/pysdmx/model/map.py
+++ b/src/pysdmx/model/map.py
@@ -6,6 +6,7 @@ from typing import Any, Iterator, Literal, Optional, Sequence, Tuple, Union
 
 from msgspec import Struct
 
+from pysdmx.errors import Invalid
 from pysdmx.model.__base import Agency, MaintainableArtefact
 from pysdmx.util._date_pattern_map import convert_dpm
 
@@ -332,6 +333,25 @@ class RepresentationMap(MaintainableArtefact, frozen=True, omit_defaults=True):
     source: Optional[str] = None
     target: Optional[str] = None
     maps: Sequence[ValueMap] = []
+
+    def __post_init__(self) -> None:
+        """Validate the representation map."""
+        super().__post_init__()
+
+        if not self.maps:
+            return
+
+        if self.source is None:
+            raise Invalid(
+                "Validation Error",
+                "RepresentationMap source is required when maps are set.",
+            )
+
+        if self.target is None:
+            raise Invalid(
+                "Validation Error",
+                "RepresentationMap target is required when maps are set.",
+            )
 
     def __iter__(
         self,

--- a/src/pysdmx/model/map.py
+++ b/src/pysdmx/model/map.py
@@ -11,6 +11,25 @@ from pysdmx.model.__base import Agency, MaintainableArtefact
 from pysdmx.util._date_pattern_map import convert_dpm
 
 
+def _raise_missing_map_side(map_type: str, side: str) -> None:
+    """Raise a standardized missing-side validation error."""
+    raise Invalid(
+        "Validation Error",
+        f"{map_type} {side} is required when maps are set.",
+    )
+
+
+def _raise_map_side_length_error(map_type: str, side: str) -> None:
+    """Raise a standardized side-length validation error."""
+    raise Invalid(
+        "Validation Error",
+        (
+            f"{map_type} {side} must contain the same number of entries "
+            f"as the first map {side}."
+        ),
+    )
+
+
 class _BaseMap(
     Struct,
     frozen=True,
@@ -273,41 +292,21 @@ class MultiRepresentationMap(
             return
 
         if not self.source:
-            raise Invalid(
-                "Validation Error",
-                (
-                    "MultiRepresentationMap source is required when "
-                    "maps are set."
-                ),
-            )
+            _raise_missing_map_side("MultiRepresentationMap", "source")
 
         if not self.target:
-            raise Invalid(
-                "Validation Error",
-                (
-                    "MultiRepresentationMap target is required when "
-                    "maps are set."
-                ),
-            )
+            _raise_missing_map_side("MultiRepresentationMap", "target")
 
         first_map = self.maps[0]
 
         if len(self.source) != len(first_map.source):
-            raise Invalid(
-                "Validation Error",
-                (
-                    "MultiRepresentationMap source must contain the "
-                    "same number of entries as the first map source."
-                ),
+            _raise_map_side_length_error(
+                "MultiRepresentationMap", "source"
             )
 
         if len(self.target) != len(first_map.target):
-            raise Invalid(
-                "Validation Error",
-                (
-                    "MultiRepresentationMap target must contain the "
-                    "same number of entries as the first map target."
-                ),
+            _raise_map_side_length_error(
+                "MultiRepresentationMap", "target"
             )
 
     @property
@@ -387,16 +386,10 @@ class RepresentationMap(MaintainableArtefact, frozen=True, omit_defaults=True):
             return
 
         if self.source is None:
-            raise Invalid(
-                "Validation Error",
-                "RepresentationMap source is required when maps are set.",
-            )
+            _raise_missing_map_side("RepresentationMap", "source")
 
         if self.target is None:
-            raise Invalid(
-                "Validation Error",
-                "RepresentationMap target is required when maps are set.",
-            )
+            _raise_missing_map_side("RepresentationMap", "target")
 
     def __iter__(
         self,

--- a/src/pysdmx/model/map.py
+++ b/src/pysdmx/model/map.py
@@ -300,14 +300,10 @@ class MultiRepresentationMap(
         first_map = self.maps[0]
 
         if len(self.source) != len(first_map.source):
-            _raise_map_side_length_error(
-                "MultiRepresentationMap", "source"
-            )
+            _raise_map_side_length_error("MultiRepresentationMap", "source")
 
         if len(self.target) != len(first_map.target):
-            _raise_map_side_length_error(
-                "MultiRepresentationMap", "target"
-            )
+            _raise_map_side_length_error("MultiRepresentationMap", "target")
 
     @property
     def short_urn(self) -> str:

--- a/tests/io/samples/maps.xml
+++ b/tests/io/samples/maps.xml
@@ -34,6 +34,7 @@
             <str:RepresentationMap urn="urn:sdmx:org.sdmx.infomodel.structuremapping.RepresentationMap=ESTAT:REPMAP_CURR(1.0)" id="REPMAP_CURR" agencyID="ESTAT" version="1.0">
                 <com:Name xml:lang="en">Country + Local Currency to ISO Currency</com:Name>
                 <str:SourceCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_COUNTRY_LOCALCURR(1.0)</str:SourceCodelist>
+                <str:SourceCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_CURRENCY(1.0)</str:SourceCodelist>
                 <str:TargetCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_CURRENCY_ISO3(1.0)</str:TargetCodelist>
                 <str:RepresentationMapping>
                     <str:SourceValue>DE</str:SourceValue>
@@ -51,6 +52,7 @@
                 <com:Name xml:lang="en">Series code to Indicator + Status</com:Name>
                 <str:SourceCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_SERIES_CODE(1.0)</str:SourceCodelist>
                 <str:TargetCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_INDICATOR_STATUS(1.0)</str:TargetCodelist>
+                <str:TargetCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_INDICATOR_STATUS2(1.0)</str:TargetCodelist>
                 <str:RepresentationMapping>
                     <str:SourceValue>XMAN_Z_34</str:SourceValue>
                     <str:TargetValue>XM</str:TargetValue>
@@ -66,7 +68,9 @@
             <str:RepresentationMap urn="urn:sdmx:org.sdmx.infomodel.structuremapping.RepresentationMap=ESTAT:REPMAP_NN(1.0)" id="REPMAP_NN" agencyID="ESTAT" version="1.0">
                 <com:Name xml:lang="en">Freq + Adjustment to Indicator + Note</com:Name>
                 <str:SourceCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_FREQ_ADJ(1.0)</str:SourceCodelist>
+                <str:SourceCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_FREQ_ADJ2(1.0)</str:SourceCodelist>
                 <str:TargetCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_IND_NOTE(1.0)</str:TargetCodelist>
+                <str:TargetCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_IND_NOTE2(1.0)</str:TargetCodelist>
                 <str:RepresentationMapping>
                     <str:SourceValue>A</str:SourceValue>
                     <str:SourceValue>N</str:SourceValue>

--- a/tests/model/test_map_multi_component_mapper.py
+++ b/tests/model/test_map_multi_component_mapper.py
@@ -29,8 +29,8 @@ def values():
         id="RM_ID",
         name="Map ISO2 to ISO3",
         agency="BIS",
-        source="SRC_CL",
-        target="TGT_CL",
+        source=["SRC_CL1", "SRC_CL2"],
+        target=["TGT_CL"],
         maps=vms,
     )
 
@@ -65,8 +65,8 @@ def test_not_equal(source, target, values):
             id="RM_ID1",
             name="Map ISO2 to ISO3",
             agency="BIS",
-            source="SRC_CL1",
-            target="TGT_CL1",
+            source=["SRC_CL1", "SRC_CL2"],
+            target=["TGT_CL1"],
             maps=[],
         ),
     )

--- a/tests/model/test_map_multi_representation_map.py
+++ b/tests/model/test_map_multi_representation_map.py
@@ -3,6 +3,7 @@ from typing import Iterable, Sized
 import msgspec
 import pytest
 
+from pysdmx import errors
 from pysdmx.model import (
     MultiRepresentationMap,
     MultiValueMap,
@@ -162,3 +163,54 @@ def test_serialization(
         MultiRepresentationMap, dec_hook=decoders
     ).decode(ser)
     assert out == rm
+
+
+def test_empty_maps_allow_missing_source_and_target(id, name, agency):
+    sm = MultiRepresentationMap(id=id, name=name, agency=agency)
+
+    assert sm.source == []
+    assert sm.target == []
+    assert sm.maps == []
+
+
+def test_missing_source(id, name, agency, target, mappings):
+    with pytest.raises(errors.Invalid, match="source is required"):
+        MultiRepresentationMap(
+            id=id, name=name, agency=agency, target=target, maps=mappings
+        )
+
+
+def test_missing_target(id, name, agency, source, mappings):
+    with pytest.raises(errors.Invalid, match="target is required"):
+        MultiRepresentationMap(
+            id=id, name=name, agency=agency, source=source, maps=mappings
+        )
+
+
+def test_invalid_source_length(id, name, agency, target, mappings):
+    with pytest.raises(errors.Invalid, match="same number of entries"):
+        MultiRepresentationMap(
+            id=id,
+            name=name,
+            agency=agency,
+            source=[
+                "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL1(1.0)"
+            ],
+            target=target,
+            maps=mappings,
+        )
+
+
+def test_invalid_target_length(id, name, agency, source, mappings):
+    with pytest.raises(errors.Invalid, match="same number of entries"):
+        MultiRepresentationMap(
+            id=id,
+            name=name,
+            agency=agency,
+            source=source,
+            target=[
+                "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL3(1.0)",
+                "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=BIS:CL4(1.0)",
+            ],
+            maps=mappings,
+        )

--- a/tests/model/test_map_representation_map.py
+++ b/tests/model/test_map_representation_map.py
@@ -4,6 +4,7 @@ from typing import Iterable, Sized
 import msgspec
 import pytest
 
+from pysdmx import errors
 from pysdmx.model import RepresentationMap, ValueMap, decoders, encoders
 
 
@@ -161,3 +162,25 @@ def test_serialization(
         ser
     )
     assert out == rm
+
+
+def test_empty_maps_allow_missing_source_and_target(id, name, agency):
+    sm = RepresentationMap(id=id, name=name, agency=agency)
+
+    assert sm.source is None
+    assert sm.target is None
+    assert sm.maps == []
+
+
+def test_missing_source(id, name, agency, target, mappings):
+    with pytest.raises(errors.Invalid, match="source is required"):
+        RepresentationMap(
+            id=id, name=name, agency=agency, target=target, maps=mappings
+        )
+
+
+def test_missing_target(id, name, agency, source, mappings):
+    with pytest.raises(errors.Invalid, match="target is required"):
+        RepresentationMap(
+            id=id, name=name, agency=agency, source=source, maps=mappings
+        )


### PR DESCRIPTION
This PR addresses issue #569 by validating that sources and targets are present when creating a (multi) representation map.