### PR TITLE
Add `c` filters to availability queries in the "data discovery and retrieval" connectors

### DIFF
--- a/docs/howto/dc.rst
+++ b/docs/howto/dc.rst
@@ -139,6 +139,39 @@ Rather than returning all theoretically possible values from the codelist
 for each dimension, the connector only provides values for which data
 actually exist, reducing the risk of executing queries that yield no results.
 
+Filtering availability information
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When exploring a large dataflow, you may want to focus on a specific subset
+of the data first. You can do this by supplying ``filters`` to the
+``dataflow`` method.
+
+With ``filters=None`` (the default), the connector returns availability
+information for the full dataflow. With filters set, it returns availability
+information for the matching subset only (that is, the values that remain
+available once filters are applied).
+
+For example, to inspect only Swiss cross-border claims:
+
+.. code-block:: python
+
+    from pysdmx.api.dc.query import MultiFilter, Operator, TextFilter
+
+    f1 = TextFilter("L_POSITION", Operator.EQUALS, "D")
+    f2 = TextFilter("L_REP_CTY", Operator.EQUALS, "CH")
+    mf = MultiFilter([f1, f2])
+
+    cbs_subset = conn.dataflow(cbs, mf)
+
+    for d in cbs_subset.components.dimensions:
+        dv = [c.id for c in d.enumeration]
+        print(f"{d.id}: {','.join(dv)}.")
+
+The filter syntax is the same as for ``data`` queries (see
+:ref:`Applying Query Filters <dc-applying-query-filters>`): you can
+pass query filter objects (as above), SQL-like strings, or Python
+boolean expressions.
+
 Data Retrieval: Download Data
 -----------------------------
 
@@ -167,6 +200,8 @@ It can accept the following types of input:
   used in SDMX to uniquely identify artefacts of a certain type, such as a Dataflow.
   Examples of Python objects that can be passed include ``pysdmx.Dataflow``,
   ``pysdmx.DataflowInfo``, or ``pysdmx.Reference``.
+
+.. _dc-applying-query-filters:
 
 Applying Query Filters
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/pysdmx/api/dc/_api.py
+++ b/src/pysdmx/api/dc/_api.py
@@ -284,11 +284,15 @@ class BasicConnector(Protocol):
                 necessary to uniquely identify it. Classes such as
                 `DataflowRef` or `Dataflow` are examples of pysdmx classes that
                 implement the `MaintainableIdentification` protocol.
-            filters: The data query filters, if any. This can be a string
-                similar to a SQL WHERE clause ("AREA='UY' AND FREQ <> 'A'")
-                or a Python expression ("REF_AREA=='UY' and FREQ != 'A'") or
-                one of the various filters the `pysdmx.api.dc.query` module
-                offers, including `MultiFilter`.
+            filters: Filters used to scope the data availability
+                information for the selected dataflow. If not supplied,
+                information about the full dataflow is returned. If
+                supplied, information about the matching subset is
+                returned. This can be a string similar to a SQL WHERE
+                clause ("AREA='UY' AND FREQ <> 'A'") or a Python expression
+                ("REF_AREA=='UY' and FREQ != 'A'") or one of the various
+                filters the `pysdmx.api.dc.query` module offers, including
+                `MultiFilter`.
 
         Returns:
             Dataflow: Information about the requested dataflow.

--- a/src/pysdmx/api/dc/_api.py
+++ b/src/pysdmx/api/dc/_api.py
@@ -272,7 +272,9 @@ class BasicConnector(Protocol):
         """
 
     def dataflow(
-        self, dataflow: Union[str, MaintainableIdentification]
+        self,
+        dataflow: Union[str, MaintainableIdentification],
+        filters: Optional[Union[BasicFilter, str]] = None,
     ) -> Dataflow:
         """Get information about a dataflow.
 
@@ -282,6 +284,11 @@ class BasicConnector(Protocol):
                 necessary to uniquely identify it. Classes such as
                 `DataflowRef` or `Dataflow` are examples of pysdmx classes that
                 implement the `MaintainableIdentification` protocol.
+            filters: The data query filters, if any. This can be a string
+                similar to a SQL WHERE clause ("AREA='UY' AND FREQ <> 'A'")
+                or a Python expression ("REF_AREA=='UY' and FREQ != 'A'") or
+                one of the various filters the `pysdmx.api.dc.query` module
+                offers, including `MultiFilter`.
 
         Returns:
             Dataflow: Information about the requested dataflow.

