### PR TITLE
Distinguish RepresentationMap and MultiRepresentationMap in SDMX-ML

### DIFF
--- a/src/pysdmx/io/xml/__structure_aux_reader.py
+++ b/src/pysdmx/io/xml/__structure_aux_reader.py
@@ -191,6 +191,7 @@ from pysdmx.model import (
     ImplicitComponentMap,
     KeySet,
     MultiComponentMap,
+    MultiRepresentationMap,
     MultiValueMap,
     RepresentationMap,
     StructureMap,
@@ -240,6 +241,13 @@ T = Any
 
 def _identity(x: T) -> T:
     return x
+
+
+def _convert(converter: Callable[[Any], Any], value: Any) -> Any:
+    """Applies a converter to a value, or to each item if it is a list."""
+    if isinstance(value, list):
+        return [converter(v) for v in value]
+    return converter(value)
 
 
 STRUCTURES_MAPPING = {
@@ -365,7 +373,9 @@ class StructureParser(Struct):
     structure_maps: Dict[str, StructureMap] = {}
     component_maps: Dict[str, ComponentMap] = {}
     fixed_value_maps: Dict[str, FixedValueMap] = {}
-    representation_maps: Dict[str, RepresentationMap] = {}
+    representation_maps: Dict[
+        str, Union[RepresentationMap, MultiRepresentationMap]
+    ] = {}
     name_personalisations: Dict[str, NamePersonalisationScheme] = {}
     custom_types: Dict[str, CustomTypeScheme] = {}
     transformations: Dict[str, TransformationScheme] = {}
@@ -1295,6 +1305,21 @@ class StructureParser(Struct):
             values=child_dict["values"],
         )
 
+    def __build_representation_map(
+        self, structure: Dict[str, Any]
+    ) -> Union[RepresentationMap, MultiRepresentationMap]:
+        src_list = add_list(structure.get("source"))
+        tgt_list = add_list(structure.get("target"))
+
+        if len(src_list) != 1 or len(tgt_list) != 1:
+            structure["source"] = src_list
+            structure["target"] = tgt_list
+            return MultiRepresentationMap(**structure)
+
+        structure["source"] = src_list[0]
+        structure["target"] = tgt_list[0]
+        return RepresentationMap(**structure)
+
     def __build_representation_mapping(
         self, child_dict: Dict[str, Any]
     ) -> Union[ValueMap, MultiValueMap]:
@@ -1352,7 +1377,9 @@ class StructureParser(Struct):
         for xml_key, py_key in renames.items():
             if xml_key in element:
                 value = element.pop(xml_key)
-                element[py_key] = converters.get(xml_key, _identity)(value)
+                element[py_key] = _convert(
+                    converters.get(xml_key, _identity), value
+                )
 
         child_class_mapping: Dict[str, Type[Any]] = {
             "ComponentMap": ComponentMap,
@@ -1519,7 +1546,10 @@ class StructureParser(Struct):
                     structure[COMPS] = Components(structure[COMPS])
                 else:
                     structure[COMPS] = Components([])
-            schemas[short_urn] = STRUCTURES_MAPPING[schema](**structure)
+            if schema == REPRESENTATION_MAP:
+                schemas[short_urn] = self.__build_representation_map(structure)
+            else:
+                schemas[short_urn] = STRUCTURES_MAPPING[schema](**structure)
 
         return schemas
 

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -118,6 +118,7 @@ from pysdmx.model import (
     ImplicitComponentMap,
     KeySet,
     MultiComponentMap,
+    MultiRepresentationMap,
     MultiValueMap,
     NamePersonalisation,
     NamePersonalisationScheme,
@@ -201,6 +202,7 @@ STR_DICT_TYPE_LIST_21 = {
     Dataflow: "Dataflows",
     DataConstraint: "Constraints",
     RepresentationMap: "RepresentationMaps",
+    MultiRepresentationMap: "RepresentationMaps",
     StructureMap: "StructureMaps",
     DatePatternMap: "DatePatternMaps",
     CustomTypeScheme: "CustomTypes",
@@ -221,6 +223,7 @@ STR_DICT_TYPE_LIST_30 = {
     Dataflow: "Dataflows",
     DataConstraint: "DataConstraints",
     RepresentationMap: "RepresentationMaps",
+    MultiRepresentationMap: "RepresentationMaps",
     StructureMap: "StructureMaps",
     DatePatternMap: "DatePatternMaps",
     CustomTypeScheme: "CustomTypeSchemes",
@@ -975,9 +978,11 @@ def __write_multi_component_map(
 
 
 def __write_representation_map(
-    rep_map: RepresentationMap, indent: str, references_30: bool = False
+    rep_map: Union[RepresentationMap, MultiRepresentationMap],
+    indent: str,
+    references_30: bool = False,
 ) -> str:
-    """Writes a RepresentationMap to the XML file."""
+    """Writes a (multi) representation map to the XML file."""
 
     def __source_target_tag(prefix: str, value: Optional[str]) -> str:
         if value and ("Codelist" in value or "ValueList" in value):
@@ -993,19 +998,29 @@ def __write_representation_map(
     outfile = f"{indent}<{label}{attributes}>"
     outfile += __export_intern_data(data)
 
-    # Write Source and Target references
-    src_tag = __source_target_tag("Source", rep_map.source)
-    outfile += (
-        f"{add_indent(indent)}<{ABBR_STR}:{src_tag}>"
-        f"{rep_map.source}"
-        f"</{ABBR_STR}:{src_tag}>"
-    )
-    tgt_tag = __source_target_tag("Target", rep_map.target)
-    outfile += (
-        f"{add_indent(indent)}<{ABBR_STR}:{tgt_tag}>"
-        f"{rep_map.target}"
-        f"</{ABBR_STR}:{tgt_tag}>"
-    )
+    # Write Source and Target references (one element per codelist/datatype)
+    sources: Sequence[Optional[str]]
+    targets: Sequence[Optional[str]]
+    if isinstance(rep_map, MultiRepresentationMap):
+        sources = rep_map.source
+        targets = rep_map.target
+    else:
+        sources = [rep_map.source]
+        targets = [rep_map.target]
+    for source in sources:
+        src_tag = __source_target_tag("Source", source)
+        outfile += (
+            f"{add_indent(indent)}<{ABBR_STR}:{src_tag}>"
+            f"{source}"
+            f"</{ABBR_STR}:{src_tag}>"
+        )
+    for target in targets:
+        tgt_tag = __source_target_tag("Target", target)
+        outfile += (
+            f"{add_indent(indent)}<{ABBR_STR}:{tgt_tag}>"
+            f"{target}"
+            f"</{ABBR_STR}:{tgt_tag}>"
+        )
 
     # Write ValueMaps
     for value_map in rep_map.maps:
@@ -1405,7 +1420,7 @@ def __write_scheme(  # noqa: C901
     if getattr(item_scheme, "sdmx_type", None) == "valuelist":
         scheme = VALUE_LIST
 
-    if scheme == REPRESENTATION_MAP:
+    if isinstance(item_scheme, (RepresentationMap, MultiRepresentationMap)):
         return __write_representation_map(item_scheme, indent, references_30)
     if scheme == STRUCTURE_MAP:
         return __write_structure_map(item_scheme, indent, references_30)

--- a/tests/io/samples/maps.xml
+++ b/tests/io/samples/maps.xml
@@ -34,6 +34,7 @@
             <str:RepresentationMap urn="urn:sdmx:org.sdmx.infomodel.structuremapping.RepresentationMap=ESTAT:REPMAP_CURR(1.0)" id="REPMAP_CURR" agencyID="ESTAT" version="1.0">
                 <com:Name xml:lang="en">Country + Local Currency to ISO Currency</com:Name>
                 <str:SourceCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_COUNTRY_LOCALCURR(1.0)</str:SourceCodelist>
+                <str:SourceCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_CURRENCY(1.0)</str:SourceCodelist>
                 <str:TargetCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_CURRENCY_ISO3(1.0)</str:TargetCodelist>
                 <str:RepresentationMapping>
                     <str:SourceValue>DE</str:SourceValue>
@@ -51,6 +52,7 @@
                 <com:Name xml:lang="en">Series code to Indicator + Status</com:Name>
                 <str:SourceCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_SERIES_CODE(1.0)</str:SourceCodelist>
                 <str:TargetCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_INDICATOR_STATUS(1.0)</str:TargetCodelist>
+                <str:TargetCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_INDICATOR_STATUS2(1.0)</str:TargetCodelist>
                 <str:RepresentationMapping>
                     <str:SourceValue>XMAN_Z_34</str:SourceValue>
                     <str:TargetValue>XM</str:TargetValue>
@@ -66,7 +68,9 @@
             <str:RepresentationMap urn="urn:sdmx:org.sdmx.infomodel.structuremapping.RepresentationMap=ESTAT:REPMAP_NN(1.0)" id="REPMAP_NN" agencyID="ESTAT" version="1.0">
                 <com:Name xml:lang="en">Freq + Adjustment to Indicator + Note</com:Name>
                 <str:SourceCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_FREQ_ADJ(1.0)</str:SourceCodelist>
+                <str:SourceCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_FREQ_ADJ2(1.0)</str:SourceCodelist>
                 <str:TargetCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_IND_NOTE(1.0)</str:TargetCodelist>
+                <str:TargetCodelist>urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_IND_NOTE2(1.0)</str:TargetCodelist>
                 <str:RepresentationMapping>
                     <str:SourceValue>A</str:SourceValue>
                     <str:SourceValue>N</str:SourceValue>

--- a/tests/io/samples/maps_datatype_multi.xml
+++ b/tests/io/samples/maps_datatype_multi.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<message:Structure
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message"
+    xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure"
+    xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common">
+
+    <message:Header>
+        <message:ID>MAP_DT_MULTI_001</message:ID>
+        <message:Test>true</message:Test>
+        <message:Prepared>2025-05-26T12:00:00Z</message:Prepared>
+        <message:Sender id="ESTAT"/>
+        <message:Receiver id="not_supplied"/>
+    </message:Header>
+
+    <message:Structures>
+        <str:RepresentationMaps>
+            <!-- Multi representation map with data type source/target -->
+            <str:RepresentationMap urn="urn:sdmx:org.sdmx.infomodel.structuremapping.RepresentationMap=ESTAT:REPMAP_DT_NN(1.0)" id="REPMAP_DT_NN" agencyID="ESTAT" version="1.0">
+                <com:Name xml:lang="en">Multi data type mapping</com:Name>
+                <str:SourceDataType>String</str:SourceDataType>
+                <str:SourceDataType>Integer</str:SourceDataType>
+                <str:TargetDataType>String</str:TargetDataType>
+                <str:TargetDataType>Integer</str:TargetDataType>
+                <str:RepresentationMapping>
+                    <str:SourceValue>A</str:SourceValue>
+                    <str:SourceValue>1</str:SourceValue>
+                    <str:TargetValue>X</str:TargetValue>
+                    <str:TargetValue>9</str:TargetValue>
+                </str:RepresentationMapping>
+                <str:RepresentationMapping>
+                    <str:SourceValue>B</str:SourceValue>
+                    <str:SourceValue>2</str:SourceValue>
+                    <str:TargetValue>Y</str:TargetValue>
+                    <str:TargetValue>8</str:TargetValue>
+                </str:RepresentationMapping>
+            </str:RepresentationMap>
+        </str:RepresentationMaps>
+    </message:Structures>
+</message:Structure>

--- a/tests/io/test_general_reader.py
+++ b/tests/io/test_general_reader.py
@@ -19,6 +19,7 @@ from pysdmx.model import (
     ImplicitComponentMap,
     MetadataReport,
     MultiComponentMap,
+    MultiRepresentationMap,
     MultiValueMap,
     RepresentationMap,
     Schema,
@@ -582,12 +583,21 @@ def test_read_maps():
     assert m.source == "2"
     assert m.target == "F"
 
-    # RepresentationMap 2 - REPMAP_CURR (N-1 => MultiValueMap)
+    # MultiRepresentationMap - REPMAP_CURR (N-1 => MultiValueMap)
     rep_map = result.structures[2]
-    assert isinstance(rep_map, RepresentationMap)
+    assert isinstance(rep_map, MultiRepresentationMap)
     assert rep_map.id == "REPMAP_CURR"
     assert rep_map.agency == "ESTAT"
     assert rep_map.version == "1.0"
+    assert list(rep_map.source) == [
+        "urn:sdmx:org.sdmx.infomodel.codelist."
+        "Codelist=ESTAT:CL_COUNTRY_LOCALCURR(1.0)",
+        "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_CURRENCY(1.0)",
+    ]
+    assert list(rep_map.target) == [
+        "urn:sdmx:org.sdmx.infomodel.codelist."
+        "Codelist=ESTAT:CL_CURRENCY_ISO3(1.0)"
+    ]
     assert len(rep_map.maps) == 2
 
     m = rep_map.maps[0]
@@ -602,12 +612,22 @@ def test_read_maps():
     assert list(m.source) == ["CH", "LC"]
     assert list(m.target) == ["CHF"]
 
-    # RepresentationMap 3 - REPMAP_SERIES (1-N => MultiValueMap)
+    # MultiRepresentationMap - REPMAP_SERIES (1-N => MultiValueMap)
     rep_map = result.structures[3]
-    assert isinstance(rep_map, RepresentationMap)
+    assert isinstance(rep_map, MultiRepresentationMap)
     assert rep_map.id == "REPMAP_SERIES"
     assert rep_map.agency == "ESTAT"
     assert rep_map.version == "1.0"
+    assert list(rep_map.source) == [
+        "urn:sdmx:org.sdmx.infomodel.codelist."
+        "Codelist=ESTAT:CL_SERIES_CODE(1.0)"
+    ]
+    assert list(rep_map.target) == [
+        "urn:sdmx:org.sdmx.infomodel.codelist."
+        "Codelist=ESTAT:CL_INDICATOR_STATUS(1.0)",
+        "urn:sdmx:org.sdmx.infomodel.codelist."
+        "Codelist=ESTAT:CL_INDICATOR_STATUS2(1.0)",
+    ]
     assert len(rep_map.maps) == 2
 
     m = rep_map.maps[0]
@@ -620,12 +640,22 @@ def test_read_maps():
     assert list(m.source) == ["YBOP_A_12"]
     assert list(m.target) == ["YB", "OK"]
 
-    # RepresentationMap 4 - REPMAP_NN (N-N => MultiValueMap)
+    # MultiRepresentationMap - REPMAP_NN (N-N => MultiValueMap)
     rep_map = result.structures[4]
-    assert isinstance(rep_map, RepresentationMap)
+    assert isinstance(rep_map, MultiRepresentationMap)
     assert rep_map.id == "REPMAP_NN"
     assert rep_map.agency == "ESTAT"
     assert rep_map.version == "1.0"
+    assert list(rep_map.source) == [
+        "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_FREQ_ADJ(1.0)",
+        "urn:sdmx:org.sdmx.infomodel.codelist."
+        "Codelist=ESTAT:CL_FREQ_ADJ2(1.0)",
+    ]
+    assert list(rep_map.target) == [
+        "urn:sdmx:org.sdmx.infomodel.codelist.Codelist=ESTAT:CL_IND_NOTE(1.0)",
+        "urn:sdmx:org.sdmx.infomodel.codelist."
+        "Codelist=ESTAT:CL_IND_NOTE2(1.0)",
+    ]
     assert len(rep_map.maps) == 2
 
     m = rep_map.maps[0]
@@ -778,3 +808,21 @@ def test_read_maps():
     assert dpm.locale == "es"
     assert dpm.pattern_type == "variable"
     assert dpm.resolve_period == "endOfPeriod"
+
+
+def test_read_multi_datatype_representation_map():
+    data_path = Path(__file__).parent / "samples" / "maps_datatype_multi.xml"
+    result = read_sdmx(data_path, validate=True)
+    assert len(result.structures) == 1
+
+    rep_map = result.structures[0]
+    assert isinstance(rep_map, MultiRepresentationMap)
+    assert rep_map.id == "REPMAP_DT_NN"
+    assert list(rep_map.source) == [DataType.STRING, DataType.INTEGER]
+    assert list(rep_map.target) == [DataType.STRING, DataType.INTEGER]
+    assert len(rep_map.maps) == 2
+
+    m = rep_map.maps[0]
+    assert isinstance(m, MultiValueMap)
+    assert list(m.source) == ["A", "1"]
+    assert list(m.target) == ["X", "9"]

--- a/tests/io/test_general_writer.py
+++ b/tests/io/test_general_writer.py
@@ -617,7 +617,11 @@ def test_write_representation_map_datatype_tags(tmpdir, format):
 
 
 def test_write_maps_xml_json_roundtrip(tmpdir):
-    from pysdmx.model import DataType, RepresentationMap
+    from pysdmx.model import (
+        DataType,
+        MultiRepresentationMap,
+        RepresentationMap,
+    )
 
     data_path = Path(__file__).parent / "samples" / "maps.xml"
     from_xml = read_sdmx(data_path, validate=True)
@@ -634,7 +638,8 @@ def test_write_maps_xml_json_roundtrip(tmpdir):
         return next(
             s
             for s in structures
-            if isinstance(s, RepresentationMap) and s.id == rm_id
+            if isinstance(s, (RepresentationMap, MultiRepresentationMap))
+            and s.id == rm_id
         )
 
     # Codelist-based RepresentationMap round-trips correctly
@@ -651,3 +656,45 @@ def test_write_maps_xml_json_roundtrip(tmpdir):
     assert xml_dt.source == json_dt.source
     assert xml_dt.target == json_dt.target
     assert xml_dt.maps == json_dt.maps
+
+    # MultiRepresentationMap (N-N) round-trips correctly
+    xml_nn = find_rm(from_xml.structures, "REPMAP_NN")
+    json_nn = find_rm(from_json.structures, "REPMAP_NN")
+    assert isinstance(xml_nn, MultiRepresentationMap)
+    assert isinstance(json_nn, MultiRepresentationMap)
+    assert list(xml_nn.source) == list(json_nn.source)
+    assert list(xml_nn.target) == list(json_nn.target)
+    assert xml_nn.maps == json_nn.maps
+
+
+@pytest.mark.parametrize(
+    "format",
+    [
+        Format.STRUCTURE_SDMX_ML_3_0,
+        Format.STRUCTURE_SDMX_ML_3_1,
+    ],
+)
+def test_write_multi_datatype_representation_map(tmpdir, format):
+    from pysdmx.model import DataType, MultiRepresentationMap
+
+    data_path = Path(__file__).parent / "samples" / "maps_datatype_multi.xml"
+    reference = read_sdmx(data_path, validate=True)
+
+    out_path = tmpdir / "maps_dt_written.xml"
+    write_sdmx(
+        reference.structures,
+        sdmx_format=format,
+        output_path=out_path,
+        header=reference.header,
+    )
+    written = read_sdmx(out_path, validate=True)
+
+    assert reference == written
+    rep_map = written.structures[0]
+    assert isinstance(rep_map, MultiRepresentationMap)
+    assert list(rep_map.source) == [DataType.STRING, DataType.INTEGER]
+    assert list(rep_map.target) == [DataType.STRING, DataType.INTEGER]
+
+    xml_content = out_path.read_text("utf-8")
+    assert xml_content.count("<str:SourceDataType>") == 2
+    assert xml_content.count("<str:TargetDataType>") == 2


### PR DESCRIPTION
## Summary

Closes #611.

The SDMX-ML (XML) readers always built `RepresentationMap` regardless of cardinality, and the writer could only serialize a single source/target. As a result, n-to-1 / 1-to-n / n-to-n maps were mistyped and could not round-trip.

This PR makes the SDMX-ML reader return `MultiRepresentationMap` when a representation map has more than one source **or** more than one target codelist/datatype, and generalises the writer to serialize both types. This mirrors the rule already used by the SDMX-JSON reader (`len(source) != 1 or len(target) != 1`) and the FMR/Fusion-JSON client, which already distinguished the two types — the XML path was the last one lagging behind.

### Changes
- **Reader** (`__structure_aux_reader.py`): new `__build_representation_map` that picks the type by source/target codelist count (mirroring the existing `__build_component_map`); routed at the construction point.
- **Writer** (`__structure_aux_writer.py`): registered `MultiRepresentationMap` in both `STR_DICT_TYPE_LIST_21/30`, switched `__write_scheme` dispatch to an `isinstance` check, and generalised `__write_representation_map` to emit one `Source/Target{Codelist,DataType}` element per entry.
- **Bug fix found in review**: a representation map declaring multiple `SourceDataType`/`TargetDataType` elements previously crashed (`DataType(['String','Integer'])`); the converter is now applied per element.
- **Tests/sample**: `maps.xml` gains matching second codelists; `test_read_maps` asserts `MultiRepresentationMap` with list source/target; new `maps_datatype_multi.xml` + read/round-trip tests for the multi-datatype case; XML↔JSON round-trip covers a multi map.

### SDMX-ML versions
Readers share one `StructureParser` and writers share both dispatch tables, so all versions are covered. Representation maps are a 3.0+ artifact (not valid in the SDMX-ML 2.1 schema), so the round-trip tests cover 3.0 and 3.1.

## Relationship to #610 (branch `cr-569`)
This unblocks #610. The two PRs are complementary:
- **This PR** (#611): reader/writer produce/consume the correct type + io tests + the `maps.xml` second codelists.
- **#610** (#569): model-level validation that source/target counts match the value-map counts.

The `maps.xml` second-codelist additions are intentionally identical to those in `cr-569` to merge cleanly. Consistency between codelist count (container type) and per-mapping value count is enforced by #610's model validation; this PR deliberately does not touch `model/map.py`.

## Verification
- `4857 passed`, **100% branch coverage**
- `ruff format` / `ruff check` clean · `mypy` clean