### PR TITLE
Escape single quotes in VTL code bodies when writing SDMX-ML

### DIFF
--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -96,6 +96,7 @@ from pysdmx.io.xml.__write_aux import (
     MSG_CONTENT_PKG_21,
     MSG_CONTENT_PKG_30,
     __escape_xml,
+    __escape_xml_vtl,
     __to_lower_camel_case,
     add_indent,
 )
@@ -1653,7 +1654,7 @@ def _write_vtl(  # noqa: C901
             label = f"{ABBR_STR}:{RULE}"
             data += f"{add_indent(indent)}<{ABBR_STR}:RulesetDefinition>"
             data += (
-                f"{__escape_xml(item_or_scheme.ruleset_definition)}"
+                f"{__escape_xml_vtl(item_or_scheme.ruleset_definition)}"
                 f"</{ABBR_STR}:RulesetDefinition>"
             )
             attrib += (
@@ -1665,7 +1666,7 @@ def _write_vtl(  # noqa: C901
             label = f"{ABBR_STR}:{TRANSFORMATION}"
             data += f"{add_indent(indent)}<{ABBR_STR}:Expression>"
             data += (
-                f"{__escape_xml(item_or_scheme.expression)}"
+                f"{__escape_xml_vtl(item_or_scheme.expression)}"
                 f"</{ABBR_STR}:Expression>"
             )
             data += f"{add_indent(indent)}<{ABBR_STR}:Result>"
@@ -1678,7 +1679,7 @@ def _write_vtl(  # noqa: C901
             label = f"{ABBR_STR}:{UDO}"
             data += f"{add_indent(indent)}<{ABBR_STR}:OperatorDefinition>"
             data += (
-                f"{__escape_xml(item_or_scheme.operator_definition)}"
+                f"{__escape_xml_vtl(item_or_scheme.operator_definition)}"
                 f"</{ABBR_STR}:OperatorDefinition>"
             )
         if isinstance(item_or_scheme, VtlDataflowMapping):

--- a/src/pysdmx/io/xml/__write_aux.py
+++ b/src/pysdmx/io/xml/__write_aux.py
@@ -531,3 +531,11 @@ def __escape_xml(value: str) -> str:
     final_value = escape(value)
     final_value = re.sub(r'(?<!\w)"(?!\w)', "&quot;", final_value)
     return final_value
+
+
+def __escape_xml_vtl(value: str) -> str:
+    # Also escape single quotes: VTL code bodies are subject to the
+    # structure writer's blanket single-to-double quote replacement,
+    # which would otherwise turn identifier escapes such as
+    # 'errorlevel' into string literals.
+    return __escape_xml(value).replace("'", "&apos;")

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -1239,6 +1239,107 @@ def test_writer_transformation_scheme_structure(
     assert structure == transformation_sample
 
 
+def test_writer_transformation_single_quoted_identifier(complete_header):
+    # Reserved VTL keywords used as identifiers must stay single-quoted
+    # (e.g. 'errorlevel'); the writer must not turn that escape into a
+    # "errorlevel" string literal (issue #615).
+    expression = (
+        "check_datapoint(ds, dp_ruleset) [calc errorcode := errorcode, "
+        "'errorlevel' := errorlevel]"
+    )
+    scheme = TransformationScheme(
+        id="TEST_TS",
+        urn="urn:sdmx:org.sdmx.infomodel.transformation."
+        "TransformationScheme=MD:TEST_TS(1.0)",
+        name="Testing TS",
+        version="1.0",
+        agency="MD",
+        items=[
+            Transformation(
+                id="TEST_Tr",
+                urn="urn:sdmx:org.sdmx.infomodel.transformation."
+                "Transformation=MD:TEST_TS(1.0).TEST_Tr",
+                name="Validation",
+                expression=expression,
+                is_persistent=False,
+                result="validation_result",
+            )
+        ],
+        is_partial=False,
+        vtl_version="2.0",
+    )
+
+    structure = write([scheme], header=complete_header, prettyprint=True)
+
+    assert "&apos;errorlevel&apos;" in structure
+    assert '"errorlevel"' not in structure
+
+    # The single-quoted identifier must round-trip back unchanged.
+    read_result = read(structure, validate=True)
+    assert read_result[0].items[0].expression == expression
+
+
+def test_writer_ruleset_udo_single_quoted_identifier(complete_header):
+    # The same escaping applies to ruleset and operator definitions.
+    ruleset_definition = (
+        "define datapoint ruleset r1 (variable 'errorlevel' as E) is "
+        "myrule: when E > 0 then E > 0 end datapoint ruleset;"
+    )
+    operator_definition = (
+        "define operator op1 (ds dataset) returns dataset is "
+        "ds['errorlevel' = 1] end operator;"
+    )
+    ruleset_scheme = RulesetScheme(
+        id="TEST_RS",
+        urn="urn:sdmx:org.sdmx.infomodel.transformation."
+        "RulesetScheme=MD:TEST_RS(1.0)",
+        name="RS",
+        version="1.0",
+        agency="MD",
+        items=[
+            Ruleset(
+                id="R1",
+                urn="urn:sdmx:org.sdmx.infomodel.transformation."
+                "Ruleset=MD:TEST_RS(1.0).R1",
+                name="R1",
+                ruleset_definition=ruleset_definition,
+                ruleset_scope="variable",
+                ruleset_type="datapoint",
+            )
+        ],
+        is_partial=False,
+        vtl_version="2.0",
+    )
+    udo_scheme = UserDefinedOperatorScheme(
+        id="TEST_UDO",
+        urn="urn:sdmx:org.sdmx.infomodel.transformation."
+        "UserDefinedOperatorScheme=MD:TEST_UDO(1.0)",
+        name="UDO",
+        version="1.0",
+        agency="MD",
+        items=[
+            UserDefinedOperator(
+                id="OP1",
+                urn="urn:sdmx:org.sdmx.infomodel.transformation."
+                "UserDefinedOperator=MD:TEST_UDO(1.0).OP1",
+                name="OP1",
+                operator_definition=operator_definition,
+            )
+        ],
+        is_partial=False,
+        vtl_version="2.0",
+    )
+
+    structure = write(
+        [ruleset_scheme, udo_scheme],
+        header=complete_header,
+        prettyprint=True,
+    )
+
+    assert structure.count("&apos;errorlevel&apos;") == 2
+    assert '"errorlevel"' not in structure
+
+
 def test_writer_ruleset_scheme_structure(
     complete_header, ruleset_scheme_structure, ruleset_sample
 ):


### PR DESCRIPTION
## What

Fixes #615 — the SDMX-ML writer corrupted single-quoted VTL identifiers in Transformation expressions (and Ruleset/UDO definitions).

## Why

`_write_vtl` builds XML attributes via Python `repr` (single quotes) and then runs a **blanket** `outfile.replace("'", '"')` over the whole serialized chunk to turn those into XML double quotes. That replace also rewrote single quotes inside the VTL **code bodies**, turning identifier escapes such as `'errorlevel'` (required because `errorlevel` is a reserved VTL keyword) into the string literal `"errorlevel"`. FMR then rejects the result with *"expecting IDENTIFIER"*. SDMX-JSON was unaffected; SDMX-ML 2.1/3.0/3.1 all share this writer.

## How

Add a small `__escape_xml_vtl` helper that, on top of the existing `__escape_xml` escaping, escapes single quotes to `&apos;` (a standard XML entity the reader unescapes back to `'`). It is applied only to the three VTL code bodies routed through `__escape_xml` — `<Expression>`, `<RulesetDefinition>`, `<OperatorDefinition>` — so the escapes survive the blanket replace and round-trip correctly.

The change is deliberately scoped to the VTL code bodies: a global `__escape_xml` change would needlessly rewrite legitimate prose apostrophes in Names/descriptions (e.g. `Cote d'Ivoire`), which are on a path with no blanket replace and are correct today.

## Tests

- `test_writer_transformation_single_quoted_identifier` — asserts `&apos;errorlevel&apos;` is emitted, the `"errorlevel"` corruption is gone, and the expression round-trips back unchanged through the (XSD-validating) reader.
- `test_writer_ruleset_udo_single_quoted_identifier` — covers the `RulesetDefinition` and `OperatorDefinition` bodies.

Existing VTL writer golden samples contain no single quotes, so they are unchanged. Full suite passes at 100% branch coverage; ruff + mypy clean.