--- a/src/pysdmx/api/dc/pd.py
+++ b/src/pysdmx/api/dc/pd.py
@@ -11,6 +11,7 @@ __check_data_extra()
 
 import pandas as pd
 
+from pysdmx import errors
 from pysdmx.api.dc import BasicConnector, MaintainableIdentification
 from pysdmx.api.dc.query import BasicFilter
 from pysdmx.api.dc.rest import SdmxConnector
@@ -184,17 +185,10 @@ class PandasConnector(BasicConnector):
             The requested data, if any. Data are returned as Pandas data frame.
         """
         q = prepare_basic_data_query(dataflow, filters)
+        temp_path: Optional[pathlib.Path] = None
         try:
             # Write response in chunks to temporary file
-            with tempfile.NamedTemporaryFile(
-                mode="wb", suffix=".csv", delete=False
-            ) as f:
-                for chunk in self.__client.stream_data(
-                    q, chunk_size=1_048_576
-                ):
-                    f.write(chunk)
-                f.flush()
-                f.close()
+            temp_path = self.__write_temp_csv(q)
 
             # Infer read parameters (exclude SDMX columns, add data types etc.)
             params: dict[str, Any] = {}
@@ -217,7 +211,7 @@ class PandasConnector(BasicConnector):
                 params["dtype"] = schema
 
             # Read CSV
-            df = pd.read_csv(f.name, **params)
+            df = pd.read_csv(temp_path, **params)
 
             # Infer series keys
             if (
@@ -251,7 +245,32 @@ class PandasConnector(BasicConnector):
             # Return requested data as a DataFrame
             return df
         finally:
-            pathlib.Path(f.name).unlink()
+            if temp_path:
+                temp_path.unlink(missing_ok=True)
+
+    def __write_temp_csv(self, query: Any) -> pathlib.Path:
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="wb", suffix=".csv", delete=False
+            ) as f:
+                temp_path = pathlib.Path(f.name)
+                for chunk in self.__client.stream_data(
+                    query, chunk_size=1_048_576
+                ):
+                    f.write(chunk)
+                f.flush()
+                return temp_path
+        except OSError as error:
+            raise errors.InternalError(
+                "Unexpected I/O issue",
+                (
+                    "An internal I/O error occurred while creating a "
+                    "temporary file to process SDMX-CSV data."
+                ),
+                {
+                    "original_exception": str(error),
+                },
+            ) from error
 
     def __map_category_fields(
         self, df: pd.DataFrame, flow: Dataflow, labels: Literal["name", "both"]

--- a/src/pysdmx/api/dc/pd.py
+++ b/src/pysdmx/api/dc/pd.py
@@ -1,6 +1,7 @@
 """A Pandas connector for SDMX-REST services."""
 
 # ruff: noqa: E402
+import contextlib
 import pathlib
 import tempfile
 from typing import Any, Iterable, Literal, Optional, Union
@@ -245,10 +246,10 @@ class PandasConnector(BasicConnector):
             # Return requested data as a DataFrame
             return df
         finally:
-            if temp_path:
-                temp_path.unlink(missing_ok=True)
+            self.__cleanup_temp_file(temp_path)
 
     def __write_temp_csv(self, query: Any) -> pathlib.Path:
+        temp_path: Optional[pathlib.Path] = None
         try:
             with tempfile.NamedTemporaryFile(
                 mode="wb", suffix=".csv", delete=False
@@ -260,7 +261,20 @@ class PandasConnector(BasicConnector):
                     f.write(chunk)
                 f.flush()
                 return temp_path
-        except OSError as error:
+        except BaseException as error:
+            self.__cleanup_temp_file(temp_path)
+
+            # Preserve control-flow exceptions after cleanup.
+            if isinstance(
+                error, (KeyboardInterrupt, SystemExit, GeneratorExit)
+            ):
+                raise
+
+            # Keep domain errors unchanged to preserve their semantics.
+            if isinstance(error, errors.PysdmxError):
+                raise
+
+            # Map any remaining unexpected failure to a pysdmx error.
             raise errors.InternalError(
                 "Unexpected I/O issue",
                 (
@@ -271,6 +285,13 @@ class PandasConnector(BasicConnector):
                     "original_exception": str(error),
                 },
             ) from error
+
+    def __cleanup_temp_file(
+        self, temp_path: Optional[pathlib.Path]
+    ) -> None:
+        if temp_path is not None:
+            with contextlib.suppress(OSError):
+                temp_path.unlink(missing_ok=True)
 
     def __map_category_fields(
         self, df: pd.DataFrame, flow: Dataflow, labels: Literal["name", "both"]

--- a/src/pysdmx/api/dc/pd.py
+++ b/src/pysdmx/api/dc/pd.py
@@ -98,11 +98,15 @@ class PandasConnector(BasicConnector):
                 shorthand notation (`agency:id(version)`) is also acceptable.
                 - An object implementing the `MaintainableIdentification`
                 protocol (e.g., instances of `DataflowRef` or `Dataflow`).
-            filters: The data query filters, if any. This can be a string
-                similar to a SQL WHERE clause ("AREA='UY' AND FREQ <> 'A'")
-                or a Python expression ("REF_AREA=='UY' and FREQ != 'A'") or
-                one of the various filters the `pysdmx.api.dc.query` module
-                offers, including `MultiFilter`.
+            filters: Filters used to scope the data availability
+                information for the selected dataflow. If not supplied,
+                information about the full dataflow is returned. If
+                supplied, information about the matching subset is
+                returned. This can be a string similar to a SQL WHERE
+                clause ("AREA='UY' AND FREQ <> 'A'") or a Python expression
+                ("REF_AREA=='UY' and FREQ != 'A'") or one of the various
+                filters the `pysdmx.api.dc.query` module offers, including
+                `MultiFilter`.
 
         Returns:
             Dataflow: An object containing detailed information about

--- a/src/pysdmx/api/dc/pd.py
+++ b/src/pysdmx/api/dc/pd.py
@@ -286,9 +286,7 @@ class PandasConnector(BasicConnector):
                 },
             ) from error
 
-    def __cleanup_temp_file(
-        self, temp_path: Optional[pathlib.Path]
-    ) -> None:
+    def __cleanup_temp_file(self, temp_path: Optional[pathlib.Path]) -> None:
         if temp_path is not None:
             with contextlib.suppress(OSError):
                 temp_path.unlink(missing_ok=True)

--- a/src/pysdmx/api/dc/pd.py
+++ b/src/pysdmx/api/dc/pd.py
@@ -82,7 +82,9 @@ class PandasConnector(BasicConnector):
         return self.__conn.dataflows(search_term)
 
     def dataflow(
-        self, dataflow: Union[str, MaintainableIdentification]
+        self,
+        dataflow: Union[str, MaintainableIdentification],
+        filters: Optional[Union[BasicFilter, str]] = None,
     ) -> Dataflow:
         """Retrieve information about a dataflow.
 
