### PR TITLE
Add SDMX-ML support for hierarchies with formal levels

### DIFF
--- a/src/pysdmx/io/xml/__structure_aux_reader.py
+++ b/src/pysdmx/io/xml/__structure_aux_reader.py
@@ -11,6 +11,7 @@ from pysdmx.io.xml.__tokens import (
     AGENCY,
     AGENCY_ID,
     AGENCY_SCHEME,
+    ALIAS,
     ALIAS_LOW,
     ANNOTATION,
     ANNOTATION_TEXT,
@@ -29,6 +30,8 @@ from pysdmx.io.xml.__tokens import (
     CLASS,
     CLS,
     CODE,
+    CODE_ID,
+    CODELIST_ALIAS_REF,
     CODES_LOW,
     COMPONENT_MAP,
     COMPONENT_MAPS,
@@ -80,9 +83,16 @@ from pysdmx.io.xml.__tokens import (
     GROUP,
     GROUP_DIM,
     GROUPS_LOW,
+    HAS_FORMAL_LEVELS,
+    HIERARCHICAL_CODE,
+    HIERARCHICAL_CODELIST,
+    HIERARCHICAL_CODELISTS,
+    HIERARCHIES,
+    HIERARCHY,
     ID,
     INCLUDE,
     INCLUDED,
+    INCLUDED_CODELIST,
     IS_EXTERNAL_REF,
     IS_EXTERNAL_REF_LOW,
     IS_FINAL,
@@ -91,6 +101,8 @@ from pysdmx.io.xml.__tokens import (
     IS_PARTIAL_LOW,
     KEY,
     KEY_VALUE,
+    LEVEL,
+    LEVELED,
     LINK,
     LOCAL_CODES_LOW,
     LOCAL_DTYPE,
@@ -188,8 +200,11 @@ from pysdmx.model import (
     DatePatternMap,
     Facets,
     FixedValueMap,
+    HierarchicalCode,
+    Hierarchy,
     ImplicitComponentMap,
     KeySet,
+    LevelType,
     MultiComponentMap,
     MultiRepresentationMap,
     MultiValueMap,
@@ -1469,6 +1484,206 @@ class StructureParser(Struct):
 
         return elements
 
+    def __format_level(self, level_elem: Dict[str, Any]) -> LevelType:
+        """Recursively formats a Level element into a LevelType."""
+        level_elem = self.__format_annotations(level_elem)
+        level_elem = self.__format_name_description(level_elem)
+        child = (
+            self.__format_level(level_elem[LEVEL])
+            if LEVEL in level_elem
+            else None
+        )
+        return LevelType(
+            id=level_elem[ID],
+            name=level_elem.get(NAME.lower()),
+            description=level_elem.get(DESC.lower()),
+            annotations=tuple(level_elem.get(ANNOTATIONS.lower(), ())),
+            level=child,
+        )
+
+    @staticmethod
+    def __urn_from_code_ref(ref: Dict[str, Any]) -> str:
+        """Builds a code URN from an SDMX-ML 2.1 <Code> reference."""
+        return (
+            "urn:sdmx:org.sdmx.infomodel.codelist.Code="
+            f"{ref[AGENCY_ID]}:{ref[PAR_ID]}({ref[PAR_VER]}).{ref[ID]}"
+        )
+
+    def __format_code_ref(
+        self, hc_elem: Dict[str, Any], aliases: Dict[str, str]
+    ) -> str:
+        """Resolves the referenced code URN (text, <Ref> or alias forms)."""
+        if CODE in hc_elem:
+            code_val = hc_elem[CODE]
+            if isinstance(code_val, dict):
+                return self.__urn_from_code_ref(code_val[REF])
+            return _extract_text(code_val)
+        alias = _extract_text(hc_elem[CODELIST_ALIAS_REF])
+        code_id = str(hc_elem[CODE_ID][REF][ID])
+        return f"{aliases[alias]}.{code_id}"
+
+    @staticmethod
+    def __format_level_ref(level_val: Any) -> str:
+        """Resolves a per-code level id (text or <Ref> forms)."""
+        if isinstance(level_val, dict):
+            return str(level_val[REF][ID])
+        return _extract_text(level_val)
+
+    def __format_hierarchical_code(
+        self,
+        hc_elem: Dict[str, Any],
+        aliases: Optional[Dict[str, str]] = None,
+    ) -> HierarchicalCode:
+        """Formats a HierarchicalCode element into the model."""
+        aliases = aliases or {}
+        hc_elem = self.__format_annotations(hc_elem)
+        children = (
+            [
+                self.__format_hierarchical_code(child, aliases)
+                for child in add_list(hc_elem[HIERARCHICAL_CODE])
+            ]
+            if HIERARCHICAL_CODE in hc_elem
+            else []
+        )
+        rel_valid_from = (
+            datetime.fromisoformat(hc_elem[VALID_FROM])
+            if VALID_FROM in hc_elem
+            else None
+        )
+        rel_valid_to = (
+            datetime.fromisoformat(hc_elem[VALID_TO])
+            if VALID_TO in hc_elem
+            else None
+        )
+        level = (
+            self.__format_level_ref(hc_elem[LEVEL])
+            if LEVEL in hc_elem
+            else None
+        )
+        return HierarchicalCode(
+            id=hc_elem[ID],
+            rel_valid_from=rel_valid_from,
+            rel_valid_to=rel_valid_to,
+            codes=tuple(children),
+            annotations=tuple(hc_elem.get(ANNOTATIONS.lower(), ())),
+            urn=self.__format_code_ref(hc_elem, aliases),
+            level=level,
+        )
+
+    def __format_hierarchy(
+        self, json_hierarchies: Dict[str, Any]
+    ) -> Dict[str, Hierarchy]:
+        """Formats the hierarchies (SDMX-ML 3.0/3.1) into the model."""
+        elements: Dict[str, Hierarchy] = {}
+        for element in add_list(json_hierarchies[HIERARCHY]):
+            element = self.__format_annotations(element)
+            element = self.__format_name_description(element)
+            element = self.__format_urls(element)
+            element = self.__format_agency(element)
+            element = self.__format_validity(element)
+            if IS_EXTERNAL_REF in element:
+                element[IS_EXTERNAL_REF_LOW] = (
+                    element.pop(IS_EXTERNAL_REF) == "true"
+                )
+            has_formal_levels = (
+                element.pop(HAS_FORMAL_LEVELS, "false") == "true"
+            )
+            level = (
+                self.__format_level(element[LEVEL])
+                if LEVEL in element
+                else None
+            )
+            codes = (
+                [
+                    self.__format_hierarchical_code(child)
+                    for child in add_list(element[HIERARCHICAL_CODE])
+                ]
+                if HIERARCHICAL_CODE in element
+                else []
+            )
+            version = element.get(VERSION, "1.0")
+            hierarchy = Hierarchy(
+                id=element[ID],
+                name=element.get(NAME.lower()),
+                description=element.get(DESC.lower()),
+                agency=element[AGENCY.lower()],
+                version=version,
+                valid_from=element.get(VALID_FROM_LOW),
+                valid_to=element.get(VALID_TO_LOW),
+                annotations=tuple(element.get(ANNOTATIONS.lower(), ())),
+                is_external_reference=element.get(IS_EXTERNAL_REF_LOW, False),
+                is_final=is_final(version),
+                has_formal_levels=has_formal_levels,
+                level=level,
+                codes=tuple(codes),
+            )
+            elements[hierarchy.short_urn] = hierarchy
+        return elements
+
+    @staticmethod
+    def __format_codelist_aliases(hcl: Dict[str, Any]) -> Dict[str, str]:
+        """Maps each IncludedCodelist alias to a code-URN prefix."""
+        aliases: Dict[str, str] = {}
+        for incl in add_list(hcl.get(INCLUDED_CODELIST, [])):
+            ref = incl[REF]
+            aliases[incl[ALIAS]] = (
+                "urn:sdmx:org.sdmx.infomodel.codelist.Code="
+                f"{ref[AGENCY_ID]}:{ref[ID]}({ref.get(VERSION, '1.0')})"
+            )
+        return aliases
+
+    def __format_inner_hierarchy(
+        self,
+        inner: Dict[str, Any],
+        agency: str,
+        version: str,
+        aliases: Dict[str, str],
+    ) -> Hierarchy:
+        """Formats an SDMX-ML 2.1 inner <Hierarchy> into the model."""
+        inner = self.__format_annotations(inner)
+        inner = self.__format_name_description(inner)
+        has_formal_levels = inner.pop(LEVELED, "false") == "true"
+        level = self.__format_level(inner[LEVEL]) if LEVEL in inner else None
+        codes = (
+            [
+                self.__format_hierarchical_code(child, aliases)
+                for child in add_list(inner[HIERARCHICAL_CODE])
+            ]
+            if HIERARCHICAL_CODE in inner
+            else []
+        )
+        return Hierarchy(
+            id=inner[ID],
+            name=inner.get(NAME.lower()),
+            description=inner.get(DESC.lower()),
+            agency=agency,
+            version=version,
+            has_formal_levels=has_formal_levels,
+            level=level,
+            codes=tuple(codes),
+        )
+
+    def __format_hierarchical_codelist(
+        self, json_hcls: Dict[str, Any]
+    ) -> Dict[str, Hierarchy]:
+        """Formats SDMX-ML 2.1 HierarchicalCodelists into the model.
+
+        Each inner ``<Hierarchy>`` becomes a separate pysdmx ``Hierarchy``,
+        inheriting the agency and version of the wrapping codelist.
+        """
+        elements: Dict[str, Hierarchy] = {}
+        for hcl in add_list(json_hcls[HIERARCHICAL_CODELIST]):
+            aliases = self.__format_codelist_aliases(hcl)
+            hcl = self.__format_agency(hcl)
+            agency = hcl[AGENCY.lower()]
+            version = hcl.get(VERSION, "1.0")
+            for inner in add_list(hcl.get(HIERARCHY, [])):
+                hierarchy = self.__format_inner_hierarchy(
+                    inner, agency, version, aliases
+                )
+                elements[hierarchy.short_urn] = hierarchy
+        return elements
+
     def __format_schema(  # noqa: C901
         self, json_element: Dict[str, Any], schema: str, item: str
     ) -> Dict[str, Any]:
@@ -1593,6 +1808,14 @@ class StructureParser(Struct):
                     data, VALUE_LIST, VALUE_ITEM
                 ),
                 "valuelists",
+            ),
+            HIERARCHIES: process_structure(
+                HIERARCHIES,
+                self.__format_hierarchy,
+            ),
+            HIERARCHICAL_CODELISTS: process_structure(
+                HIERARCHICAL_CODELISTS,
+                self.__format_hierarchical_codelist,
             ),
             CON_SCHEMES: process_structure(
                 CON_SCHEMES,

--- a/src/pysdmx/io/xml/__structure_aux_reader.py
+++ b/src/pysdmx/io/xml/__structure_aux_reader.py
@@ -46,6 +46,7 @@ from pysdmx.io.xml.__tokens import (
     CONS_ATT,
     CONSTRAINTS,
     CONTACT,
+    CONTEXT_OBJECT,
     CORE_REP,
     CS,
     CUBE_REGION,
@@ -89,6 +90,8 @@ from pysdmx.io.xml.__tokens import (
     HIERARCHICAL_CODELISTS,
     HIERARCHIES,
     HIERARCHY,
+    HIERARCHY_ASSOCIATION,
+    HIERARCHY_ASSOCIATIONS,
     ID,
     INCLUDE,
     INCLUDED,
@@ -104,6 +107,8 @@ from pysdmx.io.xml.__tokens import (
     LEVEL,
     LEVELED,
     LINK,
+    LINKED_HIERARCHY,
+    LINKED_OBJECT,
     LOCAL_CODES_LOW,
     LOCAL_DTYPE,
     LOCAL_FACETS_LOW,
@@ -202,6 +207,7 @@ from pysdmx.model import (
     FixedValueMap,
     HierarchicalCode,
     Hierarchy,
+    HierarchyAssociation,
     ImplicitComponentMap,
     KeySet,
     LevelType,
@@ -1684,6 +1690,45 @@ class StructureParser(Struct):
                 elements[hierarchy.short_urn] = hierarchy
         return elements
 
+    def __format_hierarchy_association(
+        self, json_has: Dict[str, Any]
+    ) -> Dict[str, HierarchyAssociation]:
+        """Formats SDMX-ML 3.0/3.1 HierarchyAssociations into the model."""
+        elements: Dict[str, HierarchyAssociation] = {}
+        for element in add_list(json_has[HIERARCHY_ASSOCIATION]):
+            element = self.__format_annotations(element)
+            element = self.__format_name_description(element)
+            element = self.__format_urls(element)
+            element = self.__format_agency(element)
+            element = self.__format_validity(element)
+            if IS_EXTERNAL_REF in element:
+                element[IS_EXTERNAL_REF_LOW] = (
+                    element.pop(IS_EXTERNAL_REF) == "true"
+                )
+            context = (
+                _extract_text(element[CONTEXT_OBJECT])
+                if CONTEXT_OBJECT in element
+                else ""
+            )
+            version = element.get(VERSION, "1.0")
+            ha = HierarchyAssociation(
+                id=element[ID],
+                name=element.get(NAME.lower()),
+                description=element.get(DESC.lower()),
+                agency=element[AGENCY.lower()],
+                version=version,
+                valid_from=element.get(VALID_FROM_LOW),
+                valid_to=element.get(VALID_TO_LOW),
+                annotations=tuple(element.get(ANNOTATIONS.lower(), ())),
+                is_external_reference=element.get(IS_EXTERNAL_REF_LOW, False),
+                is_final=is_final(version),
+                hierarchy=_extract_text(element[LINKED_HIERARCHY]),
+                component_ref=_extract_text(element[LINKED_OBJECT]),
+                context_ref=context,
+            )
+            elements[ha.short_urn] = ha
+        return elements
+
     def __format_schema(  # noqa: C901
         self, json_element: Dict[str, Any], schema: str, item: str
     ) -> Dict[str, Any]:
@@ -1816,6 +1861,10 @@ class StructureParser(Struct):
             HIERARCHICAL_CODELISTS: process_structure(
                 HIERARCHICAL_CODELISTS,
                 self.__format_hierarchical_codelist,
+            ),
+            HIERARCHY_ASSOCIATIONS: process_structure(
+                HIERARCHY_ASSOCIATIONS,
+                self.__format_hierarchy_association,
             ),
             CON_SCHEMES: process_structure(
                 CON_SCHEMES,

--- a/src/pysdmx/io/xml/__structure_aux_reader.py
+++ b/src/pysdmx/io/xml/__structure_aux_reader.py
@@ -1641,12 +1641,15 @@ class StructureParser(Struct):
     def __format_inner_hierarchy(
         self,
         inner: Dict[str, Any],
-        agency: str,
-        version: str,
+        meta: Dict[str, Any],
         aliases: Dict[str, str],
     ) -> Hierarchy:
-        """Formats an SDMX-ML 2.1 inner <Hierarchy> into the model."""
-        inner = self.__format_annotations(inner)
+        """Formats an SDMX-ML 2.1 inner <Hierarchy> into the model.
+
+        The wrapping codelist (the maintainable) carries the agency,
+        version, validity, annotations and description, so those are taken
+        from ``meta``; the inner element supplies the id, name and codes.
+        """
         inner = self.__format_name_description(inner)
         has_formal_levels = inner.pop(LEVELED, "false") == "true"
         level = self.__format_level(inner[LEVEL]) if LEVEL in inner else None
@@ -1658,12 +1661,18 @@ class StructureParser(Struct):
             if HIERARCHICAL_CODE in inner
             else []
         )
+        version = meta["version"]
         return Hierarchy(
             id=inner[ID],
             name=inner.get(NAME.lower()),
-            description=inner.get(DESC.lower()),
-            agency=agency,
+            description=meta["description"],
+            agency=meta["agency"],
             version=version,
+            valid_from=meta["valid_from"],
+            valid_to=meta["valid_to"],
+            annotations=meta["annotations"],
+            is_external_reference=meta["is_external_reference"],
+            is_final=is_final(version),
             has_formal_levels=has_formal_levels,
             level=level,
             codes=tuple(codes),
@@ -1675,18 +1684,29 @@ class StructureParser(Struct):
         """Formats SDMX-ML 2.1 HierarchicalCodelists into the model.
 
         Each inner ``<Hierarchy>`` becomes a separate pysdmx ``Hierarchy``,
-        inheriting the agency and version of the wrapping codelist.
+        inheriting the maintainable metadata (agency, version, validity,
+        description, annotations) of the wrapping codelist.
         """
         elements: Dict[str, Hierarchy] = {}
         for hcl in add_list(json_hcls[HIERARCHICAL_CODELIST]):
             aliases = self.__format_codelist_aliases(hcl)
+            hcl = self.__format_annotations(hcl)
+            hcl = self.__format_name_description(hcl)
             hcl = self.__format_agency(hcl)
-            agency = hcl[AGENCY.lower()]
-            version = hcl.get(VERSION, "1.0")
+            hcl = self.__format_validity(hcl)
+            if IS_EXTERNAL_REF in hcl:
+                hcl[IS_EXTERNAL_REF_LOW] = hcl.pop(IS_EXTERNAL_REF) == "true"
+            meta = {
+                "agency": hcl[AGENCY.lower()],
+                "version": hcl.get(VERSION, "1.0"),
+                "description": hcl.get(DESC.lower()),
+                "valid_from": hcl.get(VALID_FROM_LOW),
+                "valid_to": hcl.get(VALID_TO_LOW),
+                "is_external_reference": hcl.get(IS_EXTERNAL_REF_LOW, False),
+                "annotations": tuple(hcl.get(ANNOTATIONS.lower(), ())),
+            }
             for inner in add_list(hcl.get(HIERARCHY, [])):
-                hierarchy = self.__format_inner_hierarchy(
-                    inner, agency, version, aliases
-                )
+                hierarchy = self.__format_inner_hierarchy(inner, meta, aliases)
                 elements[hierarchy.short_urn] = hierarchy
         return elements
 

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -21,6 +21,7 @@ from pysdmx.io.xml.__tokens import (
     CON_ID,
     CONDITIONAL,
     CONS_ATT,
+    CONTEXT_OBJECT,
     CORE_REP,
     CS,
     CUBE_REGION,
@@ -46,6 +47,7 @@ from pysdmx.io.xml.__tokens import (
     HIERARCHICAL_CODE,
     HIERARCHICAL_CODELIST,
     HIERARCHY,
+    HIERARCHY_ASSOCIATION,
     ID,
     INCLUDE,
     INCLUDED,
@@ -53,6 +55,8 @@ from pysdmx.io.xml.__tokens import (
     KEY_VALUE,
     LEVEL,
     LEVELED,
+    LINKED_HIERARCHY,
+    LINKED_OBJECT,
     LOCAL_REP,
     MANDATORY,
     MANDATORY_LOW,
@@ -124,6 +128,7 @@ from pysdmx.model import (
     FixedValueMap,
     HierarchicalCode,
     Hierarchy,
+    HierarchyAssociation,
     ImplicitComponentMap,
     KeySet,
     LevelType,
@@ -230,6 +235,7 @@ STR_DICT_TYPE_LIST_30 = {
     AgencyScheme: "AgencySchemes",
     Codelist: "Codelists",
     Hierarchy: "Hierarchies",
+    HierarchyAssociation: "HierarchyAssociations",
     ConceptScheme: "ConceptSchemes",
     DataStructureDefinition: "DataStructures",
     Dataflow: "Dataflows",
@@ -1563,6 +1569,43 @@ def __write_hierarchical_codelist(hierarchy: Hierarchy, indent: str) -> str:
     return outfile
 
 
+def __write_hierarchy_association(
+    ha: HierarchyAssociation, indent: str, references_30: bool = True
+) -> str:
+    """Writes a <str:HierarchyAssociation> (SDMX-ML 3.0/3.1)."""
+    if ha.hierarchy is None:
+        raise Invalid(
+            "Invalid input",
+            "SDMX-ML hierarchy associations must reference a hierarchy",
+            {"hierarchy_association": ha.id},
+        )
+    if not ha.component_ref:
+        raise Invalid(
+            "Invalid input",
+            "SDMX-ML hierarchy associations must reference a component",
+            {"hierarchy_association": ha.id},
+        )
+    data = __write_maintainable(ha, indent, references_30)
+    label = f"{ABBR_STR}:{HIERARCHY_ASSOCIATION}"
+    attributes = (data.get("Attributes") or "").replace("'", '"')
+    outfile = f"{indent}<{label}{attributes}>"
+    outfile += __export_intern_data(data)
+    child = add_indent(indent)
+    if isinstance(ha.hierarchy, Hierarchy):
+        href = f"urn:sdmx:org.sdmx.infomodel.codelist.{ha.hierarchy.short_urn}"
+    else:
+        href = ha.hierarchy
+    linked_h = f"{ABBR_STR}:{LINKED_HIERARCHY}"
+    linked_o = f"{ABBR_STR}:{LINKED_OBJECT}"
+    outfile += f"{child}<{linked_h}>{href}</{linked_h}>"
+    outfile += f"{child}<{linked_o}>{ha.component_ref}</{linked_o}>"
+    if ha.context_ref:
+        context = f"{ABBR_STR}:{CONTEXT_OBJECT}"
+        outfile += f"{child}<{context}>{ha.context_ref}</{context}>"
+    outfile += f"{indent}</{label}>"
+    return outfile
+
+
 def __write_scheme(  # noqa: C901
     item_scheme: Any, indent: str, scheme: str, references_30: bool = False
 ) -> str:
@@ -1581,6 +1624,10 @@ def __write_scheme(  # noqa: C901
             __write_hierarchy(item_scheme, indent, references_30)
             if references_30
             else __write_hierarchical_codelist(item_scheme, indent)
+        )
+    if isinstance(item_scheme, HierarchyAssociation):
+        return __write_hierarchy_association(
+            item_scheme, indent, references_30
         )
 
     label = f"{ABBR_STR}:{scheme}"

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -14,6 +14,7 @@ from pysdmx.io.xml.__tokens import (
     CL,
     CL_LOW,
     CLASS,
+    CODE,
     COMPONENT_MAP,
     CON,
     CON_CONS,
@@ -41,11 +42,17 @@ from pysdmx.io.xml.__tokens import (
     GROUP,
     GROUP_DIM,
     GROUPS_LOW,
+    HAS_FORMAL_LEVELS,
+    HIERARCHICAL_CODE,
+    HIERARCHICAL_CODELIST,
+    HIERARCHY,
     ID,
     INCLUDE,
     INCLUDED,
     KEY,
     KEY_VALUE,
+    LEVEL,
+    LEVELED,
     LOCAL_REP,
     MANDATORY,
     MANDATORY_LOW,
@@ -115,9 +122,11 @@ from pysdmx.model import (
     DatePatternMap,
     Facets,
     FixedValueMap,
+    HierarchicalCode,
     Hierarchy,
     ImplicitComponentMap,
     KeySet,
+    LevelType,
     MultiComponentMap,
     MultiRepresentationMap,
     MultiValueMap,
@@ -198,6 +207,7 @@ STR_TYPES = Union[
 STR_DICT_TYPE_LIST_21 = {
     AgencyScheme: "OrganisationSchemes",
     Codelist: "Codelists",
+    Hierarchy: "HierarchicalCodelists",
     ConceptScheme: "Concepts",
     DataStructureDefinition: "DataStructures",
     Dataflow: "Dataflows",
@@ -219,6 +229,7 @@ STR_DICT_TYPE_LIST_21 = {
 STR_DICT_TYPE_LIST_30 = {
     AgencyScheme: "AgencySchemes",
     Codelist: "Codelists",
+    Hierarchy: "Hierarchies",
     ConceptScheme: "ConceptSchemes",
     DataStructureDefinition: "DataStructures",
     Dataflow: "Dataflows",
@@ -237,7 +248,9 @@ STR_DICT_TYPE_LIST_30 = {
 }
 
 
-def __write_annotable(annotable: AnnotableArtefact, indent: str) -> str:
+def __write_annotable(
+    annotable: Union[AnnotableArtefact, HierarchicalCode], indent: str
+) -> str:
     """Writes the annotations to the XML file."""
     if len(annotable.annotations) == 0:
         return ""
@@ -1414,6 +1427,142 @@ def __write_data_constraint(
     return outfile
 
 
+def __write_code_reference(urn: str, indent: str, references_30: bool) -> str:
+    """Writes a <str:Code> reference (URN text in 3.x, <Ref> in 2.1)."""
+    label = f"{ABBR_STR}:{CODE}"
+    if references_30:
+        return f"{indent}<{label}>{urn}</{label}>"
+    ref = parse_item_urn(urn)
+    outfile = f"{indent}<{label}>"
+    outfile += f"{add_indent(indent)}<{REF} "
+    outfile += f"{AGENCY_ID}={ref.agency!r} "
+    outfile += f"{CLASS}={CODE!r} "
+    outfile += f"{ID}={ref.item_id!r} "
+    outfile += f"{PAR_ID}={ref.id!r} "
+    outfile += f"{PAR_VER}={ref.version!r} "
+    outfile += f"{PACKAGE}={CL_LOW!r}/>"
+    outfile += f"{indent}</{label}>"
+    return outfile.replace("'", '"')
+
+
+def __write_code_level_ref(
+    level: str, indent: str, references_30: bool
+) -> str:
+    """Writes a per-code <str:Level> (id text in 3.x, <Ref id> in 2.1)."""
+    label = f"{ABBR_STR}:{LEVEL}"
+    if references_30:
+        return f"{indent}<{label}>{level}</{label}>"
+    outfile = f"{indent}<{label}>"
+    outfile += f"{add_indent(indent)}<{REF} {ID}={level!r}/>"
+    outfile += f"{indent}</{label}>"
+    return outfile.replace("'", '"')
+
+
+def __write_level(level: LevelType, indent: str) -> str:
+    """Recursively writes a <str:Level> element (SDMX-ML 2.1/3.0/3.1)."""
+    if not level.name:
+        raise Invalid(
+            "Invalid input",
+            "SDMX-ML hierarchy levels must have a name",
+            {"level": level.id},
+        )
+    data = __write_nameable(level, add_indent(indent))
+    label = f"{ABBR_STR}:{LEVEL}"
+    attributes = (data.get("Attributes") or "").replace("'", '"')
+    outfile = f"{indent}<{label}{attributes}>"
+    outfile += __export_intern_data(data)
+    if level.level is not None:
+        outfile += __write_level(level.level, add_indent(indent))
+    outfile += f"{indent}</{label}>"
+    return outfile
+
+
+def __write_hierarchical_code(
+    code: HierarchicalCode, indent: str, references_30: bool = False
+) -> str:
+    """Recursively writes a <str:HierarchicalCode> element."""
+    if not code.urn:
+        raise Invalid(
+            "Invalid input",
+            "SDMX-ML hierarchical codes must reference a code urn",
+            {"code": code.id},
+        )
+    attrs = f" {ID}={code.id!r}"
+    if code.rel_valid_from is not None:
+        valid_from = code.rel_valid_from.strftime("%Y-%m-%dT%H:%M:%S")
+        attrs += f" validFrom={valid_from!r}"
+    if code.rel_valid_to is not None:
+        valid_to = code.rel_valid_to.strftime("%Y-%m-%dT%H:%M:%S")
+        attrs += f" validTo={valid_to!r}"
+    attrs = attrs.replace("'", '"')
+    label = f"{ABBR_STR}:{HIERARCHICAL_CODE}"
+    child = add_indent(indent)
+    outfile = f"{indent}<{label}{attrs}>"
+    outfile += __write_annotable(code, child)
+    outfile += __write_code_reference(code.urn, child, references_30)
+    for sub_code in code.codes:
+        outfile += __write_hierarchical_code(sub_code, child, references_30)
+    if code.level is not None:
+        outfile += __write_code_level_ref(code.level, child, references_30)
+    outfile += f"{indent}</{label}>"
+    return outfile
+
+
+def __write_hierarchy(
+    hierarchy: Hierarchy, indent: str, references_30: bool = True
+) -> str:
+    """Writes a <str:Hierarchy> (SDMX-ML 3.0/3.1) to the XML file."""
+    data = __write_maintainable(hierarchy, indent, references_30)
+    data["Attributes"] += (
+        f" {HAS_FORMAL_LEVELS}={str(hierarchy.has_formal_levels).lower()!r}"
+    )
+    label = f"{ABBR_STR}:{HIERARCHY}"
+    attributes = (data.get("Attributes") or "").replace("'", '"')
+    outfile = f"{indent}<{label}{attributes}>"
+    outfile += __export_intern_data(data)
+    if hierarchy.level is not None:
+        outfile += __write_level(hierarchy.level, add_indent(indent))
+    for code in hierarchy.codes:
+        outfile += __write_hierarchical_code(
+            code, add_indent(indent), references_30
+        )
+    outfile += f"{indent}</{label}>"
+    return outfile
+
+
+def __write_hierarchical_codelist(hierarchy: Hierarchy, indent: str) -> str:
+    """Writes an SDMX-ML 2.1 <str:HierarchicalCodelist> for a Hierarchy.
+
+    The pysdmx ``Hierarchy`` (a maintainable) is wrapped in a 2.1
+    ``HierarchicalCodelist`` containing a single inner ``<Hierarchy>``.
+    """
+    data = __write_maintainable(hierarchy, indent, references_30=False)
+    hcl_label = f"{ABBR_STR}:{HIERARCHICAL_CODELIST}"
+    attributes = (data.get("Attributes") or "").replace("'", '"')
+    outfile = f"{indent}<{hcl_label}{attributes}>"
+    outfile += __export_intern_data(data)
+
+    h_indent = add_indent(indent)
+    h_label = f"{ABBR_STR}:{HIERARCHY}"
+    leveled = str(hierarchy.has_formal_levels).lower()
+    h_attrs = f" {ID}={hierarchy.id!r} {LEVELED}={leveled!r}".replace("'", '"')
+    outfile += f"{h_indent}<{h_label}{h_attrs}>"
+    name = __escape_xml(str(hierarchy.name))
+    outfile += (
+        f'{add_indent(h_indent)}<{ABBR_COM}:Name xml:lang="en">'
+        f"{name}</{ABBR_COM}:Name>"
+    )
+    for code in hierarchy.codes:
+        outfile += __write_hierarchical_code(
+            code, add_indent(h_indent), references_30=False
+        )
+    if hierarchy.level is not None:
+        outfile += __write_level(hierarchy.level, add_indent(h_indent))
+    outfile += f"{h_indent}</{h_label}>"
+    outfile += f"{indent}</{hcl_label}>"
+    return outfile
+
+
 def __write_scheme(  # noqa: C901
     item_scheme: Any, indent: str, scheme: str, references_30: bool = False
 ) -> str:
@@ -1427,6 +1576,12 @@ def __write_scheme(  # noqa: C901
         return __write_structure_map(item_scheme, indent, references_30)
     if isinstance(item_scheme, DataConstraint):
         return __write_data_constraint(item_scheme, indent, references_30)
+    if isinstance(item_scheme, Hierarchy):
+        return (
+            __write_hierarchy(item_scheme, indent, references_30)
+            if references_30
+            else __write_hierarchical_codelist(item_scheme, indent)
+        )
 
     label = f"{ABBR_STR}:{scheme}"
     components = ""

--- a/src/pysdmx/io/xml/__tokens.py
+++ b/src/pysdmx/io/xml/__tokens.py
@@ -303,6 +303,21 @@ VALUE_LIST = "ValueList"
 VALUE_LIST_LOW = "valuelist"
 VALUE_ITEM = "ValueItem"
 
+# Hierarchy
+HIERARCHIES = "Hierarchies"
+HIERARCHICAL_CODELISTS = "HierarchicalCodelists"
+HIERARCHICAL_CODELIST = "HierarchicalCodelist"
+HIERARCHY = "Hierarchy"
+HIERARCHICAL_CODE = "HierarchicalCode"
+LEVEL = "Level"
+CODING_FORMAT = "CodingFormat"
+HAS_FORMAL_LEVELS = "hasFormalLevels"
+LEVELED = "leveled"
+INCLUDED_CODELIST = "IncludedCodelist"
+CODELIST_ALIAS_REF = "CodelistAliasRef"
+CODE_ID = "CodeID"
+ALIAS = "alias"
+
 # Mapping
 STRUCTURE_MAPS = "StructureMaps"
 STRUCTURE_MAP = "StructureMap"

--- a/src/pysdmx/io/xml/__tokens.py
+++ b/src/pysdmx/io/xml/__tokens.py
@@ -317,6 +317,11 @@ INCLUDED_CODELIST = "IncludedCodelist"
 CODELIST_ALIAS_REF = "CodelistAliasRef"
 CODE_ID = "CodeID"
 ALIAS = "alias"
+HIERARCHY_ASSOCIATIONS = "HierarchyAssociations"
+HIERARCHY_ASSOCIATION = "HierarchyAssociation"
+LINKED_HIERARCHY = "LinkedHierarchy"
+LINKED_OBJECT = "LinkedObject"
+CONTEXT_OBJECT = "ContextObject"
 
 # Mapping
 STRUCTURE_MAPS = "StructureMaps"

--- a/src/pysdmx/io/xml/__write_aux.py
+++ b/src/pysdmx/io/xml/__write_aux.py
@@ -68,6 +68,8 @@ ORGS = "OrganisationSchemes"
 AGC = "AgencySchemes"
 AGENCIES = "AgencyScheme"
 CODELISTS = "Codelists"
+HIERARCHIES = "Hierarchies"
+HIERARCHICAL_CODELISTS = "HierarchicalCodelists"
 CONCEPTS = "Concepts"
 CONCEPTS_SCHEMES = "ConceptSchemes"
 DSDS = "DataStructures"
@@ -216,6 +218,7 @@ MSG_CONTENT_PKG_21 = OrderedDict(
         (DATAFLOWS, "Dataflows"),
         (PROV_AGREEMENTS, "ProvisionAgreements"),
         (CODELISTS, "Codelists"),
+        (HIERARCHICAL_CODELISTS, "HierarchicalCodelists"),
         (CONCEPTS, "Concepts"),
         (DSDS, "DataStructures"),
         (CONSTRAINTS, "Constraints"),
@@ -237,6 +240,7 @@ MSG_CONTENT_PKG_30 = OrderedDict(
         (DATAFLOWS, "Dataflows"),
         (PROV_AGREEMENTS, "ProvisionAgreements"),
         (CODELISTS, "Codelists"),
+        (HIERARCHIES, "Hierarchies"),
         (CONCEPTS_SCHEMES, "ConceptSchemes"),
         (DSDS, "DataStructures"),
         (DATA_CONSTRAINTS, "DataConstraints"),

--- a/src/pysdmx/io/xml/__write_aux.py
+++ b/src/pysdmx/io/xml/__write_aux.py
@@ -69,6 +69,7 @@ AGC = "AgencySchemes"
 AGENCIES = "AgencyScheme"
 CODELISTS = "Codelists"
 HIERARCHIES = "Hierarchies"
+HIERARCHY_ASSOCIATIONS = "HierarchyAssociations"
 HIERARCHICAL_CODELISTS = "HierarchicalCodelists"
 CONCEPTS = "Concepts"
 CONCEPTS_SCHEMES = "ConceptSchemes"
@@ -241,6 +242,7 @@ MSG_CONTENT_PKG_30 = OrderedDict(
         (PROV_AGREEMENTS, "ProvisionAgreements"),
         (CODELISTS, "Codelists"),
         (HIERARCHIES, "Hierarchies"),
+        (HIERARCHY_ASSOCIATIONS, "HierarchyAssociations"),
         (CONCEPTS_SCHEMES, "ConceptSchemes"),
         (DSDS, "DataStructures"),
         (DATA_CONSTRAINTS, "DataConstraints"),

--- a/tests/io/xml/sdmx21/reader/samples/hierarchy.xml
+++ b/tests/io/xml/sdmx21/reader/samples/hierarchy.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				xmlns:xml="http://www.w3.org/XML/1998/namespace"
+				xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+				xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure"
+				xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common"
+				xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+    <mes:Header>
+        <mes:ID>IREF1</mes:ID>
+        <mes:Test>false</mes:Test>
+        <mes:Prepared>2021-03-08T17:49:35Z</mes:Prepared>
+        <mes:Sender id="Unknown" />
+        <mes:Receiver id="not_supplied" /></mes:Header>
+    <mes:Structures>
+        <str:HierarchicalCodelists>
+            <str:HierarchicalCodelist agencyID="BIS" id="HCL1" version="1.0">
+                <com:Name xml:lang="en">Hierarchical codelist</com:Name>
+                <str:Hierarchy id="H1" leveled="true">
+                    <com:Name xml:lang="en">Hierarchy 1</com:Name>
+                    <str:HierarchicalCode id="A">
+                        <str:Code>
+                            <Ref agencyID="BIS" maintainableParentID="CL_FREQ" maintainableParentVersion="1.0" id="A" package="codelist" class="Code" />
+                        </str:Code>
+                        <str:HierarchicalCode id="A1">
+                            <str:Code>
+                                <Ref agencyID="BIS" maintainableParentID="CL_FREQ" maintainableParentVersion="1.0" id="M" package="codelist" class="Code" />
+                            </str:Code>
+                        </str:HierarchicalCode>
+                        <str:Level>
+                            <Ref id="1" />
+                        </str:Level>
+                    </str:HierarchicalCode>
+                    <str:Level id="0">
+                        <com:Name xml:lang="en">Division</com:Name>
+                        <str:Level id="1">
+                            <com:Name xml:lang="en">Group</com:Name>
+                        </str:Level>
+                    </str:Level>
+                </str:Hierarchy>
+            </str:HierarchicalCodelist>
+        </str:HierarchicalCodelists>
+    </mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/reader/samples/hierarchy_alias.xml
+++ b/tests/io/xml/sdmx21/reader/samples/hierarchy_alias.xml
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				xmlns:xml="http://www.w3.org/XML/1998/namespace"
+				xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+				xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure"
+				xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common"
+				xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+    <mes:Header>
+        <mes:ID>IREF1</mes:ID>
+        <mes:Test>false</mes:Test>
+        <mes:Prepared>2021-03-08T17:49:35Z</mes:Prepared>
+        <mes:Sender id="Unknown" />
+        <mes:Receiver id="not_supplied" /></mes:Header>
+    <mes:Structures>
+        <str:HierarchicalCodelists>
+            <str:HierarchicalCodelist agencyID="BIS" id="HCL2" version="1.0">
+                <com:Name xml:lang="en">Aliased codelist</com:Name>
+                <str:IncludedCodelist alias="FREQ">
+                    <Ref agencyID="BIS" id="CL_FREQ" version="1.0" package="codelist" class="Codelist" />
+                </str:IncludedCodelist>
+                <str:Hierarchy id="H2" leveled="false">
+                    <com:Name xml:lang="en">Aliased hierarchy</com:Name>
+                    <str:HierarchicalCode id="A">
+                        <str:CodelistAliasRef>FREQ</str:CodelistAliasRef>
+                        <str:CodeID>
+                            <Ref id="A" />
+                        </str:CodeID>
+                        <str:HierarchicalCode id="A1">
+                            <str:CodelistAliasRef>FREQ</str:CodelistAliasRef>
+                            <str:CodeID>
+                                <Ref id="M" />
+                            </str:CodeID>
+                        </str:HierarchicalCode>
+                    </str:HierarchicalCode>
+                </str:Hierarchy>
+            </str:HierarchicalCodelist>
+        </str:HierarchicalCodelists>
+    </mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/reader/test_reader.py
+++ b/tests/io/xml/sdmx21/reader/test_reader.py
@@ -32,6 +32,7 @@ from pysdmx.model import (
     DataKeyValue,
     DataStructureDefinition,
     FromVtlMapping,
+    Hierarchy,
     ItemReference,
     KeySet,
     NamePersonalisationScheme,
@@ -84,6 +85,66 @@ def estat_data_path():
 @pytest.fixture
 def samples_folder():
     return Path(__file__).parent / "samples"
+
+
+@pytest.mark.xml
+def test_hierarchy_21(samples_folder):
+    data_path = samples_folder / "hierarchy.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_2_1
+    result = read_sdmx(input_str, validate=True).structures
+    hierarchy = result[0]
+    assert isinstance(hierarchy, Hierarchy)
+    assert hierarchy.id == "H1"
+    assert hierarchy.agency == "BIS"
+    assert hierarchy.version == "1.0"
+    assert hierarchy.has_formal_levels is True
+    assert hierarchy.level is not None
+    assert hierarchy.level.id == "0"
+    assert hierarchy.level.name == "Division"
+    assert hierarchy.level.level.id == "1"
+    assert hierarchy.level.level.name == "Group"
+    assert hierarchy.level.level.level is None
+    assert len(hierarchy.codes) == 1
+    code_a = hierarchy.codes[0]
+    assert code_a.id == "A"
+    assert (
+        code_a.urn
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A"
+    )
+    assert code_a.level == "1"
+    assert len(code_a.codes) == 1
+    assert code_a.codes[0].id == "A1"
+    assert (
+        code_a.codes[0].urn
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).M"
+    )
+
+
+@pytest.mark.xml
+def test_hierarchy_alias_21(samples_folder):
+    data_path = samples_folder / "hierarchy_alias.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_2_1
+    result = read_sdmx(input_str, validate=True).structures
+    hierarchy = result[0]
+    assert isinstance(hierarchy, Hierarchy)
+    assert hierarchy.id == "H2"
+    assert hierarchy.agency == "BIS"
+    assert hierarchy.has_formal_levels is False
+    assert hierarchy.level is None
+    assert len(hierarchy.codes) == 1
+    code_a = hierarchy.codes[0]
+    assert code_a.id == "A"
+    assert (
+        code_a.urn
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A"
+    )
+    assert code_a.codes[0].id == "A1"
+    assert (
+        code_a.codes[0].urn
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).M"
+    )
 
 
 @pytest.fixture

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -178,7 +178,7 @@ def hierarchy_with_levels():
             name="Division",
             level=LevelType(id="1", name="Group"),
         ),
-        codes=[
+        codes=(
             HierarchicalCode(
                 id="A",
                 urn=(
@@ -186,7 +186,7 @@ def hierarchy_with_levels():
                     "Code=BIS:CL_FREQ(1.0).A"
                 ),
                 level="1",
-                codes=[
+                codes=(
                     HierarchicalCode(
                         id="A1",
                         urn=(
@@ -194,9 +194,9 @@ def hierarchy_with_levels():
                             "Code=BIS:CL_FREQ(1.0).M"
                         ),
                     ),
-                ],
+                ),
             ),
-        ],
+        ),
     )
 
 
@@ -208,19 +208,7 @@ def test_hierarchy_21_round_trip(complete_header, hierarchy_with_levels):
     assert "<str:HierarchicalCodelist " in result
     assert 'leveled="true"' in result
     re_read = read_sdmx(result, validate=True).structures[0]
-    assert isinstance(re_read, Hierarchy)
-    assert re_read.id == "H1"
-    assert re_read.agency == "BIS"
-    assert re_read.has_formal_levels is True
-    assert re_read.level.id == "0"
-    assert re_read.level.level.name == "Group"
-    code_a = re_read.codes[0]
-    assert (
-        code_a.urn
-        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A"
-    )
-    assert code_a.level == "1"
-    assert code_a.codes[0].id == "A1"
+    assert re_read == hierarchy_with_levels
 
 
 def test_hierarchy_21_no_levels(complete_header):
@@ -229,7 +217,7 @@ def test_hierarchy_21_no_levels(complete_header):
         name="Flat hierarchy",
         agency="BIS",
         version="1.0",
-        codes=[
+        codes=(
             HierarchicalCode(
                 id="A",
                 urn=(
@@ -237,18 +225,12 @@ def test_hierarchy_21_no_levels(complete_header):
                     "Code=BIS:CL_FREQ(1.0).A"
                 ),
             ),
-        ],
+        ),
     )
     result = write([hierarchy], header=complete_header, prettyprint=True)
     assert 'leveled="false"' in result
     re_read = read_sdmx(result, validate=True).structures[0]
-    assert isinstance(re_read, Hierarchy)
-    assert re_read.has_formal_levels is False
-    assert re_read.level is None
-    assert (
-        re_read.codes[0].urn
-        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A"
-    )
+    assert re_read == hierarchy
 
 
 def test_hierarchy_21_metadata_round_trip(complete_header):
@@ -260,8 +242,8 @@ def test_hierarchy_21_metadata_round_trip(complete_header):
         version="1.0",
         valid_from=datetime(2021, 1, 1),
         valid_to=datetime(2021, 12, 31),
-        annotations=[Annotation(id="AN1", title="anno")],
-        codes=[
+        annotations=(Annotation(id="AN1", title="anno"),),
+        codes=(
             HierarchicalCode(
                 id="A",
                 urn=(
@@ -269,15 +251,11 @@ def test_hierarchy_21_metadata_round_trip(complete_header):
                     "Code=BIS:CL_FREQ(1.0).A"
                 ),
             ),
-        ],
+        ),
     )
     result = write([hierarchy], header=complete_header, prettyprint=True)
     re_read = read_sdmx(result, validate=True).structures[0]
-    assert re_read.name == "Hierarchy 1"
-    assert re_read.description == "My description"
-    assert re_read.valid_from == datetime(2021, 1, 1)
-    assert re_read.valid_to == datetime(2021, 12, 31)
-    assert re_read.annotations[0].id == "AN1"
+    assert re_read == hierarchy
 
 
 def test_hierarchy_21_name_with_apostrophe(complete_header):

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -251,6 +251,35 @@ def test_hierarchy_21_no_levels(complete_header):
     )
 
 
+def test_hierarchy_21_metadata_round_trip(complete_header):
+    hierarchy = Hierarchy(
+        id="H1",
+        name="Hierarchy 1",
+        description="My description",
+        agency="BIS",
+        version="1.0",
+        valid_from=datetime(2021, 1, 1),
+        valid_to=datetime(2021, 12, 31),
+        annotations=[Annotation(id="AN1", title="anno")],
+        codes=[
+            HierarchicalCode(
+                id="A",
+                urn=(
+                    "urn:sdmx:org.sdmx.infomodel.codelist."
+                    "Code=BIS:CL_FREQ(1.0).A"
+                ),
+            ),
+        ],
+    )
+    result = write([hierarchy], header=complete_header, prettyprint=True)
+    re_read = read_sdmx(result, validate=True).structures[0]
+    assert re_read.name == "Hierarchy 1"
+    assert re_read.description == "My description"
+    assert re_read.valid_from == datetime(2021, 1, 1)
+    assert re_read.valid_to == datetime(2021, 12, 31)
+    assert re_read.annotations[0].id == "AN1"
+
+
 def test_hierarchy_21_name_with_apostrophe(complete_header):
     hierarchy = Hierarchy(
         id="H4",

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -29,7 +29,10 @@ from pysdmx.model import (
     DataKeyValue,
     Facets,
     FromVtlMapping,
+    HierarchicalCode,
+    Hierarchy,
     KeySet,
+    LevelType,
     NamePersonalisationScheme,
     Ruleset,
     RulesetScheme,
@@ -160,6 +163,113 @@ def complete_header():
         ),
         source="PySDMX",
     )
+
+
+@pytest.fixture
+def hierarchy_with_levels():
+    return Hierarchy(
+        id="H1",
+        name="Hierarchy 1",
+        agency="BIS",
+        version="1.0",
+        has_formal_levels=True,
+        level=LevelType(
+            id="0",
+            name="Division",
+            level=LevelType(id="1", name="Group"),
+        ),
+        codes=[
+            HierarchicalCode(
+                id="A",
+                urn=(
+                    "urn:sdmx:org.sdmx.infomodel.codelist."
+                    "Code=BIS:CL_FREQ(1.0).A"
+                ),
+                level="1",
+                codes=[
+                    HierarchicalCode(
+                        id="A1",
+                        urn=(
+                            "urn:sdmx:org.sdmx.infomodel.codelist."
+                            "Code=BIS:CL_FREQ(1.0).M"
+                        ),
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def test_hierarchy_21_round_trip(complete_header, hierarchy_with_levels):
+    result = write(
+        [hierarchy_with_levels], header=complete_header, prettyprint=True
+    )
+    assert "<str:HierarchicalCodelists>" in result
+    assert "<str:HierarchicalCodelist " in result
+    assert 'leveled="true"' in result
+    re_read = read_sdmx(result, validate=True).structures[0]
+    assert isinstance(re_read, Hierarchy)
+    assert re_read.id == "H1"
+    assert re_read.agency == "BIS"
+    assert re_read.has_formal_levels is True
+    assert re_read.level.id == "0"
+    assert re_read.level.level.name == "Group"
+    code_a = re_read.codes[0]
+    assert (
+        code_a.urn
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A"
+    )
+    assert code_a.level == "1"
+    assert code_a.codes[0].id == "A1"
+
+
+def test_hierarchy_21_no_levels(complete_header):
+    hierarchy = Hierarchy(
+        id="H3",
+        name="Flat hierarchy",
+        agency="BIS",
+        version="1.0",
+        codes=[
+            HierarchicalCode(
+                id="A",
+                urn=(
+                    "urn:sdmx:org.sdmx.infomodel.codelist."
+                    "Code=BIS:CL_FREQ(1.0).A"
+                ),
+            ),
+        ],
+    )
+    result = write([hierarchy], header=complete_header, prettyprint=True)
+    assert 'leveled="false"' in result
+    re_read = read_sdmx(result, validate=True).structures[0]
+    assert isinstance(re_read, Hierarchy)
+    assert re_read.has_formal_levels is False
+    assert re_read.level is None
+    assert (
+        re_read.codes[0].urn
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A"
+    )
+
+
+def test_hierarchy_21_name_with_apostrophe(complete_header):
+    hierarchy = Hierarchy(
+        id="H4",
+        name="Côte d'Ivoire groups",
+        agency="BIS",
+        version="1.0",
+        codes=[
+            HierarchicalCode(
+                id="A",
+                urn=(
+                    "urn:sdmx:org.sdmx.infomodel.codelist."
+                    "Code=BIS:CL_FREQ(1.0).A"
+                ),
+            ),
+        ],
+    )
+    result = write([hierarchy], header=complete_header, prettyprint=True)
+    re_read = read_sdmx(result, validate=True).structures[0]
+    assert re_read.name == "Côte d'Ivoire groups"
 
 
 @pytest.fixture

--- a/tests/io/xml/sdmx30/reader/samples/hierarchy.xml
+++ b/tests/io/xml/sdmx30/reader/samples/hierarchy.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				xmlns:xml="http://www.w3.org/XML/1998/namespace"
+				xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message"
+				xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure"
+				xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common"
+				xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://xml.sdmx.org/3.0/SDMXMessage.xsd">
+    <mes:Header>
+        <mes:ID>IREF1</mes:ID>
+        <mes:Test>false</mes:Test>
+        <mes:Prepared>2021-03-08T17:49:35Z</mes:Prepared>
+        <mes:Sender id="Unknown" />
+        <mes:Receiver id="not_supplied" /></mes:Header>
+    <mes:Structures>
+        <str:Hierarchies>
+            <str:Hierarchy agencyID="BIS" id="H1" version="1.0" hasFormalLevels="false">
+                <com:Name xml:lang="en">Hierarchy 1</com:Name>
+                <com:Description xml:lang="en">A test hierarchy</com:Description>
+                <str:HierarchicalCode id="A">
+                    <str:Code>urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A</str:Code>
+                    <str:HierarchicalCode id="A1">
+                        <str:Code>urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).M</str:Code>
+                    </str:HierarchicalCode>
+                </str:HierarchicalCode>
+                <str:HierarchicalCode id="B" validFrom="2021-01-01T00:00:00" validTo="2021-12-31T00:00:00">
+                    <str:Code>urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).Q</str:Code>
+                </str:HierarchicalCode>
+            </str:Hierarchy>
+        </str:Hierarchies>
+    </mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/reader/samples/hierarchy_levels.xml
+++ b/tests/io/xml/sdmx30/reader/samples/hierarchy_levels.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				xmlns:xml="http://www.w3.org/XML/1998/namespace"
+				xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message"
+				xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure"
+				xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common"
+				xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://xml.sdmx.org/3.0/SDMXMessage.xsd">
+    <mes:Header>
+        <mes:ID>IREF1</mes:ID>
+        <mes:Test>false</mes:Test>
+        <mes:Prepared>2021-03-08T17:49:35Z</mes:Prepared>
+        <mes:Sender id="Unknown" />
+        <mes:Receiver id="not_supplied" /></mes:Header>
+    <mes:Structures>
+        <str:Hierarchies>
+            <str:Hierarchy agencyID="BIS" id="H2" version="1.0" hasFormalLevels="true">
+                <com:Name xml:lang="en">Hierarchy with levels</com:Name>
+                <str:Level id="0">
+                    <com:Name xml:lang="en">Division</com:Name>
+                    <com:Description xml:lang="en">Top level</com:Description>
+                    <str:Level id="1">
+                        <com:Name xml:lang="en">Group</com:Name>
+                    </str:Level>
+                </str:Level>
+                <str:HierarchicalCode id="A">
+                    <str:Code>urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A</str:Code>
+                    <str:Level>1</str:Level>
+                </str:HierarchicalCode>
+                <str:HierarchicalCode id="B">
+                    <str:Code>urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).Q</str:Code>
+                </str:HierarchicalCode>
+            </str:Hierarchy>
+        </str:Hierarchies>
+    </mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/reader/test_reader.py
+++ b/tests/io/xml/sdmx30/reader/test_reader.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -25,6 +26,7 @@ from pysdmx.model import (
     Dataflow,
     DataKey,
     DataKeyValue,
+    Hierarchy,
     ItemReference,
     KeySet,
     NamePersonalisation,
@@ -42,6 +44,51 @@ from pysdmx.model.dataflow import DataStructureDefinition, ProvisionAgreement
 @pytest.fixture
 def samples_folder():
     return Path(__file__).parent / "samples"
+
+
+@pytest.mark.xml
+def test_hierarchy_30(samples_folder):
+    data_path = samples_folder / "hierarchy.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_0
+    result = read_sdmx(input_str, validate=True).structures
+    hierarchy = result[0]
+    assert isinstance(hierarchy, Hierarchy)
+    assert hierarchy.id == "H1"
+    assert hierarchy.agency == "BIS"
+    assert hierarchy.has_formal_levels is False
+    assert hierarchy.level is None
+    assert len(hierarchy.codes) == 2
+    code_a = hierarchy.codes[0]
+    assert code_a.id == "A"
+    assert (
+        code_a.urn
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A"
+    )
+    assert len(code_a.codes) == 1
+    assert code_a.codes[0].id == "A1"
+    code_b = hierarchy.codes[1]
+    assert code_b.rel_valid_from == datetime(2021, 1, 1)
+    assert code_b.rel_valid_to == datetime(2021, 12, 31)
+
+
+@pytest.mark.xml
+def test_hierarchy_levels_30(samples_folder):
+    data_path = samples_folder / "hierarchy_levels.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_0
+    result = read_sdmx(input_str, validate=True).structures
+    hierarchy = result[0]
+    assert isinstance(hierarchy, Hierarchy)
+    assert hierarchy.has_formal_levels is True
+    assert hierarchy.level is not None
+    assert hierarchy.level.id == "0"
+    assert hierarchy.level.name == "Division"
+    assert hierarchy.level.level.id == "1"
+    assert hierarchy.level.level.name == "Group"
+    assert hierarchy.level.level.level is None
+    assert hierarchy.codes[0].level == "1"
+    assert hierarchy.codes[1].level is None
 
 
 def test_dataflow_30(samples_folder):

--- a/tests/io/xml/sdmx31/reader/samples/hierarchy.xml
+++ b/tests/io/xml/sdmx31/reader/samples/hierarchy.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				xmlns:xml="http://www.w3.org/XML/1998/namespace"
+				xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/message"
+				xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/structure"
+				xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/common"
+				xsi:schemaLocation="http://xmlschema.sdmx.org/resources/sdmxml/schemas/v3_1/message https://xml.sdmx.org/3.1/SDMXMessage.xsd">
+    <mes:Header>
+        <mes:ID>IREF1</mes:ID>
+        <mes:Test>false</mes:Test>
+        <mes:Prepared>2021-03-08T17:49:35Z</mes:Prepared>
+        <mes:Sender id="Unknown" />
+        <mes:Receiver id="not_supplied" /></mes:Header>
+    <mes:Structures>
+        <str:Hierarchies>
+            <str:Hierarchy agencyID="BIS" id="H1" version="1.0" hasFormalLevels="false">
+                <com:Name xml:lang="en">Hierarchy 1</com:Name>
+                <com:Description xml:lang="en">A test hierarchy</com:Description>
+                <str:HierarchicalCode id="A">
+                    <str:Code>urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A</str:Code>
+                    <str:HierarchicalCode id="A1">
+                        <str:Code>urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).M</str:Code>
+                    </str:HierarchicalCode>
+                </str:HierarchicalCode>
+                <str:HierarchicalCode id="B" validFrom="2021-01-01T00:00:00" validTo="2021-12-31T00:00:00">
+                    <str:Code>urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).Q</str:Code>
+                </str:HierarchicalCode>
+            </str:Hierarchy>
+        </str:Hierarchies>
+    </mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx31/reader/samples/hierarchy_association.xml
+++ b/tests/io/xml/sdmx31/reader/samples/hierarchy_association.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				xmlns:xml="http://www.w3.org/XML/1998/namespace"
+				xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/message"
+				xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/structure"
+				xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/common"
+				xsi:schemaLocation="http://xmlschema.sdmx.org/resources/sdmxml/schemas/v3_1/message https://xml.sdmx.org/3.1/SDMXMessage.xsd">
+    <mes:Header>
+        <mes:ID>IREF1</mes:ID>
+        <mes:Test>false</mes:Test>
+        <mes:Prepared>2021-03-08T17:49:35Z</mes:Prepared>
+        <mes:Sender id="Unknown" />
+        <mes:Receiver id="not_supplied" /></mes:Header>
+    <mes:Structures>
+        <str:HierarchyAssociations>
+            <str:HierarchyAssociation agencyID="BIS" id="HA1" version="1.0">
+                <com:Name xml:lang="en">Association 1</com:Name>
+                <str:LinkedHierarchy>urn:sdmx:org.sdmx.infomodel.codelist.Hierarchy=BIS:H1(1.0)</str:LinkedHierarchy>
+                <str:LinkedObject>urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:DSD(1.0).FREQ</str:LinkedObject>
+                <str:ContextObject>urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS:DF(1.0)</str:ContextObject>
+            </str:HierarchyAssociation>
+            <str:HierarchyAssociation agencyID="BIS" id="HA2" version="1.0">
+                <com:Name xml:lang="en">Association 2</com:Name>
+                <str:LinkedHierarchy>urn:sdmx:org.sdmx.infomodel.codelist.Hierarchy=BIS:H2(1.0)</str:LinkedHierarchy>
+                <str:LinkedObject>urn:sdmx:org.sdmx.infomodel.datastructure.Dimension=BIS:DSD(1.0).REF_AREA</str:LinkedObject>
+            </str:HierarchyAssociation>
+        </str:HierarchyAssociations>
+    </mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx31/reader/samples/hierarchy_levels.xml
+++ b/tests/io/xml/sdmx31/reader/samples/hierarchy_levels.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				xmlns:xml="http://www.w3.org/XML/1998/namespace"
+				xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/message"
+				xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/structure"
+				xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/common"
+				xsi:schemaLocation="http://xmlschema.sdmx.org/resources/sdmxml/schemas/v3_1/message https://xml.sdmx.org/3.1/SDMXMessage.xsd">
+    <mes:Header>
+        <mes:ID>IREF1</mes:ID>
+        <mes:Test>false</mes:Test>
+        <mes:Prepared>2021-03-08T17:49:35Z</mes:Prepared>
+        <mes:Sender id="Unknown" />
+        <mes:Receiver id="not_supplied" /></mes:Header>
+    <mes:Structures>
+        <str:Hierarchies>
+            <str:Hierarchy agencyID="BIS" id="H2" version="1.0" hasFormalLevels="true">
+                <com:Name xml:lang="en">Hierarchy with levels</com:Name>
+                <str:Level id="0">
+                    <com:Name xml:lang="en">Division</com:Name>
+                    <com:Description xml:lang="en">Top level</com:Description>
+                    <str:Level id="1">
+                        <com:Name xml:lang="en">Group</com:Name>
+                    </str:Level>
+                </str:Level>
+                <str:HierarchicalCode id="A">
+                    <str:Code>urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A</str:Code>
+                    <str:Level>1</str:Level>
+                </str:HierarchicalCode>
+                <str:HierarchicalCode id="B">
+                    <str:Code>urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).Q</str:Code>
+                </str:HierarchicalCode>
+            </str:Hierarchy>
+        </str:Hierarchies>
+    </mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx31/reader/test_read_write.py
+++ b/tests/io/xml/sdmx31/reader/test_read_write.py
@@ -14,6 +14,7 @@ from pysdmx.model import (
     Codelist,
     ConceptScheme,
     Hierarchy,
+    HierarchyAssociation,
     NamePersonalisationScheme,
     RulesetScheme,
     TransformationScheme,
@@ -84,6 +85,32 @@ def test_hierarchy_levels_31(samples_folder):
     assert hierarchy.level.level.level is None
     assert hierarchy.codes[0].level == "1"
     assert hierarchy.codes[1].level is None
+
+
+def test_hierarchy_association_31(samples_folder):
+    data_path = samples_folder / "hierarchy_association.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_1
+    structures = read_sdmx(input_str, validate=True).structures
+    write = write_structure(structures=structures, prettyprint=True)
+    result = read_sdmx(write, validate=True).structures
+    assert len(result) == 2
+    ha1 = result[0]
+    assert isinstance(ha1, HierarchyAssociation)
+    assert ha1.id == "HA1"
+    assert (
+        ha1.hierarchy
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Hierarchy=BIS:H1(1.0)"
+    )
+    assert (
+        ha1.component_ref == "urn:sdmx:org.sdmx.infomodel.datastructure."
+        "Dimension=BIS:DSD(1.0).FREQ"
+    )
+    assert (
+        ha1.context_ref
+        == "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS:DF(1.0)"
+    )
+    assert result[1].context_ref == ""
 
 
 def test_concept_scheme_31(samples_folder):

--- a/tests/io/xml/sdmx31/reader/test_read_write.py
+++ b/tests/io/xml/sdmx31/reader/test_read_write.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,7 @@ from pysdmx.io.xml.sdmx30.writer.structure_specific import (
 from pysdmx.model import (
     Codelist,
     ConceptScheme,
+    Hierarchy,
     NamePersonalisationScheme,
     RulesetScheme,
     TransformationScheme,
@@ -34,6 +36,54 @@ def test_codelist_31(samples_folder):
     result = read_sdmx(write, validate=True).structures
     codelist = result[0]
     assert isinstance(codelist, Codelist)
+
+
+def test_hierarchy_31(samples_folder):
+    data_path = samples_folder / "hierarchy.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_1
+    structures = read_sdmx(input_str, validate=True).structures
+    write = write_structure(structures=structures, prettyprint=True)
+    result = read_sdmx(write, validate=True).structures
+    hierarchy = result[0]
+    assert isinstance(hierarchy, Hierarchy)
+    assert hierarchy.id == "H1"
+    assert hierarchy.agency == "BIS"
+    assert hierarchy.version == "1.0"
+    assert hierarchy.has_formal_levels is False
+    assert hierarchy.level is None
+    assert len(hierarchy.codes) == 2
+    code_a = hierarchy.codes[0]
+    assert (
+        code_a.urn
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A"
+    )
+    assert len(code_a.codes) == 1
+    assert code_a.codes[0].id == "A1"
+    code_b = hierarchy.codes[1]
+    assert code_b.rel_valid_from == datetime(2021, 1, 1)
+    assert code_b.rel_valid_to == datetime(2021, 12, 31)
+
+
+def test_hierarchy_levels_31(samples_folder):
+    data_path = samples_folder / "hierarchy_levels.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_1
+    structures = read_sdmx(input_str, validate=True).structures
+    write = write_structure(structures=structures, prettyprint=True)
+    result = read_sdmx(write, validate=True).structures
+    hierarchy = result[0]
+    assert isinstance(hierarchy, Hierarchy)
+    assert hierarchy.has_formal_levels is True
+    assert hierarchy.level is not None
+    assert hierarchy.level.id == "0"
+    assert hierarchy.level.name == "Division"
+    assert hierarchy.level.description == "Top level"
+    assert hierarchy.level.level.id == "1"
+    assert hierarchy.level.level.name == "Group"
+    assert hierarchy.level.level.level is None
+    assert hierarchy.codes[0].level == "1"
+    assert hierarchy.codes[1].level is None
 
 
 def test_concept_scheme_31(samples_folder):

--- a/tests/io/xml/sdmx31/reader/test_read_write.py
+++ b/tests/io/xml/sdmx31/reader/test_read_write.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -46,24 +45,8 @@ def test_hierarchy_31(samples_folder):
     structures = read_sdmx(input_str, validate=True).structures
     write = write_structure(structures=structures, prettyprint=True)
     result = read_sdmx(write, validate=True).structures
-    hierarchy = result[0]
-    assert isinstance(hierarchy, Hierarchy)
-    assert hierarchy.id == "H1"
-    assert hierarchy.agency == "BIS"
-    assert hierarchy.version == "1.0"
-    assert hierarchy.has_formal_levels is False
-    assert hierarchy.level is None
-    assert len(hierarchy.codes) == 2
-    code_a = hierarchy.codes[0]
-    assert (
-        code_a.urn
-        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A"
-    )
-    assert len(code_a.codes) == 1
-    assert code_a.codes[0].id == "A1"
-    code_b = hierarchy.codes[1]
-    assert code_b.rel_valid_from == datetime(2021, 1, 1)
-    assert code_b.rel_valid_to == datetime(2021, 12, 31)
+    assert isinstance(result[0], Hierarchy)
+    assert result == structures
 
 
 def test_hierarchy_levels_31(samples_folder):
@@ -73,18 +56,8 @@ def test_hierarchy_levels_31(samples_folder):
     structures = read_sdmx(input_str, validate=True).structures
     write = write_structure(structures=structures, prettyprint=True)
     result = read_sdmx(write, validate=True).structures
-    hierarchy = result[0]
-    assert isinstance(hierarchy, Hierarchy)
-    assert hierarchy.has_formal_levels is True
-    assert hierarchy.level is not None
-    assert hierarchy.level.id == "0"
-    assert hierarchy.level.name == "Division"
-    assert hierarchy.level.description == "Top level"
-    assert hierarchy.level.level.id == "1"
-    assert hierarchy.level.level.name == "Group"
-    assert hierarchy.level.level.level is None
-    assert hierarchy.codes[0].level == "1"
-    assert hierarchy.codes[1].level is None
+    assert isinstance(result[0], Hierarchy)
+    assert result == structures
 
 
 def test_hierarchy_association_31(samples_folder):
@@ -95,22 +68,8 @@ def test_hierarchy_association_31(samples_folder):
     write = write_structure(structures=structures, prettyprint=True)
     result = read_sdmx(write, validate=True).structures
     assert len(result) == 2
-    ha1 = result[0]
-    assert isinstance(ha1, HierarchyAssociation)
-    assert ha1.id == "HA1"
-    assert (
-        ha1.hierarchy
-        == "urn:sdmx:org.sdmx.infomodel.codelist.Hierarchy=BIS:H1(1.0)"
-    )
-    assert (
-        ha1.component_ref == "urn:sdmx:org.sdmx.infomodel.datastructure."
-        "Dimension=BIS:DSD(1.0).FREQ"
-    )
-    assert (
-        ha1.context_ref
-        == "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS:DF(1.0)"
-    )
-    assert result[1].context_ref == ""
+    assert isinstance(result[0], HierarchyAssociation)
+    assert result == structures
 
 
 def test_concept_scheme_31(samples_folder):

--- a/tests/io/xml/sdmx31/reader/test_reader.py
+++ b/tests/io/xml/sdmx31/reader/test_reader.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ from pysdmx.io.xml.sdmx31.reader.structure import read as read_structure
 from pysdmx.model import (
     Codelist,
     ConceptScheme,
+    Hierarchy,
     NamePersonalisationScheme,
     RulesetScheme,
     TransformationScheme,
@@ -38,6 +40,69 @@ def test_codelist_31(samples_folder):
     assert codelist.id == "CL_AGE"
     assert codelist.agency == "SDMX"
     assert len(codelist.items) == 5
+
+
+@pytest.mark.xml
+def test_hierarchy_31(samples_folder):
+    data_path = samples_folder / "hierarchy.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_1
+    result = read_sdmx(input_str, validate=True).structures
+    hierarchy = result[0]
+    assert isinstance(hierarchy, Hierarchy)
+    assert hierarchy.id == "H1"
+    assert hierarchy.agency == "BIS"
+    assert hierarchy.version == "1.0"
+    assert hierarchy.name == "Hierarchy 1"
+    assert hierarchy.description == "A test hierarchy"
+    assert hierarchy.has_formal_levels is False
+    assert hierarchy.level is None
+    assert len(hierarchy.codes) == 2
+
+    code_a = hierarchy.codes[0]
+    assert code_a.id == "A"
+    assert (
+        code_a.urn
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).A"
+    )
+    assert code_a.level is None
+    assert len(code_a.codes) == 1
+    assert code_a.codes[0].id == "A1"
+    assert (
+        code_a.codes[0].urn
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Code=BIS:CL_FREQ(1.0).M"
+    )
+
+    code_b = hierarchy.codes[1]
+    assert code_b.id == "B"
+    assert code_b.rel_valid_from == datetime(2021, 1, 1)
+    assert code_b.rel_valid_to == datetime(2021, 12, 31)
+    assert not code_b.codes
+
+
+@pytest.mark.xml
+def test_hierarchy_levels_31(samples_folder):
+    data_path = samples_folder / "hierarchy_levels.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_1
+    result = read_sdmx(input_str, validate=True).structures
+    hierarchy = result[0]
+    assert isinstance(hierarchy, Hierarchy)
+    assert hierarchy.id == "H2"
+    assert hierarchy.has_formal_levels is True
+    assert hierarchy.level is not None
+    assert hierarchy.level.id == "0"
+    assert hierarchy.level.name == "Division"
+    assert hierarchy.level.description == "Top level"
+    assert hierarchy.level.level is not None
+    assert hierarchy.level.level.id == "1"
+    assert hierarchy.level.level.name == "Group"
+    assert hierarchy.level.level.description is None
+    assert hierarchy.level.level.level is None
+    assert hierarchy.codes[0].id == "A"
+    assert hierarchy.codes[0].level == "1"
+    assert hierarchy.codes[1].id == "B"
+    assert hierarchy.codes[1].level is None
 
 
 @pytest.mark.xml

--- a/tests/io/xml/sdmx31/reader/test_reader.py
+++ b/tests/io/xml/sdmx31/reader/test_reader.py
@@ -12,6 +12,7 @@ from pysdmx.model import (
     Codelist,
     ConceptScheme,
     Hierarchy,
+    HierarchyAssociation,
     NamePersonalisationScheme,
     RulesetScheme,
     TransformationScheme,
@@ -103,6 +104,43 @@ def test_hierarchy_levels_31(samples_folder):
     assert hierarchy.codes[0].level == "1"
     assert hierarchy.codes[1].id == "B"
     assert hierarchy.codes[1].level is None
+
+
+@pytest.mark.xml
+def test_hierarchy_association_31(samples_folder):
+    data_path = samples_folder / "hierarchy_association.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_3_1
+    result = read_sdmx(input_str, validate=True).structures
+    assert len(result) == 2
+
+    ha1 = result[0]
+    assert isinstance(ha1, HierarchyAssociation)
+    assert ha1.id == "HA1"
+    assert ha1.agency == "BIS"
+    assert ha1.version == "1.0"
+    assert ha1.name == "Association 1"
+    assert (
+        ha1.hierarchy
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Hierarchy=BIS:H1(1.0)"
+    )
+    assert (
+        ha1.component_ref == "urn:sdmx:org.sdmx.infomodel.datastructure."
+        "Dimension=BIS:DSD(1.0).FREQ"
+    )
+    assert (
+        ha1.context_ref
+        == "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS:DF(1.0)"
+    )
+
+    ha2 = result[1]
+    assert isinstance(ha2, HierarchyAssociation)
+    assert ha2.id == "HA2"
+    assert (
+        ha2.component_ref == "urn:sdmx:org.sdmx.infomodel.datastructure."
+        "Dimension=BIS:DSD(1.0).REF_AREA"
+    )
+    assert ha2.context_ref == ""
 
 
 @pytest.mark.xml

--- a/tests/io/xml/sdmx31/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx31/writer/test_structures_writing.py
@@ -653,7 +653,7 @@ def hierarchy_with_levels():
             name="Division",
             level=LevelType(id="1", name="Group"),
         ),
-        codes=[
+        codes=(
             HierarchicalCode(
                 id="A",
                 urn=(
@@ -661,7 +661,7 @@ def hierarchy_with_levels():
                     "Code=BIS:CL_FREQ(1.0).A"
                 ),
                 level="1",
-                codes=[
+                codes=(
                     HierarchicalCode(
                         id="A1",
                         urn=(
@@ -669,7 +669,7 @@ def hierarchy_with_levels():
                             "Code=BIS:CL_FREQ(1.0).M"
                         ),
                     ),
-                ],
+                ),
             ),
             HierarchicalCode(
                 id="B",
@@ -678,7 +678,7 @@ def hierarchy_with_levels():
                     "Code=BIS:CL_FREQ(1.0).Q"
                 ),
             ),
-        ],
+        ),
     )
 
 
@@ -691,11 +691,7 @@ def test_hierarchy(complete_header, hierarchy_with_levels):
     assert '<str:Level id="0">' in result
     assert '<str:Level id="1">' in result
     re_read = read_sdmx(result, validate=True).structures[0]
-    assert isinstance(re_read, Hierarchy)
-    assert re_read.has_formal_levels is True
-    assert re_read.level.level.name == "Group"
-    assert re_read.codes[0].level == "1"
-    assert re_read.codes[0].codes[0].id == "A1"
+    assert re_read == hierarchy_with_levels
 
 
 def test_hierarchy_with_annotations(complete_header):
@@ -708,24 +704,22 @@ def test_hierarchy_with_annotations(complete_header):
         level=LevelType(
             id="0",
             name="Division",
-            annotations=[Annotation(id="LA", title="Level annotation")],
+            annotations=(Annotation(id="LA", title="Level annotation"),),
         ),
-        codes=[
+        codes=(
             HierarchicalCode(
                 id="A",
                 urn=(
                     "urn:sdmx:org.sdmx.infomodel.codelist."
                     "Code=BIS:CL_FREQ(1.0).A"
                 ),
-                annotations=[Annotation(id="CA", text="Code annotation")],
+                annotations=(Annotation(id="CA", text="Code annotation"),),
             ),
-        ],
+        ),
     )
     result = write([hierarchy], header=complete_header, prettyprint=True)
     re_read = read_sdmx(result, validate=True).structures[0]
-    assert re_read.level.annotations[0].id == "LA"
-    assert re_read.codes[0].annotations[0].id == "CA"
-    assert re_read.codes[0].annotations[0].text == "Code annotation"
+    assert re_read == hierarchy
 
 
 def test_hierarchy_association(complete_header):

--- a/tests/io/xml/sdmx31/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx31/writer/test_structures_writing.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from pysdmx.errors import Invalid
 from pysdmx.io import write_sdmx
 from pysdmx.io.format import Format
 from pysdmx.io.reader import read_sdmx as read_sdmx
@@ -18,6 +19,9 @@ from pysdmx.model import (
     DataType,
     Facets,
     FromVtlMapping,
+    HierarchicalCode,
+    Hierarchy,
+    LevelType,
     Ruleset,
     RulesetScheme,
     ToVtlMapping,
@@ -633,6 +637,89 @@ def test_codelist(complete_header, codelist, codelist_sample):
         prettyprint=True,
     )
     assert result == codelist_sample
+
+
+@pytest.fixture
+def hierarchy_with_levels():
+    return Hierarchy(
+        id="H1",
+        name="Hierarchy 1",
+        agency="BIS",
+        version="1.0",
+        has_formal_levels=True,
+        level=LevelType(
+            id="0",
+            name="Division",
+            level=LevelType(id="1", name="Group"),
+        ),
+        codes=[
+            HierarchicalCode(
+                id="A",
+                urn=(
+                    "urn:sdmx:org.sdmx.infomodel.codelist."
+                    "Code=BIS:CL_FREQ(1.0).A"
+                ),
+                level="1",
+                codes=[
+                    HierarchicalCode(
+                        id="A1",
+                        urn=(
+                            "urn:sdmx:org.sdmx.infomodel.codelist."
+                            "Code=BIS:CL_FREQ(1.0).M"
+                        ),
+                    ),
+                ],
+            ),
+            HierarchicalCode(
+                id="B",
+                urn=(
+                    "urn:sdmx:org.sdmx.infomodel.codelist."
+                    "Code=BIS:CL_FREQ(1.0).Q"
+                ),
+            ),
+        ],
+    )
+
+
+def test_hierarchy(complete_header, hierarchy_with_levels):
+    result = write(
+        [hierarchy_with_levels], header=complete_header, prettyprint=True
+    )
+    assert "<str:Hierarchies>" in result
+    assert 'hasFormalLevels="true"' in result
+    assert '<str:Level id="0">' in result
+    assert '<str:Level id="1">' in result
+    re_read = read_sdmx(result, validate=True).structures[0]
+    assert isinstance(re_read, Hierarchy)
+    assert re_read.has_formal_levels is True
+    assert re_read.level.level.name == "Group"
+    assert re_read.codes[0].level == "1"
+    assert re_read.codes[0].codes[0].id == "A1"
+
+
+def test_hierarchy_level_no_name(complete_header):
+    hierarchy = Hierarchy(
+        id="H1",
+        name="H",
+        agency="BIS",
+        version="1.0",
+        has_formal_levels=True,
+        level=LevelType(id="0"),
+    )
+    with pytest.raises(Invalid, match="hierarchy levels must have a name"):
+        write([hierarchy], header=complete_header, prettyprint=True)
+
+
+def test_hierarchy_code_no_urn(complete_header):
+    hierarchy = Hierarchy(
+        id="H1",
+        name="H",
+        agency="BIS",
+        version="1.0",
+        codes=[HierarchicalCode(id="A")],
+    )
+    with pytest.raises(Invalid, match="must reference a code urn"):
+        write([hierarchy], header=complete_header, prettyprint=True)
 
 
 def test_concept(complete_header, concept, concept_sample):

--- a/tests/io/xml/sdmx31/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx31/writer/test_structures_writing.py
@@ -21,6 +21,7 @@ from pysdmx.model import (
     FromVtlMapping,
     HierarchicalCode,
     Hierarchy,
+    HierarchyAssociation,
     LevelType,
     Ruleset,
     RulesetScheme,
@@ -695,6 +696,61 @@ def test_hierarchy(complete_header, hierarchy_with_levels):
     assert re_read.level.level.name == "Group"
     assert re_read.codes[0].level == "1"
     assert re_read.codes[0].codes[0].id == "A1"
+
+
+def test_hierarchy_association(complete_header):
+    ha = HierarchyAssociation(
+        id="HA1",
+        name="Association 1",
+        agency="BIS",
+        version="1.0",
+        hierarchy=Hierarchy(id="H1", name="H", agency="BIS", version="1.0"),
+        component_ref=(
+            "urn:sdmx:org.sdmx.infomodel.datastructure."
+            "Dimension=BIS:DSD(1.0).FREQ"
+        ),
+        context_ref=(
+            "urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS:DF(1.0)"
+        ),
+    )
+    result = write([ha], header=complete_header, prettyprint=True)
+    assert "<str:HierarchyAssociations>" in result
+    assert (
+        "<str:LinkedHierarchy>"
+        "urn:sdmx:org.sdmx.infomodel.codelist.Hierarchy=BIS:H1(1.0)"
+        "</str:LinkedHierarchy>" in result
+    )
+    re_read = read_sdmx(result, validate=True).structures[0]
+    assert isinstance(re_read, HierarchyAssociation)
+    assert (
+        re_read.hierarchy
+        == "urn:sdmx:org.sdmx.infomodel.codelist.Hierarchy=BIS:H1(1.0)"
+    )
+
+
+def test_hierarchy_association_no_hierarchy(complete_header):
+    ha = HierarchyAssociation(
+        id="HA1",
+        name="Association 1",
+        agency="BIS",
+        version="1.0",
+        component_ref="urn:sdmx:org.sdmx.infomodel.datastructure."
+        "Dimension=BIS:DSD(1.0).FREQ",
+    )
+    with pytest.raises(Invalid, match="must reference a hierarchy"):
+        write([ha], header=complete_header, prettyprint=True)
+
+
+def test_hierarchy_association_no_component(complete_header):
+    ha = HierarchyAssociation(
+        id="HA1",
+        name="Association 1",
+        agency="BIS",
+        version="1.0",
+        hierarchy="urn:sdmx:org.sdmx.infomodel.codelist.Hierarchy=BIS:H1(1.0)",
+    )
+    with pytest.raises(Invalid, match="must reference a component"):
+        write([ha], header=complete_header, prettyprint=True)
 
 
 def test_hierarchy_level_no_name(complete_header):

--- a/tests/io/xml/sdmx31/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx31/writer/test_structures_writing.py
@@ -698,6 +698,36 @@ def test_hierarchy(complete_header, hierarchy_with_levels):
     assert re_read.codes[0].codes[0].id == "A1"
 
 
+def test_hierarchy_with_annotations(complete_header):
+    hierarchy = Hierarchy(
+        id="H1",
+        name="Hierarchy 1",
+        agency="BIS",
+        version="1.0",
+        has_formal_levels=True,
+        level=LevelType(
+            id="0",
+            name="Division",
+            annotations=[Annotation(id="LA", title="Level annotation")],
+        ),
+        codes=[
+            HierarchicalCode(
+                id="A",
+                urn=(
+                    "urn:sdmx:org.sdmx.infomodel.codelist."
+                    "Code=BIS:CL_FREQ(1.0).A"
+                ),
+                annotations=[Annotation(id="CA", text="Code annotation")],
+            ),
+        ],
+    )
+    result = write([hierarchy], header=complete_header, prettyprint=True)
+    re_read = read_sdmx(result, validate=True).structures[0]
+    assert re_read.level.annotations[0].id == "LA"
+    assert re_read.codes[0].annotations[0].id == "CA"
+    assert re_read.codes[0].annotations[0].text == "Code annotation"
+
+
 def test_hierarchy_association(complete_header):
     ha = HierarchyAssociation(
         id="HA1",


### PR DESCRIPTION
Close #612

Extends the formal-levels support added to the model and SDMX-JSON (#607) to the **SDMX-ML readers and writers**. Hierarchies were previously not read or written in any SDMX-ML version, so this adds full `Hierarchy` read+write support (formal levels included) across **2.1, 3.0 and 3.1**, plus `HierarchyAssociation` support (3.0/3.1).

## Changes
- **`Hierarchy` 3.0 / 3.1**: read/write `<str:Hierarchy>` (standalone maintainable) with `hasFormalLevels`, a recursive `<str:Level>`, and `HierarchicalCode`s referencing codes by URN plus an optional per-code level id.
- **`Hierarchy` 2.1**: read/write `<str:HierarchicalCodelist>` wrapping the hierarchy. Reading resolves codes from a `<Code>` `Ref`/`URN` **or** the `CodelistAliasRef` + `CodeID` alias form (via `IncludedCodelist`); writing emits direct `<Code><Ref/></Code>` references.
- **`HierarchyAssociation` 3.0 / 3.1**: read/write `<str:HierarchyAssociation>` (`LinkedHierarchy` ↔ `hierarchy`, `LinkedObject` ↔ `component_ref`, `ContextObject` ↔ `context_ref`). This mirrors the existing model + SDMX-JSON support, which previously had no SDMX-ML counterpart.

## Notes / design decisions
- The 2.1 `Hierarchy` mapping is necessarily lossy (the flat `Hierarchy` model vs. the nested `HierarchicalCodelist`); round-trips are lossless for the common one-hierarchy-per-codelist case.
- `HierarchyAssociation` has no SDMX-ML 2.1 construct (introduced in SDMX 3.0), so it is 3.0/3.1 only.
- Not serialized, matching existing SDMX-JSON/Fusion behaviour (feature parity): `CodingFormat` (level `dtype`/`facets`), `Hierarchy.operator`, and `HierarchyAssociation.operator` (the latter maps to a JSON `Link`, which SDMX-ML I/O does not handle).
- The model is unchanged.

## Verification
- New reader tests (2.1 direct + alias, 3.0, 3.1; hierarchy associations), round-trip tests and writer error-path tests; all sample XML passes `validate=True` (schema-valid).
- `ruff format`, `ruff check`, `mypy` and `pytest` (100% branch coverage) all pass.