### PR TITLE
Read Dataflow stubs without a Structure reference

### DIFF
--- a/src/pysdmx/io/xml/__structure_aux_reader.py
+++ b/src/pysdmx/io/xml/__structure_aux_reader.py
@@ -2129,7 +2129,7 @@ class StructureParser(Struct):
             elif self.is_sdmx_30 and VERSION in element:
                 element[IS_FINAL_LOW] = is_final(element[VERSION])
 
-            if item == DFW:
+            if item == DFW and STRUCTURE in element:
                 if isinstance(element[STRUCTURE], str):
                     ref_obj = parse_urn(element[STRUCTURE])
                     reference_str = (

--- a/tests/io/xml/sdmx21/reader/samples/dataflow_no_structure.xml
+++ b/tests/io/xml/sdmx21/reader/samples/dataflow_no_structure.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Dataflows>
+			<str:Dataflow id="DF_STUB" agencyID="MD" version="1.0" isExternalReference="false" isFinal="false">
+				<com:Name xml:lang="en">Stub dataflow without a structure reference</com:Name>
+			</str:Dataflow>
+		</str:Dataflows>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx21/reader/test_reader.py
+++ b/tests/io/xml/sdmx21/reader/test_reader.py
@@ -1512,3 +1512,14 @@ def test_category_scheme_21_enrichment_edge_cases(samples_folder):
         "urn:sdmx:org.sdmx.infomodel.categoryscheme."
         "Category=BIS:CS_ABSENT(1.0).Z"
     )
+
+
+def test_dataflow_stub_without_structure(samples_folder):
+    data_path = samples_folder / "dataflow_no_structure.xml"
+    input_str, read_format = process_string_to_read(data_path)
+    assert read_format == Format.STRUCTURE_SDMX_ML_2_1
+    result = read_sdmx(input_str, validate=False).structures
+    assert result is not None
+    df = result[0]
+    assert df.short_urn == "Dataflow=MD:DF_STUB(1.0)"
+    assert df.structure is None


### PR DESCRIPTION
# Summary

The SDMX-ML reader assumed every `<Dataflow>` element carries a `<Structure>`
(its DSD reference). A stub listing (`detail=allstubs`, or any response omitting
the DSD reference) returns dataflows without `<Structure>`, and the reader
crashed (`KeyError` on `element[STRUCTURE]`).

## Fix

`src/pysdmx/io/xml/__structure_aux_reader.py` — guard the reference resolution:

    if item == DFW and STRUCTURE in element:   # was: if item == DFW:

A dataflow without a Structure reference now reads as a `Dataflow` with
`structure=None`.

## Tests

- New sample `tests/io/xml/sdmx21/reader/samples/dataflow_no_structure.xml`.
- New `sdmx21/.../test_dataflow_stub_without_structure` (asserts `structure is None`).
---
Closes #653 