@@ -96,6 +98,11 @@ class PandasConnector(BasicConnector):
                 shorthand notation (`agency:id(version)`) is also acceptable.
                 - An object implementing the `MaintainableIdentification`
                 protocol (e.g., instances of `DataflowRef` or `Dataflow`).
+            filters: The data query filters, if any. This can be a string
+                similar to a SQL WHERE clause ("AREA='UY' AND FREQ <> 'A'")
+                or a Python expression ("REF_AREA=='UY' and FREQ != 'A'") or
+                one of the various filters the `pysdmx.api.dc.query` module
+                offers, including `MultiFilter`.
 
         Returns:
             Dataflow: An object containing detailed information about
@@ -118,7 +125,7 @@ class PandasConnector(BasicConnector):
             errors.Unavailable: In case the targeted service could not be
                 reached.
         """
-        return self.__conn.dataflow(dataflow)
+        return self.__conn.dataflow(dataflow, filters)
 
     def data(
         self,

--- a/src/pysdmx/api/dc/rest.py
+++ b/src/pysdmx/api/dc/rest.py
@@ -129,11 +129,15 @@ class SdmxConnector(BasicConnector):
                 - A string representing the SDMX URN of the dataflow.
                 - An object implementing the `MaintainableIdentification`
                   protocol (e.g., instances of `DataflowRef` or `Dataflow`).
-            filters: The data query filters, if any. This can be a string
-                similar to a SQL WHERE clause ("AREA='UY' AND FREQ <> 'A'")
-                or a Python expression ("REF_AREA=='UY' and FREQ != 'A'") or
-                one of the various filters the `pysdmx.api.dc.query` module
-                offers, including `MultiFilter`.
+            filters: Filters used to scope the data availability
+                information for the selected dataflow. If not supplied,
+                information about the full dataflow is returned. If
+                supplied, information about the matching subset is
+                returned. This can be a string similar to a SQL WHERE
+                clause ("AREA='UY' AND FREQ <> 'A'") or a Python expression
+                ("REF_AREA=='UY' and FREQ != 'A'") or one of the various
+                filters the `pysdmx.api.dc.query` module offers, including
+                `MultiFilter`.
 
         Returns:
             Dataflow: An object containing detailed information about

--- a/src/pysdmx/api/dc/rest.py
+++ b/src/pysdmx/api/dc/rest.py
@@ -12,6 +12,7 @@ from pysdmx.api.dc import (
     MaintainableIdentification,
 )
 from pysdmx.api.dc.query import BasicFilter
+from pysdmx.api.dc.query.util import parse_query
 from pysdmx.api.dc.util import prepare_basic_data_query
 from pysdmx.api.qb import (
     ApiVersion,
@@ -113,7 +114,9 @@ class SdmxConnector(BasicConnector):
         return tuple(sorted(flows, key=self.__sort_maintainable))
 
     def dataflow(
-        self, dataflow: Union[str, MaintainableIdentification]
+        self,
+        dataflow: Union[str, MaintainableIdentification],
+        filters: Optional[Union[BasicFilter, str]] = None,
     ) -> Dataflow:
         """Retrieve information about a dataflow.
 
