### PR TITLE
Fix SDMX-ML readers and writers crash when Dataflow.structure is a DSD object or None

### DIFF
--- a/src/pysdmx/io/xml/__structure_aux_reader.py
+++ b/src/pysdmx/io/xml/__structure_aux_reader.py
@@ -2129,7 +2129,7 @@ class StructureParser(Struct):
             elif self.is_sdmx_30 and VERSION in element:
                 element[IS_FINAL_LOW] = is_final(element[VERSION])
 
-            if item == DFW:
+            if item == DFW and STRUCTURE in element:
                 if isinstance(element[STRUCTURE], str):
                     ref_obj = parse_urn(element[STRUCTURE])
                     reference_str = (

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -928,13 +928,11 @@ def __write_enumeration(
 
 
 def __write_structure(
-    item: Optional[Union[str, DataStructureDefinition]],
+    item: Union[str, DataStructureDefinition],
     indent: str,
     references_30: bool = False,
 ) -> str:
     """Writes the dataflow structure to the XML file."""
-    if item is None:
-        return ""
     if isinstance(item, DataStructureDefinition):
         item = item.short_urn
     ref = parse_short_urn(item)
@@ -1857,7 +1855,7 @@ def __write_scheme(  # noqa: C901
 
     outfile += components
 
-    if scheme == DFW:
+    if scheme == DFW and item_scheme.structure is not None:
         outfile += __write_structure(
             item_scheme.structure, add_indent(indent), references_30
         )

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -933,9 +933,9 @@ def __write_structure(
     references_30: bool = False,
 ) -> str:
     """Writes the dataflow structure to the XML file."""
-    if isinstance(item, DataStructureDefinition):
-        item = item.short_urn
-    ref = parse_short_urn(item)
+    ref = parse_short_urn(
+        item.short_urn if isinstance(item, DataStructureDefinition) else item
+    )
     outfile = f"{indent}<{ABBR_STR}:Structure>"
     if references_30:
         outfile += (

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -928,9 +928,15 @@ def __write_enumeration(
 
 
 def __write_structure(
-    item: str, indent: str, references_30: bool = False
+    item: Optional[Union[str, DataStructureDefinition]],
+    indent: str,
+    references_30: bool = False,
 ) -> str:
     """Writes the dataflow structure to the XML file."""
+    if item is None:
+        return ""
+    if isinstance(item, DataStructureDefinition):
+        item = item.short_urn
     ref = parse_short_urn(item)
     outfile = f"{indent}<{ABBR_STR}:Structure>"
     if references_30:

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -1612,6 +1612,70 @@ def test_writer_dataflow(complete_header, dataflow):
     assert "Dataflow=BIS:WEBSTATS_DER_DATAFLOW(1.0)" in result
 
 
+def test_writer_dataflow_with_dsd_object(complete_header):
+    dsd = DataStructureDefinition(
+        id="DSD_X",
+        agency="MD",
+        version="1.0",
+        name="x",
+        components=Components([]),
+    )
+    dataflow = Dataflow(
+        id="DF_X",
+        agency="MD",
+        version="1.0",
+        name="x",
+        structure=dsd,
+    )
+
+    result = write(
+        [dataflow],
+        header=complete_header,
+        prettyprint=True,
+    )
+
+    assert (
+        '<Ref package="datastructure" agencyID="MD" '
+        'id="DSD_X" version="1.0" class="DataStructure"/>' in result
+    )
+
+
+def test_writer_dataflow_without_structure(complete_header):
+    dataflow = Dataflow(
+        id="DF_X",
+        agency="MD",
+        version="1.0",
+        name="x",
+    )
+
+    result = write(
+        [dataflow],
+        header=complete_header,
+        prettyprint=True,
+    )
+
+    assert "str:Structure" not in result
+    assert 'id="DF_X"' in result
+
+
+def test_write_read_dataflow_without_structure(complete_header):
+    dataflow = Dataflow(
+        id="DF_X",
+        agency="MD",
+        version="1.0",
+        name="x",
+    )
+
+    write_result = write(
+        [dataflow],
+        header=complete_header,
+        prettyprint=True,
+    )
+    read_result = read(write_result, validate=True)
+
+    assert read_result == [dataflow]
+
+
 def test_read_write(read_write_sample, read_write_header):
     content, read_format = process_string_to_read(read_write_sample)
     assert read_format == Format.STRUCTURE_SDMX_ML_2_1

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -1621,19 +1621,19 @@ def test_writer_dataflow_with_dsd_object(
     result = write(
         [dataflow_with_dsd],
         header=complete_header,
-        prettyprint=True,
+        prettyprint=False,
     )
 
     assert (
-        "\t\t\t\t<str:Structure>\n"
-        '\t\t\t\t\t<Ref package="datastructure" agencyID="BIS" '
-        'id="BIS_DER" version="1.0" class="DataStructure"/>\n'
-        "\t\t\t\t</str:Structure>" in result
+        "<str:Structure>"
+        '<Ref package="datastructure" agencyID="BIS" '
+        'id="BIS_DER" version="1.0" class="DataStructure"/>'
+        "</str:Structure>" in result.replace("\t", "")
     )
     assert result == write(
         [dataflow],
         header=complete_header,
-        prettyprint=True,
+        prettyprint=False,
     )
 
 
@@ -1643,11 +1643,11 @@ def test_writer_dataflow_without_structure(complete_header, dataflow):
     result = write(
         [dataflow_stub],
         header=complete_header,
-        prettyprint=True,
+        prettyprint=False,
     )
 
     assert (
-        "\t\t\t<str:Dataflow "
+        "<str:Dataflow "
         'id="WEBSTATS_DER_DATAFLOW" '
         'urn="urn:sdmx:org.sdmx.infomodel.datastructure.'
         'Dataflow=BIS:WEBSTATS_DER_DATAFLOW(1.0)" '
@@ -1656,12 +1656,11 @@ def test_writer_dataflow_without_structure(complete_header, dataflow):
         'validTo="2021-12-31T00:00:00" '
         'isExternalReference="true" '
         'isFinal="true" '
-        'agencyID="BIS">\n'
-        '\t\t\t\t<com:Name xml:lang="en">'
-        "OTC derivatives turnover</com:Name>\n"
-        '\t\t\t\t<com:Description xml:lang="en">'
-        "OTC derivatives and FX spot - turnover</com:Description>\n"
-        "\t\t\t</str:Dataflow>" in result
+        'agencyID="BIS">'
+        '<com:Name xml:lang="en">OTC derivatives turnover</com:Name>'
+        '<com:Description xml:lang="en">'
+        "OTC derivatives and FX spot - turnover</com:Description>"
+        "</str:Dataflow>" in result.replace("\t", "")
     )
 
 
@@ -1673,7 +1672,7 @@ def test_write_read_dataflow_with_dsd_object(
     write_result = write(
         [dataflow_with_dsd],
         header=complete_header,
-        prettyprint=True,
+        prettyprint=False,
     )
     read_result = read(write_result, validate=True)
 
@@ -1687,7 +1686,7 @@ def test_write_read_dataflow_without_structure(complete_header, dataflow):
     write_result = write(
         [dataflow_stub],
         header=complete_header,
-        prettyprint=True,
+        prettyprint=False,
     )
     read_result = read(write_result, validate=True)
 

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
+from msgspec.structs import replace
 
 from pysdmx.errors import Invalid, NotImplemented
 from pysdmx.io import read_sdmx
@@ -1612,68 +1613,85 @@ def test_writer_dataflow(complete_header, dataflow):
     assert "Dataflow=BIS:WEBSTATS_DER_DATAFLOW(1.0)" in result
 
 
-def test_writer_dataflow_with_dsd_object(complete_header):
-    dsd = DataStructureDefinition(
-        id="DSD_X",
-        agency="MD",
-        version="1.0",
-        name="x",
-        components=Components([]),
-    )
-    dataflow = Dataflow(
-        id="DF_X",
-        agency="MD",
-        version="1.0",
-        name="x",
-        structure=dsd,
-    )
+def test_writer_dataflow_with_dsd_object(
+    complete_header, dataflow, partial_datastructure
+):
+    dataflow_with_dsd = replace(dataflow, structure=partial_datastructure)
 
     result = write(
-        [dataflow],
+        [dataflow_with_dsd],
         header=complete_header,
         prettyprint=True,
     )
 
     assert (
-        '<Ref package="datastructure" agencyID="MD" '
-        'id="DSD_X" version="1.0" class="DataStructure"/>' in result
+        "\t\t\t\t<str:Structure>\n"
+        '\t\t\t\t\t<Ref package="datastructure" agencyID="BIS" '
+        'id="BIS_DER" version="1.0" class="DataStructure"/>\n'
+        "\t\t\t\t</str:Structure>" in result
     )
-
-
-def test_writer_dataflow_without_structure(complete_header):
-    dataflow = Dataflow(
-        id="DF_X",
-        agency="MD",
-        version="1.0",
-        name="x",
-    )
-
-    result = write(
+    assert result == write(
         [dataflow],
         header=complete_header,
         prettyprint=True,
     )
 
-    assert "str:Structure" not in result
-    assert 'id="DF_X"' in result
 
+def test_writer_dataflow_without_structure(complete_header, dataflow):
+    dataflow_stub = replace(dataflow, structure=None)
 
-def test_write_read_dataflow_without_structure(complete_header):
-    dataflow = Dataflow(
-        id="DF_X",
-        agency="MD",
-        version="1.0",
-        name="x",
+    result = write(
+        [dataflow_stub],
+        header=complete_header,
+        prettyprint=True,
     )
 
+    assert (
+        "\t\t\t<str:Dataflow "
+        'id="WEBSTATS_DER_DATAFLOW" '
+        'urn="urn:sdmx:org.sdmx.infomodel.datastructure.'
+        'Dataflow=BIS:WEBSTATS_DER_DATAFLOW(1.0)" '
+        'version="1.0" '
+        'validFrom="2021-01-01T00:00:00" '
+        'validTo="2021-12-31T00:00:00" '
+        'isExternalReference="true" '
+        'isFinal="true" '
+        'agencyID="BIS">\n'
+        '\t\t\t\t<com:Name xml:lang="en">'
+        "OTC derivatives turnover</com:Name>\n"
+        '\t\t\t\t<com:Description xml:lang="en">'
+        "OTC derivatives and FX spot - turnover</com:Description>\n"
+        "\t\t\t</str:Dataflow>" in result
+    )
+
+
+def test_write_read_dataflow_with_dsd_object(
+    complete_header, dataflow, partial_datastructure
+):
+    dataflow_with_dsd = replace(dataflow, structure=partial_datastructure)
+
     write_result = write(
-        [dataflow],
+        [dataflow_with_dsd],
         header=complete_header,
         prettyprint=True,
     )
     read_result = read(write_result, validate=True)
 
+    # The DSD object is read back as its short URN reference.
     assert read_result == [dataflow]
+
+
+def test_write_read_dataflow_without_structure(complete_header, dataflow):
+    dataflow_stub = replace(dataflow, structure=None)
+
+    write_result = write(
+        [dataflow_stub],
+        header=complete_header,
+        prettyprint=True,
+    )
+    read_result = read(write_result, validate=True)
+
+    assert read_result == [dataflow_stub]
 
 
 def test_read_write(read_write_sample, read_write_header):

--- a/tests/io/xml/sdmx30/writer/samples/structure_dataflow_stub.xml
+++ b/tests/io/xml/sdmx30/writer/samples/structure_dataflow_stub.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_0/message https://registry.sdmx.org/schemas/v3_0/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Dataflows>
+			<str:Dataflow id="WEBSTATS_DER_DATAFLOW" urn="urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS:WEBSTATS_DER_DATAFLOW(1.0)" version="1.0" validFrom="2021-01-01T00:00:00" validTo="2021-12-31T00:00:00" isExternalReference="false" agencyID="BIS">
+				<com:Name xml:lang="en">OTC derivatives turnover</com:Name>
+				<com:Description xml:lang="en">OTC derivatives and FX spot - turnover</com:Description>
+			</str:Dataflow>
+		</str:Dataflows>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx30/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx30/writer/test_structures_writing.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
+from msgspec.structs import replace
 
 from pysdmx.io import write_sdmx
 from pysdmx.io.format import Format
@@ -595,6 +596,17 @@ def dataflow():
 
 
 @pytest.fixture
+def partial_datastructure():
+    return DataStructureDefinition(
+        agency="BIS",
+        id="BIS_DER",
+        components=Components([]),
+        name="BIS derivatives statistics",
+        version="1.0",
+    )
+
+
+@pytest.fixture
 def vtlmapping_scheme():
     return VtlMappingScheme(
         id="VTLMS1",
@@ -748,6 +760,15 @@ def datastructure_sample():
 @pytest.fixture
 def structures_dataflow_sample():
     base_path = Path(__file__).parent / "samples" / "structure_dataflow.xml"
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def structures_dataflow_stub_sample():
+    base_path = (
+        Path(__file__).parent / "samples" / "structure_dataflow_stub.xml"
+    )
     with open(base_path, "r") as f:
         return f.read()
 
@@ -1239,50 +1260,64 @@ def test_dataflow(complete_header, dataflow, structures_dataflow_sample):
     assert result == structures_dataflow_sample
 
 
-def test_dataflow_with_dsd_object(complete_header):
-    dsd = DataStructureDefinition(
-        id="DSD_X",
-        agency="MD",
-        version="1.0",
-        name="x",
-        components=Components([]),
-    )
-    dataflow = Dataflow(
-        id="DF_X",
-        agency="MD",
-        version="1.0",
-        name="x",
-        structure=dsd,
-    )
+def test_dataflow_with_dsd_object(
+    complete_header,
+    dataflow,
+    partial_datastructure,
+    structures_dataflow_sample,
+):
+    dataflow_with_dsd = replace(dataflow, structure=partial_datastructure)
 
     result = write(
-        [dataflow],
+        [dataflow_with_dsd],
         header=complete_header,
         prettyprint=True,
     )
 
-    assert (
-        "<str:Structure>urn:sdmx:org.sdmx.infomodel.datastructure."
-        "DataStructure=MD:DSD_X(1.0)</str:Structure>" in result
-    )
+    assert result == structures_dataflow_sample
 
 
-def test_dataflow_without_structure(complete_header):
-    dataflow = Dataflow(
-        id="DF_X",
-        agency="MD",
-        version="1.0",
-        name="x",
-    )
+def test_dataflow_without_structure(
+    complete_header, dataflow, structures_dataflow_stub_sample
+):
+    dataflow_stub = replace(dataflow, structure=None)
 
     result = write(
-        [dataflow],
+        [dataflow_stub],
         header=complete_header,
         prettyprint=True,
     )
 
-    assert "str:Structure" not in result
-    assert 'id="DF_X"' in result
+    assert result == structures_dataflow_stub_sample
+
+
+def test_dataflow_with_dsd_object_round_trip(
+    complete_header, dataflow, partial_datastructure
+):
+    dataflow_with_dsd = replace(dataflow, structure=partial_datastructure)
+
+    write_result = write(
+        [dataflow_with_dsd],
+        header=complete_header,
+        prettyprint=True,
+    )
+    read_result = read(write_result, validate=True)
+
+    # The DSD object is read back as its short URN reference.
+    assert read_result == [dataflow]
+
+
+def test_dataflow_without_structure_round_trip(complete_header, dataflow):
+    dataflow_stub = replace(dataflow, structure=None)
+
+    write_result = write(
+        [dataflow_stub],
+        header=complete_header,
+        prettyprint=True,
+    )
+    read_result = read(write_result, validate=True)
+
+    assert read_result == [dataflow_stub]
 
 
 def test_transformation_scheme(

--- a/tests/io/xml/sdmx30/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx30/writer/test_structures_writing.py
@@ -1239,6 +1239,52 @@ def test_dataflow(complete_header, dataflow, structures_dataflow_sample):
     assert result == structures_dataflow_sample
 
 
+def test_dataflow_with_dsd_object(complete_header):
+    dsd = DataStructureDefinition(
+        id="DSD_X",
+        agency="MD",
+        version="1.0",
+        name="x",
+        components=Components([]),
+    )
+    dataflow = Dataflow(
+        id="DF_X",
+        agency="MD",
+        version="1.0",
+        name="x",
+        structure=dsd,
+    )
+
+    result = write(
+        [dataflow],
+        header=complete_header,
+        prettyprint=True,
+    )
+
+    assert (
+        "<str:Structure>urn:sdmx:org.sdmx.infomodel.datastructure."
+        "DataStructure=MD:DSD_X(1.0)</str:Structure>" in result
+    )
+
+
+def test_dataflow_without_structure(complete_header):
+    dataflow = Dataflow(
+        id="DF_X",
+        agency="MD",
+        version="1.0",
+        name="x",
+    )
+
+    result = write(
+        [dataflow],
+        header=complete_header,
+        prettyprint=True,
+    )
+
+    assert "str:Structure" not in result
+    assert 'id="DF_X"' in result
+
+
 def test_transformation_scheme(
     complete_header,
     transformation_scheme_structure,

--- a/tests/io/xml/sdmx30/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx30/writer/test_structures_writing.py
@@ -1299,7 +1299,7 @@ def test_dataflow_with_dsd_object_round_trip(
     write_result = write(
         [dataflow_with_dsd],
         header=complete_header,
-        prettyprint=True,
+        prettyprint=False,
     )
     read_result = read(write_result, validate=True)
 
@@ -1313,7 +1313,7 @@ def test_dataflow_without_structure_round_trip(complete_header, dataflow):
     write_result = write(
         [dataflow_stub],
         header=complete_header,
-        prettyprint=True,
+        prettyprint=False,
     )
     read_result = read(write_result, validate=True)
 

--- a/tests/io/xml/sdmx31/writer/samples/structure_dataflow_stub.xml
+++ b/tests/io/xml/sdmx31/writer/samples/structure_dataflow_stub.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:Structure xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v3_1/message https://registry.sdmx.org/schemas/v3_1/SDMXMessage.xsd">
+	<mes:Header>
+		<mes:ID>ID</mes:ID>
+		<mes:Test>false</mes:Test>
+		<mes:Prepared>2021-01-01T00:00:00</mes:Prepared>
+		<mes:Sender id="ZZZ"/>
+		<mes:Receiver id="Not_Supplied"/>
+		<mes:Source>PySDMX</mes:Source>
+	</mes:Header>
+	<mes:Structures>
+		<str:Dataflows>
+			<str:Dataflow id="WEBSTATS_DER_DATAFLOW" urn="urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=BIS:WEBSTATS_DER_DATAFLOW(1.0)" version="1.0" validFrom="2021-01-01T00:00:00" validTo="2021-12-31T00:00:00" isExternalReference="false" agencyID="BIS">
+				<com:Name xml:lang="en">OTC derivatives turnover</com:Name>
+				<com:Description xml:lang="en">OTC derivatives and FX spot - turnover</com:Description>
+			</str:Dataflow>
+		</str:Dataflows>
+	</mes:Structures>
+</mes:Structure>

--- a/tests/io/xml/sdmx31/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx31/writer/test_structures_writing.py
@@ -909,7 +909,7 @@ def test_dataflow_with_dsd_object_round_trip(
     write_result = write(
         [dataflow_with_dsd],
         header=complete_header,
-        prettyprint=True,
+        prettyprint=False,
     )
     read_result = read(write_result, validate=True)
 
@@ -923,7 +923,7 @@ def test_dataflow_without_structure_round_trip(complete_header, dataflow):
     write_result = write(
         [dataflow_stub],
         header=complete_header,
-        prettyprint=True,
+        prettyprint=False,
     )
     read_result = read(write_result, validate=True)
 

--- a/tests/io/xml/sdmx31/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx31/writer/test_structures_writing.py
@@ -3,11 +3,13 @@ from datetime import datetime
 from pathlib import Path
 
 import pytest
+from msgspec.structs import replace
 
 from pysdmx.errors import Invalid
 from pysdmx.io import write_sdmx
 from pysdmx.io.format import Format
 from pysdmx.io.reader import read_sdmx as read_sdmx
+from pysdmx.io.xml.sdmx31.reader.structure import read
 from pysdmx.io.xml.sdmx31.writer.structure import write
 from pysdmx.model import (
     Agency,
@@ -537,6 +539,17 @@ def dataflow():
 
 
 @pytest.fixture
+def partial_datastructure():
+    return DataStructureDefinition(
+        agency="BIS",
+        id="BIS_DER",
+        components=Components([]),
+        name="BIS derivatives statistics",
+        version="1.0",
+    )
+
+
+@pytest.fixture
 def dataflow2():
     return Dataflow(
         agency="MD",
@@ -601,6 +614,15 @@ def datastructure_sample():
 @pytest.fixture
 def structures_dataflow_sample():
     base_path = Path(__file__).parent / "samples" / "structure_dataflow.xml"
+    with open(base_path, "r") as f:
+        return f.read()
+
+
+@pytest.fixture
+def structures_dataflow_stub_sample():
+    base_path = (
+        Path(__file__).parent / "samples" / "structure_dataflow_stub.xml"
+    )
     with open(base_path, "r") as f:
         return f.read()
 
@@ -847,50 +869,65 @@ def test_dataflow(
     assert result == structures_dataflow_sample
 
 
-def test_dataflow_with_dsd_object(complete_header):
-    dsd = DataStructureDefinition(
-        id="DSD_X",
-        agency="MD",
-        version="1.0",
-        name="x",
-        components=Components([]),
-    )
-    dataflow = Dataflow(
-        id="DF_X",
-        agency="MD",
-        version="1.0",
-        name="x",
-        structure=dsd,
-    )
+def test_dataflow_with_dsd_object(
+    complete_header,
+    dataflow,
+    dataflow2,
+    partial_datastructure,
+    structures_dataflow_sample,
+):
+    dataflow_with_dsd = replace(dataflow, structure=partial_datastructure)
 
     result = write(
-        [dataflow],
+        [dataflow_with_dsd, dataflow2],
         header=complete_header,
         prettyprint=True,
     )
 
-    assert (
-        "<str:Structure>urn:sdmx:org.sdmx.infomodel.datastructure."
-        "DataStructure=MD:DSD_X(1.0)</str:Structure>" in result
-    )
+    assert result == structures_dataflow_sample
 
 
-def test_dataflow_without_structure(complete_header):
-    dataflow = Dataflow(
-        id="DF_X",
-        agency="MD",
-        version="1.0",
-        name="x",
-    )
+def test_dataflow_without_structure(
+    complete_header, dataflow, structures_dataflow_stub_sample
+):
+    dataflow_stub = replace(dataflow, structure=None)
 
     result = write(
-        [dataflow],
+        [dataflow_stub],
         header=complete_header,
         prettyprint=True,
     )
 
-    assert "str:Structure" not in result
-    assert 'id="DF_X"' in result
+    assert result == structures_dataflow_stub_sample
+
+
+def test_dataflow_with_dsd_object_round_trip(
+    complete_header, dataflow, partial_datastructure
+):
+    dataflow_with_dsd = replace(dataflow, structure=partial_datastructure)
+
+    write_result = write(
+        [dataflow_with_dsd],
+        header=complete_header,
+        prettyprint=True,
+    )
+    read_result = read(write_result, validate=True)
+
+    # The DSD object is read back as its short URN reference.
+    assert read_result == [dataflow]
+
+
+def test_dataflow_without_structure_round_trip(complete_header, dataflow):
+    dataflow_stub = replace(dataflow, structure=None)
+
+    write_result = write(
+        [dataflow_stub],
+        header=complete_header,
+        prettyprint=True,
+    )
+    read_result = read(write_result, validate=True)
+
+    assert read_result == [dataflow_stub]
 
 
 def test_transformation_scheme(

--- a/tests/io/xml/sdmx31/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx31/writer/test_structures_writing.py
@@ -847,6 +847,52 @@ def test_dataflow(
     assert result == structures_dataflow_sample
 
 
+def test_dataflow_with_dsd_object(complete_header):
+    dsd = DataStructureDefinition(
+        id="DSD_X",
+        agency="MD",
+        version="1.0",
+        name="x",
+        components=Components([]),
+    )
+    dataflow = Dataflow(
+        id="DF_X",
+        agency="MD",
+        version="1.0",
+        name="x",
+        structure=dsd,
+    )
+
+    result = write(
+        [dataflow],
+        header=complete_header,
+        prettyprint=True,
+    )
+
+    assert (
+        "<str:Structure>urn:sdmx:org.sdmx.infomodel.datastructure."
+        "DataStructure=MD:DSD_X(1.0)</str:Structure>" in result
+    )
+
+
+def test_dataflow_without_structure(complete_header):
+    dataflow = Dataflow(
+        id="DF_X",
+        agency="MD",
+        version="1.0",
+        name="x",
+    )
+
+    result = write(
+        [dataflow],
+        header=complete_header,
+        prettyprint=True,
+    )
+
+    assert "str:Structure" not in result
+    assert 'id="DF_X"' in result
+
+
 def test_transformation_scheme(
     complete_header,
     transformation_scheme_structure,


### PR DESCRIPTION
Closes #659
Closes #654 

`__write_structure` assumed `Dataflow.structure` is always a short-URN string, so a `DataStructureDefinition` object or `None` escaped as a raw `TypeError` in the SDMX-ML 2.1, 3.0 and 3.1 structure writers.

### Changes

- `__write_structure` now accepts all variants of `Dataflow.structure`: a DSD object is serialized via its `short_urn`, and `None` omits the `<str:Structure>` element (stub dataflow), consistent with the SDMX-JSON 2.0 writer.
- Companion one-line fix in the shared structure reader, which raised `KeyError: 'Structure'` on dataflows without a structure reference — the exact documents the writer now emits for stubs.
- Tests for the DSD-object and `None` variants across ML 2.1/3.0/3.1, plus a validated write/read round-trip for the stub case.

All six combinations (2.1/3.0/3.1 × DSD object/`None`) now produce schema-valid output that round-trips through `read_sdmx`.