@@ -126,6 +129,11 @@ class SdmxConnector(BasicConnector):
                 - A string representing the SDMX URN of the dataflow.
                 - An object implementing the `MaintainableIdentification`
                   protocol (e.g., instances of `DataflowRef` or `Dataflow`).
+            filters: The data query filters, if any. This can be a string
+                similar to a SQL WHERE clause ("AREA='UY' AND FREQ <> 'A'")
+                or a Python expression ("REF_AREA=='UY' and FREQ != 'A'") or
+                one of the various filters the `pysdmx.api.dc.query` module
+                offers, including `MultiFilter`.
 
         Returns:
             Dataflow: An object containing detailed information about
@@ -159,11 +167,15 @@ class SdmxConnector(BasicConnector):
             else dataflow.agency
         )
 
+        if isinstance(filters, str):
+            filters = parse_query(filters)  # type: ignore[assignment]
+
         q = AvailabilityQuery(
             DataContext.DATAFLOW,
             aid,
             dataflow.id,
             dataflow.version,
+            components=filters,  # type: ignore[arg-type]
             references=StructureReference.ALL,
             mode=AvailabilityMode.EXACT,
         )

--- a/src/pysdmx/api/qb/availability.py
+++ b/src/pysdmx/api/qb/availability.py
@@ -7,6 +7,8 @@ from typing import Optional, Sequence, Union
 import msgspec
 
 from pysdmx.api.dc.query import (
+    BooleanFilter,
+    DateTimeFilter,
     MultiFilter,
     NumberFilter,
     TextFilter,
@@ -88,7 +90,14 @@ class AvailabilityQuery(_CoreDataQuery, frozen=True, omit_defaults=True):
     version: Union[str, Sequence[str]] = REST_ALL
     key: Union[str, Sequence[str]] = REST_ALL
     component_id: Union[str, Sequence[str]] = REST_ALL
-    components: Union[MultiFilter, None, NumberFilter, TextFilter] = None
+    components: Union[
+        BooleanFilter,
+        DateTimeFilter,
+        MultiFilter,
+        None,
+        NumberFilter,
+        TextFilter,
+    ] = None
     updated_after: Optional[datetime] = None
     references: Union[StructureReference, Sequence[StructureReference]] = (
         StructureReference.NONE
@@ -157,6 +166,8 @@ class AvailabilityQuery(_CoreDataQuery, frozen=True, omit_defaults=True):
 
     def __get_short_v2_qs(self) -> str:
         qs = ""
+        if self.components:
+            qs += self._create_component_filters(self.components)
         if self.updated_after:
             qs = super()._append_qs_param(
                 qs,

--- a/tests/api/dc/test_pd_client.py
+++ b/tests/api/dc/test_pd_client.py
@@ -4,6 +4,7 @@ import pytest
 
 from pysdmx.api.dc.pd import PandasConnector
 from pysdmx.api.dc.query import Operator, TextFilter
+from pysdmx.errors import InternalError
 from pysdmx.model import Dataflow, Reference
 
 
@@ -494,3 +495,19 @@ def test_data_query_no_schema_query(respx_mock, client, query_data, csv_data):
     )
 
     assert len(data) == 20  # 20 observations
+
+
+def test_data_query_tempfile_creation_error(client, mocker):
+    mocker.patch(
+        "tempfile.NamedTemporaryFile",
+        side_effect=OSError("cannot create temporary file"),
+    )
+    dfref = Reference("Dataflow", "BIS", "BIS_DER", "1.0")
+
+    with pytest.raises(InternalError, match="Unexpected I/O issue"):
+        client.data(
+            dfref,
+            infer_index=False,
+            infer_series_keys=False,
+            apply_schema=False,
+        )

--- a/tests/api/dc/test_pd_client.py
+++ b/tests/api/dc/test_pd_client.py
@@ -1,10 +1,13 @@
+import pathlib
+import tempfile
+
 import httpx
 import pandas as pd
 import pytest
 
 from pysdmx.api.dc.pd import PandasConnector
 from pysdmx.api.dc.query import Operator, TextFilter
-from pysdmx.errors import InternalError
+from pysdmx.errors import InternalError, NotFound
 from pysdmx.model import Dataflow, Reference
 
 
@@ -511,3 +514,75 @@ def test_data_query_tempfile_creation_error(client, mocker):
             infer_series_keys=False,
             apply_schema=False,
         )
+
+
+@pytest.fixture
+def temp_file_creator(tmp_path):
+    created_paths = []
+    named_temp_file = tempfile.NamedTemporaryFile
+
+    def create_temp_file(*args, **kwargs):
+        handle = named_temp_file(*args, dir=tmp_path, **kwargs)
+        created_paths.append(pathlib.Path(handle.name))
+        return handle
+
+    return create_temp_file, created_paths
+
+
+@pytest.mark.parametrize(
+    (
+        "raised_error",
+        "expected_error",
+        "error_match",
+    ),
+    [
+        (
+            OSError("cannot write temporary file"),
+            InternalError,
+            "Unexpected I/O issue",
+        ),
+        (
+            NotFound("No data", "The requested data were not found."),
+            NotFound,
+            None,
+        ),
+        (KeyboardInterrupt(), KeyboardInterrupt, None),
+    ],
+    ids=[
+        "maps-unexpected-error",
+        "reraises-pysdmx-error",
+        "reraises-keyboard-interrupt",
+    ],
+)
+def test_write_temp_csv_error_handling_and_cleanup(
+    client,
+    mocker,
+    temp_file_creator,
+    raised_error,
+    expected_error,
+    error_match,
+):
+    create_temp_file, created_paths = temp_file_creator
+
+    def fail_stream(*args, **kwargs):
+        raise raised_error
+
+    mocker.patch("tempfile.NamedTemporaryFile", side_effect=create_temp_file)
+    mocker.patch.object(
+        client._PandasConnector__client,
+        "stream_data",
+        side_effect=fail_stream,
+    )
+
+    if error_match:
+        with pytest.raises(expected_error, match=error_match) as exc_info:
+            client._PandasConnector__write_temp_csv(object())
+    else:
+        with pytest.raises(expected_error) as exc_info:
+            client._PandasConnector__write_temp_csv(object())
+
+    if error_match is None:
+        assert exc_info.value is raised_error
+
+    assert len(created_paths) == 1
+    assert not created_paths[0].exists()

--- a/tests/api/dc/test_pd_client.py
+++ b/tests/api/dc/test_pd_client.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from pysdmx.api.dc.pd import PandasConnector
+from pysdmx.api.dc.query import Operator, TextFilter
 from pysdmx.model import Dataflow, Reference
 
 
@@ -100,6 +101,40 @@ def test_dataflow(client, mock_dataflow, dataflow):
     flow = client.dataflow(ref)
 
     assert flow == dataflow
+    assert mock_dataflow.call_count == 1
+    assert len(mock_dataflow.call_args.args) == 2
+    assert mock_dataflow.call_args.args[0] == ref
+    assert mock_dataflow.call_args.args[1] is None
+    assert not mock_dataflow.call_args.kwargs
+
+
+def test_dataflow_with_filter_object(client, mock_dataflow, dataflow):
+    mock_dataflow.return_value = dataflow
+    ref = Reference("Dataflow", "BIS", "CBS", "1.0")
+    flt = TextFilter("FREQ", Operator.EQUALS, "M")
+
+    flow = client.dataflow(ref, filters=flt)
+
+    assert flow == dataflow
+    assert mock_dataflow.call_count == 1
+    assert len(mock_dataflow.call_args.args) == 2
+    assert mock_dataflow.call_args.args[0] == ref
+    assert mock_dataflow.call_args.args[1] == flt
+    assert not mock_dataflow.call_args.kwargs
+
+
+def test_dataflow_with_filter_string(client, mock_dataflow, dataflow):
+    mock_dataflow.return_value = dataflow
+    ref = Reference("Dataflow", "BIS", "CBS", "1.0")
+
+    flow = client.dataflow(ref, filters="FREQ='M'")
+
+    assert flow == dataflow
+    assert mock_dataflow.call_count == 1
+    assert len(mock_dataflow.call_args.args) == 2
+    assert mock_dataflow.call_args.args[0] == ref
+    assert mock_dataflow.call_args.args[1] == "FREQ='M'"
+    assert not mock_dataflow.call_args.kwargs
 
 
 def test_data_query(

--- a/tests/api/dc/test_rest_client.py
+++ b/tests/api/dc/test_rest_client.py
@@ -1,6 +1,7 @@
 import httpx
 import pytest
 
+from pysdmx.api.dc.query import Operator, TextFilter
 from pysdmx.api.dc.rest import SdmxConnector
 from pysdmx.errors import InternalError, NotFound
 from pysdmx.model import Agency, Dataflow, DataflowRef
@@ -50,6 +51,11 @@ def query_flows(host):
 @pytest.fixture
 def query_availability(host):
     return f"{host}/availability/dataflow/BIS/CBS/1.0?references=all"
+
+
+@pytest.fixture
+def query_availability_filtered(host):
+    return f"{host}/availability/dataflow/BIS/CBS/1.0?c[FREQ]=M&references=all"
 
 
 @pytest.fixture
@@ -150,6 +156,40 @@ def test_availability_agency(
     dfref = Dataflow("CBS", agency=Agency("BIS"))
 
     flow = rest_client.dataflow(dfref)
+
+    assert isinstance(flow, Dataflow)
+
+
+def test_availability_with_filters(
+    respx_mock,
+    rest_client,
+    query_availability_filtered,
+    json_availability,
+):
+    respx_mock.get(query_availability_filtered).mock(
+        return_value=httpx.Response(200, content=json_availability)
+    )
+    dfref = DataflowRef("BIS", "CBS", "1.0")
+
+    flow = rest_client.dataflow(
+        dfref, filters=TextFilter("FREQ", Operator.EQUALS, "M")
+    )
+
+    assert isinstance(flow, Dataflow)
+
+
+def test_availability_with_string_filters(
+    respx_mock,
+    rest_client,
+    query_availability_filtered,
+    json_availability,
+):
+    respx_mock.get(query_availability_filtered).mock(
+        return_value=httpx.Response(200, content=json_availability)
+    )
+    dfref = DataflowRef("BIS", "CBS", "1.0")
+
+    flow = rest_client.dataflow(dfref, filters="FREQ='M'")
 
     assert isinstance(flow, Dataflow)
 

--- a/tests/api/qb/availability/test_availability_query_c_filter.py
+++ b/tests/api/qb/availability/test_availability_query_c_filter.py
@@ -38,6 +38,19 @@ def test_availability_unsupported_operator(api_version: ApiVersion):
 @pytest.mark.parametrize(
     "api_version", (v for v in ApiVersion if v >= ApiVersion.V2_0_0)
 )
+def test_availability_one_text_comp_eq_short(api_version: ApiVersion):
+    flt = TextFilter("FREQ", Operator.EQUALS, "M")
+    expected = "/availability?c[FREQ]=M"
+
+    q = AvailabilityQuery(components=flt)
+    url = q.get_url(api_version, True)
+
+    assert url == expected
+
+
+@pytest.mark.parametrize(
+    "api_version", (v for v in ApiVersion if v >= ApiVersion.V2_0_0)
+)
 def test_availability_one_text_comp_eq(api_version: ApiVersion):
     flt = TextFilter("FREQ", Operator.EQUALS, "M")
     expected = "/availability/*/*/*/*/*/*?c[FREQ]=M&references=none&mode=exact"


### PR DESCRIPTION
The SDMX-TWG decided to add support for `c` filters in the availability query defined in the "data discovery and retrieval" profile.

The purpose of this PR is to add support for this in the two `pysdmx` connectors supporting that profile.

While working on this, an issue was discovered in `src/pysdmx/api/qb/availability.py` (short queries would not include the `c` filters).

Close #632