### PR TITLE
Add an MCP server for SDMX data discovery and retrieval

### DIFF
--- a/docs/api/toolkit.rst
+++ b/docs/api/toolkit.rst
@@ -15,3 +15,4 @@ version of the SDMX standard.
    toolkit/vtl
    toolkit/pandas
    toolkit/sqlsrv
+   toolkit/mcp

--- a/docs/api/toolkit/mcp.rst
+++ b/docs/api/toolkit/mcp.rst
@@ -1,0 +1,30 @@
+MCP Server
+==========
+
+The MCP Toolkit exposes pysdmx data discovery and retrieval over the
+`Model Context Protocol <https://modelcontextprotocol.io>`_, so that AI
+assistants can find statistical datasets and retrieve the observations
+themselves.
+
+Requires the ``mcp`` and ``data`` extras::
+
+    pip install pysdmx[mcp,data]
+
+Run it over STDIO, the transport MCP clients launch::
+
+    python -m pysdmx.toolkit.mcp
+
+Or over Streamable HTTP::
+
+    python -m pysdmx.toolkit.mcp --transport http --port 8000
+
+Tools
+-----
+
+.. autofunction:: pysdmx.toolkit.mcp.list_services
+
+.. autofunction:: pysdmx.toolkit.mcp.search_dataflows
+
+.. autofunction:: pysdmx.toolkit.mcp.inspect_dataflow
+
+.. autofunction:: pysdmx.toolkit.mcp.get_data

--- a/docs/howto/toolkit/general.rst
+++ b/docs/howto/toolkit/general.rst
@@ -15,3 +15,5 @@ The toolkit functions does not follow any particular version of the SDMX standar
 :ref:`sqlsrv_toolkit`
 
 :ref:`pandas_toolkit`
+
+:ref:`mcp_toolkit`

--- a/docs/howto/toolkit/mcp_toolkit.rst
+++ b/docs/howto/toolkit/mcp_toolkit.rst
@@ -1,0 +1,200 @@
+.. _mcp_toolkit:
+
+MCP Server
+==========
+
+The MCP Toolkit turns pysdmx into a
+`Model Context Protocol <https://modelcontextprotocol.io>`_ server, so an
+AI assistant can discover SDMX dataflows and **retrieve the observations**,
+rather than being handed a query URL to fetch by itself.
+
+It wraps :class:`pysdmx.api.dc.pd.PandasConnector` and exposes four tools.
+
+Installation
+------------
+
+.. code-block:: bash
+
+    pip install pysdmx[mcp,data]
+
+The ``mcp`` extra brings in FastMCP; ``data`` brings in Pandas, which the
+underlying connector needs.
+
+Running the server
+------------------
+
+Most MCP clients launch the server themselves over STDIO:
+
+.. code-block:: bash
+
+    python -m pysdmx.toolkit.mcp
+
+To share one instance over the network instead, use Streamable HTTP:
+
+.. code-block:: bash
+
+    python -m pysdmx.toolkit.mcp --transport http --host 127.0.0.1 --port 8000
+
+Client configuration
+--------------------
+
+**Claude Desktop** — add to ``claude_desktop_config.json``:
+
+.. code-block:: json
+
+    {
+      "mcpServers": {
+        "sdmx": {
+          "command": "python",
+          "args": ["-m", "pysdmx.toolkit.mcp"]
+        }
+      }
+    }
+
+**Claude Code** — from the command line:
+
+.. code-block:: bash
+
+    claude mcp add sdmx -- python -m pysdmx.toolkit.mcp
+
+**Cursor** — add to ``.cursor/mcp.json``:
+
+.. code-block:: json
+
+    {
+      "mcpServers": {
+        "sdmx": {
+          "command": "python",
+          "args": ["-m", "pysdmx.toolkit.mcp"]
+        }
+      }
+    }
+
+Point ``command`` at the Python interpreter of the environment where
+pysdmx is installed if it is not the one on your ``PATH``.
+
+The tools
+---------
+
+The four tools are meant to be called in order.
+
+``list_services``
+    Reports the endpoints in :class:`pysdmx.api.dc.Endpoints` with
+    capability notes. Any SDMX-REST v2 base URL can also be passed to
+    the other tools as ``service``.
+
+``search_dataflows``
+    Issues a single ``dataflows()`` call and matches terms locally
+    against each dataflow's ID, name and description. Space-separated
+    words are treated as alternatives, so synonyms cost nothing extra.
+
+``inspect_dataflow``
+    Returns components, availability-backed codes and size signals.
+    Accepts ``filters`` to scope availability, and ``find_code`` to
+    locate a value across every component that carries it.
+
+``get_data``
+    Retrieves the observations as records, capped and with an explicit
+    truncation flag.
+
+A worked example
+----------------
+
+Asking an assistant *"how much do Swiss banks have in foreign claims
+since 2020?"* drives the following sequence against the BIS.
+
+**1. Find the dataflow.**
+
+.. code-block:: text
+
+    search_dataflows(query="consolidated banking")
+
+    -> ref: BIS:WS_CBS_PUB(1.0)
+       name: Consolidated banking
+       matched_on: name
+       next_step: Call inspect_dataflow with ref='BIS:WS_CBS_PUB(1.0)' ...
+
+**2. Work out what "Swiss" means here.**
+
+.. code-block:: text
+
+    inspect_dataflow(ref="BIS:WS_CBS_PUB(1.0)", find_code="CH")
+
+    -> code_locations:
+         L_REP_CTY      (reporting country)
+         CBS_BANK_TYPE  (bank type (shares a country codelist))
+         L_CP_COUNTRY   (counterparty country)
+       series_count: 228370
+       size_warning: This scope holds 228,370 series ...
+       next_step: That code is ambiguous - it appears in 3 components ...
+
+This is the step that prevents a confidently wrong answer. ``CH`` is
+valid in three different components of this dataflow, and each answers a
+different question: claims *by* Swiss banks, claims *on* Switzerland, or
+a bank-type code that happens to share the country codelist.
+
+**3. Scope it, and check the size.**
+
+.. code-block:: text
+
+    inspect_dataflow(
+        ref="BIS:WS_CBS_PUB(1.0)",
+        filters="L_MEASURE = 'S' AND L_REP_CTY = 'CH' AND FREQ = 'Q'",
+    )
+
+    -> series_count: 6671   (down from 228370)
+
+If the question were only *whether* data exist, the answer is already
+here and ``get_data`` should not be called.
+
+**4. Retrieve the numbers.**
+
+.. code-block:: text
+
+    get_data(
+        ref="BIS:WS_CBS_PUB(1.0)",
+        filters="L_MEASURE = 'S' AND L_REP_CTY = 'CH' AND FREQ = 'Q'"
+                " AND TIME_PERIOD >= '2020-Q1'",
+        columns=["OBS_VALUE"],
+        limit=500,
+    )
+
+    -> row_count: 500
+       total_rows_available: 112648
+       truncated: true
+       next_step: Truncated: 112,648 rows matched but only 500 were
+                  returned. These are the first rows in service order,
+                  not a sample ...
+
+Things worth knowing
+--------------------
+
+**Conjunctions only.** The query parser supports ``AND`` between
+clauses. Never generate ``OR``; for several values of one component use
+``IN ('A', 'B')``.
+
+**Availability is not validity.** ``inspect_dataflow`` reports the codes
+for which data currently exist. A code absent from that list may still
+be valid in the full codelist, so its absence is not evidence that
+something does not exist.
+
+**Size before retrieval.** ``obs_count`` is often unreported — the BIS
+returns ``None`` for it — so ``series_count`` is the signal to rely on.
+The tools warn when a scope is large enough that retrieval will
+truncate.
+
+**Truncation is not sampling.** When ``truncated`` is true the rows
+returned are the first ones in service order. They must not be
+aggregated as though they were a representative sample; narrow the
+filter instead.
+
+**Time filters degrade gracefully.** ``TIME_PERIOD`` comparisons are
+pushed down to the service when it supports them. If the service
+rejects the query, the clause is stripped, the narrower query is
+retried, and the cutoff is applied with Pandas. The response reports
+this in ``filter_fallback``.
+
+**Errors keep their meaning.** Every failure is reported with the kind
+of error it was, so an assistant can tell a transient outage
+(``unavailable``, retriable) from a bad reference (``not_found``, not
+retriable) rather than retrying blindly or giving up too early.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,7 @@ Your opinionated Python SDMX library.
    howto/toolkit/vtl_toolkit
    howto/toolkit/pandas_toolkit
    howto/toolkit/sqlsrv_toolkit
+   howto/toolkit/mcp_toolkit
 
 .. toctree::
    :maxdepth: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,10 @@ dc = ["python-dateutil>=2.8.2"]
 vtl = ["vtlengine>=1.8.0,<2.0"]
 json = ["sdmxschemas>=1.1.0", "jsonschema>=4.10"]
 xml = ["lxml>=6.1.0", "xmltodict>=0.13", "sdmxschemas>=1.1.0"]
+mcp = ["fastmcp>=3.0,<4.0; python_version >= '3.10'"]
 all = ["lxml>=6.1.0", "xmltodict>=0.13", "sdmxschemas>=1.1.0", "pandas>=2.1.4",
     "python-dateutil>=2.8.2", "vtlengine>=1.8.0,<2.0",
+    "fastmcp>=3.0,<4.0; python_version >= '3.10'",
     "numpy>=2.0.2,<2.1; python_version < '3.10'", "numpy>=2.1.0,<2.3; python_version >= '3.10'"]
 
 [tool.poetry]

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,5 @@ markers =
     vtl: Tests that require the vtl extra
     dc: Tests that require the dc extra
     json: Tests that require the json extra
+    mcp: Tests that require both the mcp and data extras
     noextra: Tests that do not required any extra

--- a/src/pysdmx/__extras_check.py
+++ b/src/pysdmx/__extras_check.py
@@ -58,6 +58,19 @@ def __check_vtl_extra() -> None:
         ) from None
 
 
+def __check_mcp_extra() -> None:
+    try:
+        import fastmcp  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            ERROR_MESSAGE.format(
+                extra_name="mcp",
+                extra_desc="the MCP server exposing data discovery and "
+                "retrieval to AI assistants",
+            )
+        ) from None
+
+
 def __check_json_extra() -> None:
     try:
         import jsonschema  # noqa: F401

--- a/src/pysdmx/toolkit/mcp/__init__.py
+++ b/src/pysdmx/toolkit/mcp/__init__.py
@@ -1,0 +1,30 @@
+"""MCP server exposing SDMX data discovery and retrieval to AI assistants.
+
+Requires the ``mcp`` and ``data`` extras::
+
+    pip install pysdmx[mcp,data]
+
+Run it over STDIO, which is what MCP clients launch::
+
+    python -m pysdmx.toolkit.mcp
+
+Or serve it over Streamable HTTP::
+
+    python -m pysdmx.toolkit.mcp --transport http --port 8000
+"""
+
+from pysdmx.toolkit.mcp.server import (
+    get_data,
+    inspect_dataflow,
+    list_services,
+    mcp,
+    search_dataflows,
+)
+
+__all__ = [
+    "get_data",
+    "inspect_dataflow",
+    "list_services",
+    "mcp",
+    "search_dataflows",
+]

--- a/src/pysdmx/toolkit/mcp/__main__.py
+++ b/src/pysdmx/toolkit/mcp/__main__.py
@@ -1,0 +1,53 @@
+"""Command-line entry point for the pysdmx MCP server.
+
+Defaults to STDIO, which is the transport MCP clients such as Claude
+Desktop, Claude Code and Cursor launch. Pass ``--transport http`` to
+serve over Streamable HTTP instead.
+"""
+
+import argparse
+from typing import Optional, Sequence
+
+from pysdmx.toolkit.mcp.server import mcp
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Parse arguments and run the server.
+
+    Args:
+        argv: Command-line arguments. Defaults to ``sys.argv[1:]``.
+    """
+    parser = argparse.ArgumentParser(
+        prog="python -m pysdmx.toolkit.mcp",
+        description=(
+            "MCP server that discovers and retrieves official statistics "
+            "from SDMX-REST v2 services."
+        ),
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "http"],
+        default="stdio",
+        help="Transport to serve on (default: stdio).",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Bind address for --transport http (default: 127.0.0.1).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port for --transport http (default: 8000).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.transport == "http":
+        mcp.run(transport="http", host=args.host, port=args.port)
+    else:
+        mcp.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/pysdmx/toolkit/mcp/_errors.py
+++ b/src/pysdmx/toolkit/mcp/_errors.py
@@ -1,0 +1,159 @@
+"""Translation of pysdmx errors into agent-actionable MCP errors.
+
+``NotFound`` and ``Unavailable`` mean very different things to an agent
+deciding whether to retry, so the error hierarchy is preserved rather
+than collapsed into a generic failure. Every error carries a
+machine-readable kind, a retriable flag and a hint about what to do next.
+"""
+
+# ruff: noqa: E402
+from typing import Any, Dict, Optional, Tuple, Type
+
+from pysdmx.__extras_check import __check_mcp_extra
+
+__check_mcp_extra()
+
+from fastmcp.exceptions import ToolError
+
+from pysdmx import errors
+
+#: Maps a pysdmx exception type to ``(kind, retriable, next_step)``.
+#:
+#: Consulted most-specific first, because ``Unavailable`` subclasses
+#: ``RetriableError`` and every error subclasses ``PysdmxError``. Only
+#: ``RetriableError`` and its subclasses are marked retriable: pysdmx
+#: documents ``InternalError`` as non-retriable, stating that clients
+#: should investigate before repeating the query.
+_ERROR_TABLE: Tuple[Tuple[Type[Exception], str, bool, str], ...] = (
+    (
+        errors.Unavailable,
+        "unavailable",
+        True,
+        "The service could not be reached. This is transient - retry "
+        "after a short delay, or allow a longer timeout.",
+    ),
+    (
+        errors.NotFound,
+        "not_found",
+        False,
+        "The requested resource does not exist on this service. Call "
+        "search_dataflows to list what is actually available. Do not "
+        "retry the same reference.",
+    ),
+    (
+        errors.Unauthorized,
+        "unauthorized",
+        False,
+        "The service rejected the credentials. A client certificate may "
+        "be required. Do not retry without changing the credentials.",
+    ),
+    (
+        errors.NotImplemented,
+        "not_implemented",
+        False,
+        "This service does not implement the required part of the "
+        "SDMX-REST v2 API. Try a different service.",
+    ),
+    (
+        errors.Invalid,
+        "invalid_request",
+        False,
+        "The service rejected the request as malformed. Check the "
+        "filter syntax: use AND only (never OR), quote code values, and "
+        "use IN (...) for several values of one component. Call "
+        "inspect_dataflow to confirm component and code IDs.",
+    ),
+    (
+        errors.InternalError,
+        "internal_error",
+        False,
+        "The service failed, or returned a response that could not be "
+        "parsed. Do not repeat the identical call - narrow the filter "
+        "or try a different dataflow, since the fault is server-side.",
+    ),
+    (
+        errors.RetriableError,
+        "retriable_error",
+        True,
+        "A transient failure occurred. Retry after a short delay.",
+    ),
+    (
+        errors.PysdmxError,
+        "sdmx_error",
+        False,
+        "The SDMX library reported an error. Inspect the detail for the "
+        "underlying cause.",
+    ),
+)
+
+_UNEXPECTED_HINT = (
+    "This is a fault in the pysdmx MCP server rather than in the SDMX "
+    "service. Report it with the message above."
+)
+
+
+def classify(exc: Exception) -> Dict[str, Any]:
+    """Classify an exception against the pysdmx error hierarchy.
+
+    Args:
+        exc: The exception raised by a connector call.
+
+    Returns:
+        A dictionary with the keys ``error``, ``retriable``, ``message``,
+        ``detail`` and ``next_step``. Exceptions outside the pysdmx
+        hierarchy are reported as ``unexpected_error``, deliberately
+        distinct from ``internal_error`` so that an agent can tell a
+        service fault from a bug in this server.
+    """
+    for exc_type, kind, retriable, hint in _ERROR_TABLE:
+        if isinstance(exc, exc_type):
+            return {
+                "error": kind,
+                "retriable": retriable,
+                "message": _summary(exc),
+                "detail": _detail(exc),
+                "next_step": hint,
+            }
+    return {
+        "error": "unexpected_error",
+        "retriable": False,
+        "message": _summary(exc),
+        "detail": type(exc).__name__,
+        "next_step": _UNEXPECTED_HINT,
+    }
+
+
+def as_tool_error(exc: Exception) -> ToolError:
+    """Convert an exception into a tool error an agent can act on.
+
+    Args:
+        exc: The exception to convert.
+
+    Returns:
+        A ``ToolError`` whose message embeds the classification, so that
+        the discriminator survives transport to clients that do not
+        propagate structured error payloads.
+    """
+    info = classify(exc)
+    detail = f" - {info['detail']}" if info["detail"] else ""
+    retriable = str(info["retriable"]).lower()
+    return ToolError(
+        f"[{info['error']}] {info['message']}{detail} "
+        f"| retriable={retriable} | next_step: {info['next_step']}"
+    )
+
+
+def _summary(exc: Exception) -> str:
+    """Extract the short title from a pysdmx error, or fall back to str."""
+    title = getattr(exc, "title", None)
+    if isinstance(title, str) and title:
+        return title
+    return str(exc) or type(exc).__name__
+
+
+def _detail(exc: Exception) -> Optional[str]:
+    """Extract the long-form description from a pysdmx error, if present."""
+    description = getattr(exc, "description", None)
+    if isinstance(description, str) and description:
+        return description
+    return None

--- a/src/pysdmx/toolkit/mcp/_matching.py
+++ b/src/pysdmx/toolkit/mcp/_matching.py
@@ -1,0 +1,114 @@
+"""Local matching of user terms against dataflow and component metadata.
+
+The discovery rule this module exists to support: issue **one**
+``dataflows()`` call per service and match locally, rather than firing
+repeated ``dataflows(search_term)`` requests for every synonym a user
+might have meant.
+"""
+
+from typing import Any, Iterable, List, Optional, Tuple
+
+#: Words in a component's metadata that hint at the role a code plays.
+#: A phrase such as "in Switzerland" may mean the reporting country, the
+#: counterparty country or the reference area, and reporting the wrong
+#: one produces a confidently incorrect answer.
+_ROLE_HINTS: Tuple[Tuple[Tuple[str, ...], str], ...] = (
+    (("reporting", "rep_cty", "reporter"), "reporting country"),
+    (
+        ("counterparty", "cp_country", "cp_cty", "partner"),
+        "counterparty country",
+    ),
+    (("reference area", "ref_area", "refarea"), "reference area"),
+    (("currency", "curr", "denom"), "currency"),
+    (("issuer",), "issuer"),
+    (("residence", "resident"), "country of residence"),
+    (("nationality",), "nationality"),
+    (("borrower",), "borrower country"),
+    (("bank type", "bank_type"), "bank type (shares a country codelist)"),
+)
+
+
+def dataflow_ref(flow: Any) -> str:
+    """Build the canonical ``agency:id(version)`` reference for a flow.
+
+    Args:
+        flow: Any object exposing ``agency``, ``id`` and ``version``.
+
+    Returns:
+        The shorthand reference pysdmx accepts wherever a dataflow is
+        expected.
+    """
+    agency = getattr(flow, "agency", "")
+    agency_id = getattr(agency, "id", agency)
+    return f"{agency_id}:{flow.id}({flow.version})"
+
+
+def match_dataflow(flow: Any, terms: Iterable[str]) -> Optional[str]:
+    """Test one dataflow against a set of search terms.
+
+    Args:
+        flow: A dataflow returned by ``dataflows()``.
+        terms: Lower-cased search terms. An empty iterable matches
+            nothing, which callers treat as "no filtering requested".
+
+    Returns:
+        The name of the field that matched - ``id``, ``name`` or
+        ``description`` - or ``None`` when nothing matched. The ID is
+        checked first, so the most precise match is the one reported.
+    """
+    terms = list(terms)
+    if not terms:
+        return None
+
+    fields = (
+        ("id", flow.id),
+        ("name", getattr(flow, "name", None)),
+        ("description", getattr(flow, "description", None)),
+    )
+    for field_name, value in fields:
+        if value and any(t in str(value).lower() for t in terms):
+            return field_name
+    return None
+
+
+def role_hint(component: Any) -> str:
+    """Infer the semantic role a component plays, for disambiguation.
+
+    Args:
+        component: A pysdmx ``Component``.
+
+    Returns:
+        A short human-readable role such as ``reporting country``. Falls
+        back to the component's own name, then to its ID, so the result
+        is never empty - callers render it directly.
+    """
+    haystack = " ".join(
+        str(v).lower()
+        for v in (
+            component.id,
+            getattr(component, "name", None),
+            getattr(component, "description", None),
+        )
+        if v
+    )
+    for needles, hint in _ROLE_HINTS:
+        if any(n in haystack for n in needles):
+            return hint
+    return str(getattr(component, "name", None) or component.id)
+
+
+def codes_of(component: Any) -> List[Any]:
+    """Return a component's available codes, tolerating a missing list.
+
+    Args:
+        component: A pysdmx ``Component``.
+
+    Returns:
+        The codes currently available. Uncoded components, and coded
+        components whose enumeration the service did not return, both
+        yield an empty list rather than raising.
+    """
+    enumeration = getattr(component, "enumeration", None)
+    if not enumeration:
+        return []
+    return [c for c in enumeration if c is not None]

--- a/src/pysdmx/toolkit/mcp/_models.py
+++ b/src/pysdmx/toolkit/mcp/_models.py
@@ -1,0 +1,214 @@
+"""Structured outputs returned by the MCP tools.
+
+Every result carries a ``next_step`` field. Telling an agent what to do
+next measurably reduces flailing between tools, and it is where the
+non-obvious SDMX rules (availability is not validity, AND but never OR,
+stop at inspection for availability-only questions) are surfaced at the
+moment they matter.
+
+Results also echo the resolved dataflow reference and the filter string
+actually sent, so a caller can verify what was queried rather than what
+it believed it asked for.
+"""
+
+# ruff: noqa: E402
+from typing import Any, Dict, List, Optional
+
+from pysdmx.__extras_check import __check_mcp_extra
+
+__check_mcp_extra()
+
+from pydantic import BaseModel, Field
+
+
+class ServiceInfo(BaseModel):
+    """A single SDMX-REST v2 service known to the server."""
+
+    name: str = Field(description="Short identifier, such as 'BIS'.")
+    base_url: str = Field(description="SDMX-REST v2 base URL.")
+    source: str = Field(
+        description=(
+            "Where the entry came from: 'pysdmx' for a member of "
+            "pysdmx.api.dc.Endpoints, 'custom' for a supplied URL."
+        )
+    )
+    verified: bool = Field(
+        description=(
+            "True only for services confirmed to meet the connector's "
+            "requirements (SDMX-REST v2, SDMX-JSON 2.0.0 structures, "
+            "SDMX-CSV data). Unverified services may fail at any step."
+        )
+    )
+    notes: str = Field(description="Capability caveats worth knowing.")
+
+
+class ServiceList(BaseModel):
+    """Result of the ``list_services`` tool."""
+
+    services: List[ServiceInfo]
+    custom_endpoints_supported: bool = Field(
+        default=True,
+        description=(
+            "Every tool accepts a 'service' argument holding either a "
+            "known name or an arbitrary SDMX-REST v2 base URL."
+        ),
+    )
+    next_step: str
+
+
+class DataflowSummary(BaseModel):
+    """One dataflow, as returned by discovery."""
+
+    ref: str = Field(
+        description=(
+            "Canonical reference in agency:id(version) form. Pass this "
+            "verbatim to inspect_dataflow and get_data."
+        )
+    )
+    id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    agency: str
+    version: str
+    matched_on: Optional[str] = Field(
+        default=None,
+        description=(
+            "Which field the search term matched: 'id', 'name' or "
+            "'description'. Null when no search term was supplied."
+        ),
+    )
+
+
+class DataflowSearchResult(BaseModel):
+    """Result of the ``search_dataflows`` tool."""
+
+    service: str
+    search_terms: List[str]
+    total_dataflows_on_service: int
+    match_count: int
+    dataflows: List[DataflowSummary]
+    next_step: str
+
+
+class CodeInfo(BaseModel):
+    """A single available code within a component."""
+
+    id: str
+    name: Optional[str] = None
+
+
+class ComponentInfo(BaseModel):
+    """A dimension, measure or attribute of a dataflow."""
+
+    id: str
+    name: Optional[str] = None
+    role: str = Field(description="'dimension', 'measure' or 'attribute'.")
+    required: bool
+    code_count: int = Field(description="Number of codes currently available.")
+    codes: List[CodeInfo] = Field(
+        description=(
+            "Available codes, truncated when numerous. These are "
+            "availability-backed: a code absent here may still be valid "
+            "in the full codelist."
+        )
+    )
+    codes_truncated: bool
+
+
+class CodeLocation(BaseModel):
+    """Where a code value was found, and in what role."""
+
+    component_id: str
+    component_name: Optional[str] = None
+    role_hint: str = Field(
+        description=(
+            "The role this component plays, inferred from its metadata, "
+            "such as 'reporting country' or 'counterparty country'. "
+            "Disambiguates phrases like 'in Switzerland'."
+        )
+    )
+    code_id: str
+    code_name: Optional[str] = None
+
+
+class DataflowDetail(BaseModel):
+    """Result of the ``inspect_dataflow`` tool."""
+
+    service: str
+    ref: str = Field(description="The resolved dataflow reference.")
+    name: Optional[str] = None
+    description: Optional[str] = None
+    filter_applied: Optional[str] = Field(
+        default=None,
+        description=(
+            "The filter used to scope availability, echoed verbatim. "
+            "Null means availability covers the whole dataflow."
+        ),
+    )
+    series_count: Optional[int] = None
+    obs_count: Optional[int] = Field(
+        default=None,
+        description=(
+            "Observation count. Frequently null - BIS does not report "
+            "it. Use series_count as the size signal when null."
+        ),
+    )
+    size_warning: Optional[str] = Field(
+        default=None,
+        description=(
+            "Present when the scope is large enough that get_data would "
+            "truncate. Narrow the filter first."
+        ),
+    )
+    dimensions: List[ComponentInfo]
+    measures: List[ComponentInfo]
+    attributes: List[ComponentInfo]
+    code_locations: List[CodeLocation] = Field(
+        default_factory=list,
+        description=(
+            "Populated when find_code was supplied: every component "
+            "whose available codes contain that value, with the role "
+            "each plays. More than one entry means the value is "
+            "ambiguous - on BIS consolidated banking 'CH' appears as "
+            "reporting country, counterparty country and bank type - so "
+            "choose the intended role before filtering."
+        ),
+    )
+    availability_note: str
+    next_step: str
+
+
+class DataResult(BaseModel):
+    """Result of the ``get_data`` tool - the observations themselves."""
+
+    service: str
+    ref: str = Field(description="The resolved dataflow reference.")
+    filter_applied: Optional[str] = Field(
+        description=(
+            "The filter actually sent to the service, echoed so the "
+            "caller can verify what was queried."
+        )
+    )
+    filter_fallback: Optional[str] = Field(
+        default=None,
+        description=(
+            "Set when server-side time pushdown failed and the time "
+            "constraint was applied locally instead. Names the filter "
+            "that was sent and the cutoff applied with pandas."
+        ),
+    )
+    columns: List[str]
+    row_count: int = Field(description="Rows actually returned.")
+    total_rows_available: int = Field(
+        description="Rows matching the filter before the cap was applied."
+    )
+    truncated: bool = Field(
+        description=(
+            "True when total_rows_available exceeded the cap. The "
+            "returned rows are the first row_count in service order and "
+            "are NOT a representative sample - narrow the filter for a "
+            "complete answer."
+        )
+    )
+    records: List[Dict[str, Any]]
+    next_step: str

--- a/src/pysdmx/toolkit/mcp/_safety.py
+++ b/src/pysdmx/toolkit/mcp/_safety.py
@@ -1,0 +1,229 @@
+"""Guards that keep retrieval bounded and honest.
+
+Three concerns:
+
+* **Row caps.** A three-clause filter on BIS consolidated banking returns
+  well over 400,000 rows. Without a cap, one tool call floods an agent's
+  context window.
+* **Size checks before retrieval.** ``series_count`` is the usable
+  signal. ``obs_count`` is ``None`` on BIS, so logic that depends on it
+  fails against the only endpoint pysdmx ships.
+* **Time-filter fallback.** Server-side pushdown of ``TIME_PERIOD`` is
+  preferred but not universally supported. When a service rejects it,
+  retry without the clause and apply the cutoff with pandas.
+"""
+
+# ruff: noqa: E402
+import re
+from typing import Callable, Dict, Optional, Tuple
+
+from pysdmx.__extras_check import __check_data_extra
+
+__check_data_extra()
+
+import pandas as pd
+
+from pysdmx import errors
+
+#: Default cap on rows returned by the ``get_data`` tool.
+DEFAULT_ROW_LIMIT = 1000
+
+#: Hard ceiling a caller may request, bounding the response payload.
+MAX_ROW_LIMIT = 10_000
+
+#: ``series_count`` above which a scope is flagged as large.
+LARGE_SERIES_THRESHOLD = 5_000
+
+#: Matches a ``TIME_PERIOD <op> value`` clause together with the ``AND``
+#: joining it to its neighbours, so the clause can be excised cleanly.
+#: Only conjunctions need handling: the SDMX query parser rejects ``OR``.
+_TIME_CLAUSE = re.compile(
+    r"""
+    (?:\s+AND\s+)?
+    \bTIME_PERIOD\b\s*
+    (?:>=|<=|<>|!=|==|=|>|<)\s*
+    (?:'[^']*'|"[^"]*"|\S+)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+#: Extracts the operator and value of each time clause, so the same
+#: constraint can be re-applied locally.
+_TIME_PARTS = re.compile(
+    r"""\bTIME_PERIOD\b\s*
+        (?P<op>>=|<=|<>|!=|==|=|>|<)\s*
+        (?P<value>'[^']*'|"[^"]*"|\S+)""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_COMPARATORS: Dict[str, Callable[["pd.Series", str], "pd.Series"]] = {
+    ">=": lambda s, v: s >= v,
+    "<=": lambda s, v: s <= v,
+    ">": lambda s, v: s > v,
+    "<": lambda s, v: s < v,
+    "=": lambda s, v: s == v,
+    "==": lambda s, v: s == v,
+    "<>": lambda s, v: s != v,
+    "!=": lambda s, v: s != v,
+}
+
+
+class TimeSplit:
+    """A filter string split into its time and non-time parts.
+
+    Attributes:
+        without_time: The filter with every ``TIME_PERIOD`` clause
+            removed, or ``None`` when nothing would remain.
+        constraints: The excised ``(operator, value)`` pairs, ready to be
+            re-applied with pandas.
+    """
+
+    def __init__(
+        self,
+        without_time: Optional[str],
+        constraints: Tuple[Tuple[str, str], ...],
+    ):
+        """Instantiate a split filter."""
+        self.without_time = without_time
+        self.constraints = constraints
+
+    @property
+    def has_time(self) -> bool:
+        """Whether any time constraint was present."""
+        return bool(self.constraints)
+
+
+def clamp_limit(limit: Optional[int]) -> int:
+    """Clamp a caller-supplied row limit into the permitted range.
+
+    Args:
+        limit: The requested limit, or ``None`` for the default.
+
+    Returns:
+        A limit between 1 and ``MAX_ROW_LIMIT``.
+    """
+    if limit is None:
+        return DEFAULT_ROW_LIMIT
+    return max(1, min(int(limit), MAX_ROW_LIMIT))
+
+
+def split_time_filter(filters: Optional[str]) -> TimeSplit:
+    """Separate ``TIME_PERIOD`` clauses from the rest of a filter.
+
+    Args:
+        filters: A filter string, or ``None``.
+
+    Returns:
+        The split. When the filter holds no time clause, ``without_time``
+        is the input unchanged and ``constraints`` is empty.
+    """
+    if not filters:
+        return TimeSplit(filters, ())
+
+    constraints = tuple(
+        (m.group("op"), _unquote(m.group("value")))
+        for m in _TIME_PARTS.finditer(filters)
+    )
+    if not constraints:
+        return TimeSplit(filters, ())
+
+    remainder = _TIME_CLAUSE.sub("", filters).strip()
+    # A leading AND survives when the time clause came first.
+    remainder = re.sub(r"^\s*AND\s+", "", remainder, flags=re.IGNORECASE)
+    remainder = remainder.strip()
+    return TimeSplit(remainder or None, constraints)
+
+
+def apply_time_locally(
+    df: "pd.DataFrame",
+    constraints: Tuple[Tuple[str, str], ...],
+) -> "pd.DataFrame":
+    """Apply time constraints to a data frame with pandas.
+
+    SDMX time periods (``2020-Q1``, ``2018-01``, ``2024``) compare
+    correctly as strings within a single frequency, which is what the
+    fallback needs. No date parsing is attempted, since that would have
+    to guess the frequency and would fail on formats such as ``2020-S1``.
+
+    Args:
+        df: The retrieved data.
+        constraints: ``(operator, value)`` pairs from
+            :func:`split_time_filter`.
+
+    Returns:
+        The filtered frame, or the frame unchanged when it holds no
+        ``TIME_PERIOD`` column and there is nothing to filter on.
+    """
+    if "TIME_PERIOD" not in df.columns or not constraints:
+        return df
+
+    series = df["TIME_PERIOD"].astype(str)
+    mask = pd.Series(True, index=df.index)
+    for op, value in constraints:
+        comparator = _COMPARATORS[op]
+        mask &= comparator(series, value)
+    return df[mask]
+
+
+def size_warning(
+    series_count: Optional[int],
+    obs_count: Optional[int],
+    row_limit: int = DEFAULT_ROW_LIMIT,
+) -> Optional[str]:
+    """Warn when a scope is large enough that retrieval would truncate.
+
+    Args:
+        series_count: Series in scope, if the service reported it.
+        obs_count: Observations in scope. Frequently ``None`` - BIS does
+            not report it - so it is treated as optional corroboration
+            rather than the primary signal.
+        row_limit: The cap the retrieval tool would apply.
+
+    Returns:
+        A warning string, or ``None`` when the scope looks retrievable.
+    """
+    if obs_count is not None and obs_count > row_limit:
+        return (
+            f"This scope holds {obs_count:,} observations but get_data "
+            f"returns at most {row_limit:,} rows. Narrow the filter "
+            f"before retrieving, or the result will be truncated."
+        )
+    if series_count is not None and series_count > LARGE_SERIES_THRESHOLD:
+        return (
+            f"This scope holds {series_count:,} series. Each carries "
+            f"many observations, so get_data will almost certainly "
+            f"truncate at {row_limit:,} rows. Add filters on the "
+            f"dimensions above before retrieving."
+        )
+    if series_count is None and obs_count is None:
+        return (
+            "This service reported neither series_count nor obs_count, "
+            "so the size of this scope is unknown. Filter defensively."
+        )
+    return None
+
+
+def is_pushdown_failure(exc: Exception) -> bool:
+    """Decide whether an error justifies retrying without the time clause.
+
+    Only client-side rejections are worth retrying this way. A
+    ``NotFound`` means the dataflow reference itself is wrong and an
+    ``Unavailable`` means the service never answered; neither is fixed by
+    dropping a clause, and retrying would waste a round trip and obscure
+    the error the caller ultimately sees.
+
+    Args:
+        exc: The exception raised by the first retrieval attempt.
+
+    Returns:
+        Whether to attempt the fallback.
+    """
+    return isinstance(exc, (errors.Invalid, errors.NotImplemented))
+
+
+def _unquote(value: str) -> str:
+    """Strip matching surrounding quotes from a filter literal."""
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value

--- a/src/pysdmx/toolkit/mcp/_services.py
+++ b/src/pysdmx/toolkit/mcp/_services.py
@@ -1,0 +1,137 @@
+"""Service registry and connector construction for the MCP server.
+
+``pysdmx.api.dc.Endpoints`` currently has a single member, ``BIS``, so a
+caller-supplied base URL is treated as a first-class input rather than a
+fallback: :func:`resolve` accepts a known name or any http(s) URL with
+equal standing.
+
+Further SDMX-REST v2 services are deliberately not hardcoded. Each would
+need individual verification that it returns structural metadata as
+SDMX-JSON 2.0.0 and data as SDMX-CSV, which the connector requires.
+Listing them unverified would invite confident failures.
+"""
+
+# ruff: noqa: E402
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+from pysdmx.__extras_check import __check_data_extra
+
+__check_data_extra()
+
+from pysdmx.api.dc import Endpoints
+from pysdmx.api.dc.pd import PandasConnector
+
+#: Socket timeout, in seconds. Higher than the pysdmx default of 20
+#: because structural metadata for large dataflows is slow to return.
+DEFAULT_TIMEOUT = 60.0
+
+#: Capability notes for services shipped by pysdmx itself.
+_KNOWN_NOTES: Dict[str, str] = {
+    "BIS": (
+        "Bank for International Settlements. Verified working. Reports "
+        "series_count but not obs_count. Supports server-side "
+        "TIME_PERIOD pushdown. Banking dataflows are very large - "
+        "filter before retrieving."
+    ),
+}
+
+
+class ResolvedService:
+    """A service argument resolved to a usable base URL.
+
+    Attributes:
+        name: The display name, such as ``BIS``, or the URL itself for
+            caller-supplied services.
+        base_url: The SDMX-REST v2 base URL to connect to.
+        known: Whether this came from ``pysdmx.api.dc.Endpoints``.
+    """
+
+    def __init__(self, name: str, base_url: str, known: bool):
+        """Instantiate a resolved service."""
+        self.name = name
+        self.base_url = base_url
+        self.known = known
+
+
+def known_services() -> Dict[str, str]:
+    """Return every service pysdmx ships, as ``{name: base_url}``.
+
+    Returns:
+        A mapping read from ``pysdmx.api.dc.Endpoints`` rather than
+        hardcoded, so that new pysdmx releases are picked up for free.
+    """
+    return {member.name: member.value for member in Endpoints}
+
+
+def notes_for(name: str) -> str:
+    """Return the capability notes recorded for a service name.
+
+    Args:
+        name: The service name.
+
+    Returns:
+        The notes, or a placeholder when none are recorded.
+    """
+    return _KNOWN_NOTES.get(
+        name, "No capability notes recorded for this service."
+    )
+
+
+def resolve(service: Optional[str]) -> ResolvedService:
+    """Resolve a service argument to a base URL.
+
+    Args:
+        service: A known service name (case-insensitive), an SDMX-REST v2
+            base URL, or ``None`` to use the default endpoint.
+
+    Returns:
+        The resolved service.
+
+    Raises:
+        errors.Invalid: If the argument is neither a known name nor a
+            syntactically valid http(s) URL. The message lists the known
+            names so the caller can recover without another round trip.
+    """
+    from pysdmx import errors
+
+    known = known_services()
+
+    if service is None:
+        name = next(iter(known))
+        return ResolvedService(name, known[name], True)
+
+    candidate = service.strip()
+    for name, url in known.items():
+        if candidate.upper() == name.upper():
+            return ResolvedService(name, url, True)
+
+    parsed = urlparse(candidate)
+    if parsed.scheme in ("http", "https") and parsed.netloc:
+        return ResolvedService(candidate, candidate.rstrip("/"), False)
+
+    raise errors.Invalid(
+        "Unknown service",
+        f"{service!r} is neither a known service name "
+        f"({sorted(known)}) nor an SDMX-REST v2 base URL. Supply a URL "
+        f"starting with http:// or https://.",
+    )
+
+
+def connector(
+    resolved: ResolvedService,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> PandasConnector:
+    """Build a connector for a resolved service.
+
+    Connectors are cheap to construct and hold no reusable session state
+    worth caching between calls, so this deliberately does not memoise.
+
+    Args:
+        resolved: The service to connect to.
+        timeout: Socket timeout, in seconds.
+
+    Returns:
+        A configured ``PandasConnector``.
+    """
+    return PandasConnector(resolved.base_url, timeout=timeout)

--- a/src/pysdmx/toolkit/mcp/server.py
+++ b/src/pysdmx/toolkit/mcp/server.py
@@ -14,6 +14,7 @@ Run it over STDIO with ``python -m pysdmx.toolkit.mcp``.
 """
 
 # ruff: noqa: E402
+import math
 from typing import Any, Dict, List, Optional, Tuple
 
 from pysdmx.__extras_check import __check_data_extra, __check_mcp_extra
@@ -531,27 +532,33 @@ def _records(df: "pd.DataFrame") -> List[Dict[str, Any]]:
     Returns:
         One dictionary per row.
     """
-    safe = df.astype(object).where(pd.notna(df), None)
     return [
         {str(k): _scalar(v) for k, v in row.items()}
-        for row in safe.to_dict(orient="records")
+        for row in df.astype(object).to_dict(orient="records")
     ]
 
 
 def _scalar(value: Any) -> Any:
     """Coerce a numpy or pandas scalar to a JSON-safe Python value.
 
+    Missing values are normalised to ``None`` here rather than through
+    ``DataFrame.where``, whose ``other=None`` overload is not accepted
+    by every pandas-stubs release and therefore fails type checking on
+    some of the Python versions this project supports.
+
     Args:
         value: The value to coerce.
 
     Returns:
-        A Python primitive, or ``None``.
+        A Python primitive, or ``None`` for any missing value.
     """
-    if value is None:
+    if value is None or value is pd.NaT or value is pd.NA:
         return None
     item = getattr(value, "item", None)
     if callable(item):
-        return item()
+        value = item()
+    if isinstance(value, float) and math.isnan(value):
+        return None
     return value
 
 

--- a/src/pysdmx/toolkit/mcp/server.py
+++ b/src/pysdmx/toolkit/mcp/server.py
@@ -1,0 +1,680 @@
+"""An MCP server exposing SDMX data discovery and retrieval.
+
+Four tools, in the order they are meant to be called:
+
+1. :func:`list_services` - what can I talk to?
+2. :func:`search_dataflows` - which dataset holds this?
+3. :func:`inspect_dataflow` - what can I filter on, and how big is it?
+4. :func:`get_data` - give me the numbers.
+
+The last one is the point. Comparable SDMX MCP servers navigate metadata
+and then hand back a URL; this one returns observations.
+
+Run it over STDIO with ``python -m pysdmx.toolkit.mcp``.
+"""
+
+# ruff: noqa: E402
+from typing import Any, Dict, List, Optional, Tuple
+
+from pysdmx.__extras_check import __check_data_extra, __check_mcp_extra
+
+__check_mcp_extra()
+__check_data_extra()
+
+import pandas as pd
+from fastmcp import FastMCP
+from pydantic import Field
+from typing_extensions import Annotated
+
+from pysdmx.toolkit.mcp import _matching, _safety, _services
+from pysdmx.toolkit.mcp._errors import as_tool_error
+from pysdmx.toolkit.mcp._models import (
+    CodeInfo,
+    CodeLocation,
+    ComponentInfo,
+    DataflowDetail,
+    DataflowSearchResult,
+    DataflowSummary,
+    DataResult,
+    ServiceInfo,
+    ServiceList,
+)
+
+_INSTRUCTIONS = (
+    "Discover and retrieve official statistics from SDMX-REST v2 "
+    "services.\n\n"
+    "Call the tools in order: list_services -> search_dataflows -> "
+    "inspect_dataflow -> get_data.\n\n"
+    "Rules that prevent wrong answers:\n"
+    "- Filter syntax supports AND only. NEVER emit OR. For several "
+    "values of one component use IN ('A', 'B').\n"
+    "- Availability is not validity. inspect_dataflow returns codes for "
+    "which data currently exist; a code absent from that list may still "
+    "be valid in the full codelist, so never report that something "
+    "'does not exist' on that basis alone.\n"
+    "- A country code may appear in several dimensions with different "
+    "meanings. Pass find_code to inspect_dataflow to see every "
+    "component carrying a value, and state which role you used.\n"
+    "- If the question is only whether data exist, stop at "
+    "inspect_dataflow. Do not call get_data unless observations were "
+    "actually requested.\n"
+    "- Check size before retrieving. When get_data reports "
+    "truncated=true the rows are the first N and NOT a sample, so do "
+    "not aggregate them - narrow the filter instead."
+)
+
+mcp: FastMCP[Any] = FastMCP(
+    name="pysdmx-sdmx-data", instructions=_INSTRUCTIONS
+)
+
+#: Cap on codes listed per component, so that inspecting a dataflow with
+#: a 259-code country dimension does not flood the response.
+_CODE_PREVIEW_LIMIT = 60
+
+_AVAILABILITY_NOTE = (
+    "These codes are availability-backed: values for which data "
+    "currently exist in this scope. A code missing here may still be "
+    "valid in the full codelist - verify against structural metadata "
+    "before concluding that it does not exist."
+)
+
+
+@mcp.tool
+def list_services() -> ServiceList:
+    """List the SDMX services this server can query.
+
+    Any SDMX-REST v2 base URL also works: pass it as the service
+    argument to any other tool. The service must return structural
+    metadata as SDMX-JSON 2.0.0 and data as SDMX-CSV.
+
+    Returns:
+        The known services, with capability notes for each.
+    """
+    entries = [
+        ServiceInfo(
+            name=name,
+            base_url=url,
+            source="pysdmx",
+            verified=name == "BIS",
+            notes=_services.notes_for(name),
+        )
+        for name, url in _services.known_services().items()
+    ]
+    return ServiceList(
+        services=entries,
+        next_step=(
+            "Call search_dataflows with a topic to find a dataset. "
+            "pysdmx currently ships one endpoint, so for any other "
+            "provider (ECB, OECD, IMF, Eurostat, ILO) pass its "
+            "SDMX-REST v2 base URL as the service argument - it is a "
+            "first-class input, not a fallback."
+        ),
+    )
+
+
+@mcp.tool
+def search_dataflows(
+    query: Annotated[
+        str,
+        Field(
+            description=(
+                "Topic to search for, such as 'banking' or 'policy "
+                "rates'. Space-separated words are treated as "
+                "alternatives and matched case-insensitively against "
+                "each dataflow's id, name and description. Pass an "
+                "empty string to list every dataflow."
+            )
+        ),
+    ] = "",
+    service: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Service name from list_services, or an SDMX-REST v2 "
+                "base URL. Defaults to the pysdmx endpoint."
+            )
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        Field(description="Maximum dataflows to return.", ge=1, le=200),
+    ] = 50,
+) -> DataflowSearchResult:
+    """Find dataflows (datasets) matching a topic.
+
+    Issues exactly one request to the service and matches the terms
+    locally, so searching for synonyms costs nothing extra: put them all
+    in one query rather than calling this repeatedly.
+
+    Returns:
+        Matching dataflows, each with a ref to pass to the next tool.
+
+    Raises:
+        ToolError: If the service is unknown or the request fails. The
+            message carries a [kind] discriminator and a retry hint.
+    """
+    resolved = _resolve(service)
+    conn = _services.connector(resolved)
+
+    try:
+        flows = conn.dataflows()
+    except Exception as exc:
+        raise as_tool_error(exc) from exc
+
+    terms = [t for t in query.lower().split() if t]
+    matches: List[DataflowSummary] = []
+    for flow in flows:
+        matched_on = _matching.match_dataflow(flow, terms)
+        if terms and matched_on is None:
+            continue
+        agency = getattr(flow, "agency", "")
+        matches.append(
+            DataflowSummary(
+                ref=_matching.dataflow_ref(flow),
+                id=flow.id,
+                name=_text(getattr(flow, "name", None)),
+                description=_text(getattr(flow, "description", None)),
+                agency=str(getattr(agency, "id", agency)),
+                version=str(flow.version),
+                matched_on=matched_on,
+            )
+        )
+
+    return DataflowSearchResult(
+        service=resolved.name,
+        search_terms=terms,
+        total_dataflows_on_service=len(flows),
+        match_count=len(matches),
+        dataflows=matches[:limit],
+        next_step=_search_next_step(matches, len(flows)),
+    )
+
+
+@mcp.tool
+def inspect_dataflow(
+    ref: Annotated[
+        str,
+        Field(
+            description=(
+                "Dataflow reference in agency:id(version) form, such as "
+                "'BIS:WS_CBS_PUB(1.0)'. Take this from the ref field of "
+                "search_dataflows. A full SDMX URN also works."
+            )
+        ),
+    ],
+    filters: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Optional filter scoping availability to a subset, such "
+                "as \"L_REP_CTY = 'CH' AND FREQ = 'Q'\". AND only, "
+                "never OR; use IN ('A', 'B') for several values of one "
+                "component. Supplying this narrows the reported codes "
+                "and counts to what remains available."
+            )
+        ),
+    ] = None,
+    find_code: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Optional code value such as 'CH'. Reports every "
+                "component whose available codes contain it, and the "
+                "role each plays. Use this before filtering on a "
+                "country: the same code often appears in several "
+                "dimensions with different meanings."
+            )
+        ),
+    ] = None,
+    service: Annotated[
+        Optional[str],
+        Field(description="Service name or SDMX-REST v2 base URL."),
+    ] = None,
+) -> DataflowDetail:
+    """Inspect a dataflow's components, available codes and size.
+
+    Call this before get_data. It answers three questions: what can I
+    filter on, which codes actually have data, and is this small enough
+    to retrieve?
+
+    If you only need to know whether data exist for some subset, pass
+    filters and stop here rather than going on to get_data.
+
+    Returns:
+        Components grouped by role, availability-backed codes, and size
+        signals with a warning when retrieval would truncate.
+
+    Raises:
+        ToolError: If the dataflow is not found or the request fails.
+    """
+    resolved = _resolve(service)
+    conn = _services.connector(resolved)
+
+    try:
+        flow = conn.dataflow(ref, filters)
+    except Exception as exc:
+        raise as_tool_error(exc) from exc
+
+    components = getattr(flow, "components", None)
+    locations = (
+        _locate_code(components, find_code)
+        if find_code and components is not None
+        else []
+    )
+
+    series_count = getattr(flow, "series_count", None)
+    obs_count = getattr(flow, "obs_count", None)
+    warning = _safety.size_warning(series_count, obs_count)
+
+    return DataflowDetail(
+        service=resolved.name,
+        ref=ref,
+        name=_text(getattr(flow, "name", None)),
+        description=_text(getattr(flow, "description", None)),
+        filter_applied=filters,
+        series_count=series_count,
+        obs_count=obs_count,
+        size_warning=warning,
+        dimensions=_describe(components, "dimensions"),
+        measures=_describe(components, "measures"),
+        attributes=_describe(components, "attributes"),
+        code_locations=locations,
+        availability_note=_AVAILABILITY_NOTE,
+        next_step=_inspect_next_step(warning, locations, filters),
+    )
+
+
+@mcp.tool
+def get_data(
+    ref: Annotated[
+        str,
+        Field(
+            description=(
+                "Dataflow reference in agency:id(version) form, such as "
+                "'BIS:WS_CBS_PUB(1.0)'."
+            )
+        ),
+    ],
+    filters: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "Filter selecting the data, such as \"L_MEASURE = 'S' "
+                "AND L_REP_CTY = 'CH' AND TIME_PERIOD >= '2020-Q1'\". "
+                "AND only, never OR; use IN ('A', 'B') for several "
+                "values of one component. Omitting this pulls the whole "
+                "dataflow and will almost certainly truncate."
+            )
+        ),
+    ] = None,
+    columns: Annotated[
+        Optional[List[str]],
+        Field(
+            description=(
+                "Components to return, such as ['OBS_VALUE']. Omit for "
+                "all. TIME_PERIOD and SERIES_KEY are added "
+                "automatically by pysdmx."
+            )
+        ),
+    ] = None,
+    limit: Annotated[
+        Optional[int],
+        Field(
+            description=(
+                "Maximum rows to return. Defaults to 1000, hard ceiling 10000."
+            )
+        ),
+    ] = None,
+    labels: Annotated[
+        str,
+        Field(
+            description=(
+                "'id' returns code IDs (default, and far more compact). "
+                "'name' substitutes human-readable names. 'both' gives "
+                "'ID: Name'. Leave as 'id' unless names were requested."
+            ),
+            pattern="^(id|name|both)$",
+        ),
+    ] = "id",
+    service: Annotated[
+        Optional[str],
+        Field(description="Service name or SDMX-REST v2 base URL."),
+    ] = None,
+) -> DataResult:
+    """Retrieve observations as records. This returns the actual numbers.
+
+    Call inspect_dataflow first to confirm component and code IDs and to
+    check the size of what you are about to pull.
+
+    If a TIME_PERIOD clause is rejected by the service, it is retried
+    without that clause and the cutoff is applied locally; the response
+    says so in filter_fallback.
+
+    Returns:
+        The observations, the filter actually sent, and a truncated
+        flag. When truncated, the rows are the first N in service order
+        and are NOT a representative sample.
+
+    Raises:
+        ToolError: If retrieval fails. The message carries a [kind]
+            discriminator and a retry hint.
+    """
+    resolved = _resolve(service)
+    conn = _services.connector(resolved)
+    row_limit = _safety.clamp_limit(limit)
+
+    df, applied, fallback = _fetch(conn, ref, filters, columns, labels)
+
+    if list(df.index.names) != [None]:
+        df = df.reset_index()
+    total = int(len(df))
+    capped = df.head(row_limit)
+
+    return DataResult(
+        service=resolved.name,
+        ref=ref,
+        filter_applied=applied,
+        filter_fallback=fallback,
+        columns=[str(c) for c in capped.columns],
+        row_count=int(len(capped)),
+        total_rows_available=total,
+        truncated=total > row_limit,
+        records=_records(capped),
+        next_step=_data_next_step(total, row_limit, fallback),
+    )
+
+
+def _fetch(
+    conn: Any,
+    ref: str,
+    filters: Optional[str],
+    columns: Optional[List[str]],
+    labels: str,
+) -> Tuple["pd.DataFrame", Optional[str], Optional[str]]:
+    """Retrieve data, falling back to local time filtering if needed.
+
+    Args:
+        conn: The connector.
+        ref: Dataflow reference.
+        filters: The requested filter.
+        columns: Requested columns.
+        labels: Label mode.
+
+    Returns:
+        A tuple of the frame, the filter actually sent, and a note
+        describing the fallback when one was used.
+
+    Raises:
+        ToolError: If retrieval fails and no fallback applies.
+    """
+    kwargs: Dict[str, Any] = {"labels": labels}
+    if columns:
+        kwargs["columns"] = columns
+
+    try:
+        return conn.data(ref, filters, **kwargs), filters, None
+    except Exception as exc:
+        split = _safety.split_time_filter(filters)
+        if not (_safety.is_pushdown_failure(exc) and split.has_time):
+            raise as_tool_error(exc) from exc
+
+        # The service rejected a query carrying a time clause. Retry
+        # without it, then re-apply the cutoff with pandas.
+        try:
+            df = conn.data(ref, split.without_time, **kwargs)
+        except Exception as retry_exc:
+            raise as_tool_error(retry_exc) from retry_exc
+
+        conditions = ", ".join(
+            f"TIME_PERIOD {op} '{value}'" for op, value in split.constraints
+        )
+        note = (
+            f"The service rejected server-side time filtering, so "
+            f"{split.without_time!r} was sent instead and {conditions} "
+            f"was applied locally with pandas."
+        )
+        filtered = _safety.apply_time_locally(df, split.constraints)
+        return filtered, split.without_time, note
+
+
+def _resolve(service: Optional[str]) -> "_services.ResolvedService":
+    """Resolve a service argument, converting failure into a ToolError.
+
+    Args:
+        service: The service name or URL.
+
+    Returns:
+        The resolved service.
+
+    Raises:
+        ToolError: If the service cannot be resolved.
+    """
+    try:
+        return _services.resolve(service)
+    except Exception as exc:
+        raise as_tool_error(exc) from exc
+
+
+def _describe(components: Any, group: str) -> List[ComponentInfo]:
+    """Render one group of components for the response.
+
+    Args:
+        components: The dataflow's components, possibly ``None``.
+        group: ``dimensions``, ``measures`` or ``attributes``.
+
+    Returns:
+        The described components, or an empty list when the service
+        returned no component metadata.
+    """
+    if components is None:
+        return []
+
+    described: List[ComponentInfo] = []
+    for comp in getattr(components, group, []):
+        codes = _matching.codes_of(comp)
+        preview = codes[:_CODE_PREVIEW_LIMIT]
+        described.append(
+            ComponentInfo(
+                id=comp.id,
+                name=_text(getattr(comp, "name", None)),
+                role=group[:-1],
+                required=bool(getattr(comp, "required", False)),
+                code_count=len(codes),
+                codes=[
+                    CodeInfo(id=c.id, name=_text(getattr(c, "name", None)))
+                    for c in preview
+                ],
+                codes_truncated=len(codes) > len(preview),
+            )
+        )
+    return described
+
+
+def _locate_code(components: Any, value: str) -> List[CodeLocation]:
+    """Find every component whose available codes contain a value.
+
+    Args:
+        components: The dataflow's components.
+        value: The code to look for, matched case-insensitively.
+
+    Returns:
+        One entry per component carrying the code.
+    """
+    wanted = value.strip().upper()
+    found: List[CodeLocation] = []
+    for comp in components:
+        for code in _matching.codes_of(comp):
+            if str(code.id).upper() == wanted:
+                found.append(
+                    CodeLocation(
+                        component_id=comp.id,
+                        component_name=_text(getattr(comp, "name", None)),
+                        role_hint=_matching.role_hint(comp),
+                        code_id=code.id,
+                        code_name=_text(getattr(code, "name", None)),
+                    )
+                )
+                break
+    return found
+
+
+def _records(df: "pd.DataFrame") -> List[Dict[str, Any]]:
+    """Convert a data frame to JSON-safe records.
+
+    Categorical dtypes and numpy scalars do not serialise cleanly and
+    NaN is not valid JSON, so values are normalised to ``None`` or
+    Python primitives.
+
+    Args:
+        df: The frame to convert.
+
+    Returns:
+        One dictionary per row.
+    """
+    safe = df.astype(object).where(pd.notna(df), None)
+    return [
+        {str(k): _scalar(v) for k, v in row.items()}
+        for row in safe.to_dict(orient="records")
+    ]
+
+
+def _scalar(value: Any) -> Any:
+    """Coerce a numpy or pandas scalar to a JSON-safe Python value.
+
+    Args:
+        value: The value to coerce.
+
+    Returns:
+        A Python primitive, or ``None``.
+    """
+    if value is None:
+        return None
+    item = getattr(value, "item", None)
+    if callable(item):
+        return item()
+    return value
+
+
+def _text(value: Any) -> Optional[str]:
+    """Normalise an optional metadata field to a string or ``None``.
+
+    Args:
+        value: The raw metadata value.
+
+    Returns:
+        The stripped string, or ``None`` when empty or absent.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _search_next_step(matches: List[DataflowSummary], total: int) -> str:
+    """Compose the hint returned by search_dataflows.
+
+    Args:
+        matches: The matching dataflows.
+        total: How many dataflows the service holds.
+
+    Returns:
+        The hint.
+    """
+    if not matches:
+        return (
+            f"Nothing matched. The service has {total} dataflows - call "
+            f"this again with an empty query to see them all, or try "
+            f"broader terms. Some concepts appear only in component or "
+            f"code labels, so also consider inspect_dataflow on a "
+            f"plausible dataflow before concluding no data exist."
+        )
+    if len(matches) == 1:
+        return (
+            f"Call inspect_dataflow with ref='{matches[0].ref}' to see "
+            f"its dimensions, available codes and size."
+        )
+    return (
+        f"{len(matches)} dataflows matched. Call inspect_dataflow on the "
+        f"most promising ref to see its dimensions and size before "
+        f"retrieving anything."
+    )
+
+
+def _inspect_next_step(
+    warning: Optional[str],
+    locations: List[CodeLocation],
+    filters: Optional[str],
+) -> str:
+    """Compose the hint returned by inspect_dataflow.
+
+    Args:
+        warning: The size warning, if any.
+        locations: Components carrying a searched-for code.
+        filters: The filter that scoped availability, if any.
+
+    Returns:
+        The hint.
+    """
+    if len(locations) > 1:
+        roles = "; ".join(
+            f"{loc.component_id} ({loc.role_hint})" for loc in locations
+        )
+        return (
+            f"That code is ambiguous - it appears in {len(locations)} "
+            f"components: {roles}. Decide which role the question "
+            f"means, filter on that component, and state which one you "
+            f"used."
+        )
+    if warning:
+        return (
+            "This scope is large. Add filters and call inspect_dataflow "
+            "again to confirm the subset shrinks, then call get_data. "
+            "If the question was only whether data exist, you already "
+            "have the answer - stop here."
+        )
+    if filters:
+        return (
+            "Availability for this subset is confirmed. If observations "
+            "were requested, call get_data with the same filter. If the "
+            "question was only whether data exist, stop here."
+        )
+    return (
+        "Choose dimensions to filter on from the codes above, then call "
+        "get_data. Filtering first is strongly preferred - unfiltered "
+        "pulls truncate."
+    )
+
+
+def _data_next_step(
+    total: int, row_limit: int, fallback: Optional[str]
+) -> str:
+    """Compose the hint returned by get_data.
+
+    Args:
+        total: Rows matching before the cap.
+        row_limit: The cap applied.
+        fallback: The fallback note, if the time filter ran locally.
+
+    Returns:
+        The hint.
+    """
+    if total > row_limit:
+        hint = (
+            f"Truncated: {total:,} rows matched but only {row_limit:,} "
+            f"were returned. These are the first rows in service order, "
+            f"not a sample - do not compute totals or averages from "
+            f"them. Narrow the filter (add a TIME_PERIOD bound or more "
+            f"dimensions) and call again."
+        )
+    else:
+        hint = (
+            f"Complete: all {total:,} matching rows were returned. Safe "
+            f"to aggregate."
+        )
+    if fallback:
+        hint += (
+            " Time filtering happened locally, so rows outside the "
+            "requested period were fetched and discarded. The counts "
+            "above are post-filter."
+        )
+    return hint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,8 @@ PATH_RULES = {
     "/tests/io/test_input_processor.py": ("data", True),
     # vtl tests
     "/tests/toolkit/vtl/": ("vtl", True),
+    # mcp tests
+    "/tests/toolkit/mcp/": ("mcp", True),
     # noextra tests
     "/tests/model/": ("noextra", True),
     "/tests/api/fmr/": ("noextra", True),

--- a/tests/toolkit/mcp/test_end_to_end.py
+++ b/tests/toolkit/mcp/test_end_to_end.py
@@ -1,0 +1,101 @@
+"""End-to-end tests over mocked HTTP.
+
+The other server tests inject a fake connector to exercise branches
+deterministically. These ones go through the real ``PandasConnector``
+against ``respx``-mocked responses, so that a change in how pysdmx
+builds SDMX-REST URLs or parses SDMX-CSV is caught here rather than in
+production.
+"""
+
+import httpx
+import pytest
+
+from pysdmx.toolkit.mcp import server
+
+
+@pytest.fixture
+def host():
+    return "https://test.org"
+
+
+@pytest.fixture
+def json_availability():
+    with open("tests/io/samples/bis_der.json", "rb") as f:
+        return f.read()
+
+
+@pytest.fixture
+def csv_data():
+    with open("tests/io/csv/sdmx20/reader/samples/data_v2.csv", "rb") as f:
+        return f.read()
+
+
+@pytest.fixture
+def query_availability(host):
+    return f"{host}/availability/dataflow/BIS/BIS_DER/1.0?references=all"
+
+
+@pytest.fixture
+def query_data(host):
+    return (
+        f"{host}/data/dataflow/BIS/BIS_DER/1.0"
+        "?dimensionAtObservation=AllDimensions"
+    )
+
+
+def test_inspect_dataflow_over_http(
+    respx_mock, host, query_availability, json_availability
+):
+    respx_mock.get(query_availability).mock(
+        return_value=httpx.Response(200, content=json_availability)
+    )
+
+    result = server.inspect_dataflow("BIS:BIS_DER(1.0)", service=host)
+
+    assert result.service == host
+    assert result.ref == "BIS:BIS_DER(1.0)"
+    assert result.dimensions
+    assert result.availability_note
+    assert result.next_step
+
+
+def test_get_data_over_http_returns_observations(
+    respx_mock,
+    host,
+    query_availability,
+    query_data,
+    json_availability,
+    csv_data,
+):
+    respx_mock.get(query_availability).mock(
+        return_value=httpx.Response(200, content=json_availability)
+    )
+    respx_mock.get(query_data).mock(
+        return_value=httpx.Response(200, content=csv_data)
+    )
+
+    result = server.get_data("BIS:BIS_DER(1.0)", service=host)
+
+    # The whole point of this server: numbers, not a query URL.
+    assert result.row_count > 0
+    assert result.records
+    assert "OBS_VALUE" in result.columns
+    assert result.truncated is False
+
+
+def test_errors_are_classified_over_http(respx_mock, host):
+    respx_mock.get(
+        f"{host}/availability/dataflow/BIS/NOPE/1.0?references=all"
+    ).mock(return_value=httpx.Response(404))
+
+    with pytest.raises(Exception, match=r"\[not_found\]"):
+        server.inspect_dataflow("BIS:NOPE(1.0)", service=host)
+
+
+def test_server_errors_are_classified_over_http(respx_mock, host):
+    respx_mock.get(
+        f"{host}/availability/dataflow/BIS/BOOM/1.0?references=all"
+    ).mock(return_value=httpx.Response(500))
+
+    with pytest.raises(Exception, match=r"\[internal_error\]"):
+        server.inspect_dataflow("BIS:BOOM(1.0)", service=host)

--- a/tests/toolkit/mcp/test_errors.py
+++ b/tests/toolkit/mcp/test_errors.py
@@ -1,0 +1,86 @@
+import pytest
+from fastmcp.exceptions import ToolError
+
+from pysdmx import errors
+from pysdmx.toolkit.mcp._errors import as_tool_error, classify
+
+
+@pytest.mark.parametrize(
+    ("exc", "kind", "retriable"),
+    [
+        (errors.Unavailable("down"), "unavailable", True),
+        (errors.NotFound("gone"), "not_found", False),
+        (errors.Unauthorized("nope"), "unauthorized", False),
+        (errors.NotImplemented("no"), "not_implemented", False),
+        (errors.Invalid("bad"), "invalid_request", False),
+        (errors.InternalError("boom"), "internal_error", False),
+        (errors.RetriableError("later"), "retriable_error", True),
+        (errors.PysdmxError("generic"), "sdmx_error", False),
+        (ValueError("bug"), "unexpected_error", False),
+    ],
+)
+def test_classify(exc, kind, retriable):
+    info = classify(exc)
+
+    assert info["error"] == kind
+    assert info["retriable"] is retriable
+    assert info["next_step"]
+
+
+def test_classify_prefers_most_specific_type():
+    # Unavailable subclasses RetriableError, which subclasses
+    # PysdmxError. Collapsing them would tell an agent to retry a
+    # NotFound, or to give up on a transient outage.
+    assert classify(errors.Unavailable("x"))["error"] == "unavailable"
+    assert classify(errors.RetriableError("x"))["error"] == "retriable_error"
+
+
+def test_classify_keeps_not_found_and_unavailable_distinct():
+    not_found = classify(errors.NotFound("x"))
+    unavailable = classify(errors.Unavailable("x"))
+
+    assert not_found["retriable"] is False
+    assert unavailable["retriable"] is True
+    assert not_found["next_step"] != unavailable["next_step"]
+
+
+def test_classify_uses_title_and_description():
+    info = classify(errors.NotFound("Flow missing", "Try search_dataflows."))
+
+    assert info["message"] == "Flow missing"
+    assert info["detail"] == "Try search_dataflows."
+
+
+def test_classify_without_description():
+    assert classify(errors.NotFound("Flow missing"))["detail"] is None
+
+
+def test_classify_non_pysdmx_error_reports_type_as_detail():
+    info = classify(ValueError("bug"))
+
+    assert info["message"] == "bug"
+    assert info["detail"] == "ValueError"
+    assert "pysdmx MCP server" in info["next_step"]
+
+
+def test_classify_falls_back_to_type_name_for_empty_message():
+    assert classify(ValueError())["message"] == "ValueError"
+
+
+def test_as_tool_error_embeds_the_classification():
+    err = as_tool_error(errors.NotFound("Flow missing", "Not here."))
+
+    assert isinstance(err, ToolError)
+    assert "[not_found]" in str(err)
+    assert "Flow missing" in str(err)
+    assert "Not here." in str(err)
+    assert "retriable=false" in str(err)
+    assert "next_step:" in str(err)
+
+
+def test_as_tool_error_without_detail():
+    err = as_tool_error(errors.Unavailable("Service down"))
+
+    assert "[unavailable]" in str(err)
+    assert "retriable=true" in str(err)
+    assert " - " not in str(err).split("|")[0]

--- a/tests/toolkit/mcp/test_main.py
+++ b/tests/toolkit/mcp/test_main.py
@@ -1,0 +1,43 @@
+import pytest
+
+from pysdmx.toolkit.mcp import __main__
+
+
+@pytest.fixture
+def run_calls(mocker):
+    return mocker.patch("pysdmx.toolkit.mcp.__main__.mcp.run")
+
+
+def test_defaults_to_stdio(run_calls):
+    __main__.main([])
+
+    run_calls.assert_called_once_with()
+
+
+def test_stdio_can_be_requested_explicitly(run_calls):
+    __main__.main(["--transport", "stdio"])
+
+    run_calls.assert_called_once_with()
+
+
+def test_http_transport(run_calls):
+    __main__.main(["--transport", "http", "--host", "10.0.0.1", "--port", "9"])
+
+    run_calls.assert_called_once_with(
+        transport="http", host="10.0.0.1", port=9
+    )
+
+
+def test_http_transport_defaults(run_calls):
+    __main__.main(["--transport", "http"])
+
+    run_calls.assert_called_once_with(
+        transport="http", host="127.0.0.1", port=8000
+    )
+
+
+def test_rejects_unknown_transport(run_calls):
+    with pytest.raises(SystemExit):
+        __main__.main(["--transport", "carrier-pigeon"])
+
+    run_calls.assert_not_called()

--- a/tests/toolkit/mcp/test_matching.py
+++ b/tests/toolkit/mcp/test_matching.py
@@ -1,0 +1,122 @@
+import pytest
+
+from pysdmx.model import Agency, Code, Dataflow
+from pysdmx.toolkit.mcp import _matching
+
+
+class FakeComponent:
+    """Duck-typed stand-in for a pysdmx Component."""
+
+    def __init__(self, id, name=None, description=None, enumeration=None):
+        """Instantiate a fake component."""
+        self.id = id
+        self.name = name
+        self.description = description
+        self.enumeration = enumeration
+
+
+def test_dataflow_ref_from_agency_object():
+    flow = Dataflow("CBS", agency=Agency("BIS"), version="1.0")
+
+    assert _matching.dataflow_ref(flow) == "BIS:CBS(1.0)"
+
+
+def test_dataflow_ref_from_agency_string():
+    flow = Dataflow("CBS", agency="BIS", version="1.0")
+
+    assert _matching.dataflow_ref(flow) == "BIS:CBS(1.0)"
+
+
+@pytest.mark.parametrize(
+    ("terms", "expected"),
+    [
+        ([], None),
+        (["cbs"], "id"),
+        (["banking"], "name"),
+        (["positions"], "description"),
+        (["nothing"], None),
+    ],
+)
+def test_match_dataflow(terms, expected):
+    flow = Dataflow(
+        "CBS",
+        agency="BIS",
+        name="Consolidated banking",
+        description="Cross-border positions",
+    )
+
+    assert _matching.match_dataflow(flow, terms) == expected
+
+
+def test_match_dataflow_reports_id_first():
+    # A term hitting several fields should be reported against the most
+    # precise one, so the caller can judge match quality.
+    flow = Dataflow("CBS", agency="BIS", name="CBS banking", description="CBS")
+
+    assert _matching.match_dataflow(flow, ["cbs"]) == "id"
+
+
+def test_match_dataflow_tolerates_missing_optional_fields():
+    flow = Dataflow("CBS", agency="BIS")
+
+    assert _matching.match_dataflow(flow, ["cbs"]) == "id"
+    assert _matching.match_dataflow(flow, ["missing"]) is None
+
+
+@pytest.mark.parametrize(
+    ("comp_id", "name", "expected"),
+    [
+        ("L_REP_CTY", "Reporting country", "reporting country"),
+        ("L_CP_COUNTRY", "Counterparty country", "counterparty country"),
+        ("REF_AREA", "Reference area", "reference area"),
+        ("CURRENCY", "Currency", "currency"),
+        ("ISSUER", "Issuer", "issuer"),
+        ("RESIDENCE", "Country of residence", "country of residence"),
+        ("NATIONALITY", "Nationality", "nationality"),
+        ("BORROWER", "Borrower", "borrower country"),
+        (
+            "CBS_BANK_TYPE",
+            "CBS bank type",
+            "bank type (shares a country codelist)",
+        ),
+    ],
+)
+def test_role_hint_recognises_country_roles(comp_id, name, expected):
+    # The point of this: 'in Switzerland' must not silently resolve to
+    # the wrong dimension.
+    assert _matching.role_hint(FakeComponent(comp_id, name)) == expected
+
+
+def test_role_hint_falls_back_to_name():
+    comp = FakeComponent("WEIRD_DIM", "Some other thing")
+
+    assert _matching.role_hint(comp) == "Some other thing"
+
+
+def test_role_hint_falls_back_to_id():
+    assert _matching.role_hint(FakeComponent("WEIRD_DIM")) == "WEIRD_DIM"
+
+
+def test_role_hint_matches_on_description():
+    comp = FakeComponent("X", "Y", description="The reporting country")
+
+    assert _matching.role_hint(comp) == "reporting country"
+
+
+def test_codes_of_returns_codes():
+    comp = FakeComponent("F", enumeration=[Code("A"), Code("B")])
+
+    assert [c.id for c in _matching.codes_of(comp)] == ["A", "B"]
+
+
+@pytest.mark.parametrize("enumeration", [None, []])
+def test_codes_of_tolerates_uncoded_components(enumeration):
+    assert (
+        _matching.codes_of(FakeComponent("F", enumeration=enumeration)) == []
+    )
+
+
+def test_codes_of_drops_none_entries():
+    comp = FakeComponent("F", enumeration=[Code("A"), None])
+
+    assert [c.id for c in _matching.codes_of(comp)] == ["A"]

--- a/tests/toolkit/mcp/test_safety.py
+++ b/tests/toolkit/mcp/test_safety.py
@@ -1,0 +1,168 @@
+import pandas as pd
+import pytest
+
+from pysdmx import errors
+from pysdmx.toolkit.mcp import _safety
+
+
+@pytest.mark.parametrize(
+    ("supplied", "expected"),
+    [
+        (None, _safety.DEFAULT_ROW_LIMIT),
+        (0, 1),
+        (-5, 1),
+        (10, 10),
+        (_safety.MAX_ROW_LIMIT + 1, _safety.MAX_ROW_LIMIT),
+        (10**9, _safety.MAX_ROW_LIMIT),
+    ],
+)
+def test_clamp_limit(supplied, expected):
+    assert _safety.clamp_limit(supplied) == expected
+
+
+@pytest.mark.parametrize(
+    ("filters", "without_time", "constraints"),
+    [
+        (None, None, ()),
+        ("", "", ()),
+        ("FREQ = 'M'", "FREQ = 'M'", ()),
+        (
+            "FREQ = 'M' AND TIME_PERIOD >= '2018-01'",
+            "FREQ = 'M'",
+            ((">=", "2018-01"),),
+        ),
+        (
+            "TIME_PERIOD >= '2018-01' AND FREQ = 'M'",
+            "FREQ = 'M'",
+            ((">=", "2018-01"),),
+        ),
+        (
+            "A = '1' AND TIME_PERIOD >= '2018-01' AND B = '2'",
+            "A = '1' AND B = '2'",
+            ((">=", "2018-01"),),
+        ),
+        ("TIME_PERIOD >= '2018-01'", None, ((">=", "2018-01"),)),
+        (
+            "TIME_PERIOD >= '2018-01' AND TIME_PERIOD <= '2020-12'",
+            None,
+            ((">=", "2018-01"), ("<=", "2020-12")),
+        ),
+        ('TIME_PERIOD = "2020"', None, (("=", "2020"),)),
+        ("TIME_PERIOD = 2020", None, (("=", "2020"),)),
+        ("time_period >= '2018'", None, ((">=", "2018"),)),
+    ],
+)
+def test_split_time_filter(filters, without_time, constraints):
+    split = _safety.split_time_filter(filters)
+
+    assert split.without_time == without_time
+    assert split.constraints == constraints
+    assert split.has_time is bool(constraints)
+
+
+def test_split_time_filter_leaves_similarly_named_component():
+    # A component whose name merely contains TIME_PERIOD as a substring
+    # must not be mistaken for the time dimension.
+    split = _safety.split_time_filter("MY_TIME_PERIODICITY = 'A'")
+
+    assert split.without_time == "MY_TIME_PERIODICITY = 'A'"
+    assert split.constraints == ()
+
+
+@pytest.fixture
+def frame():
+    return pd.DataFrame(
+        {
+            "TIME_PERIOD": ["2018-Q1", "2019-Q1", "2020-Q1", "2021-Q1"],
+            "OBS_VALUE": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("op", "value", "expected"),
+    [
+        (">=", "2020-Q1", ["2020-Q1", "2021-Q1"]),
+        (">", "2020-Q1", ["2021-Q1"]),
+        ("<=", "2019-Q1", ["2018-Q1", "2019-Q1"]),
+        ("<", "2019-Q1", ["2018-Q1"]),
+        ("=", "2019-Q1", ["2019-Q1"]),
+        ("==", "2019-Q1", ["2019-Q1"]),
+        ("<>", "2019-Q1", ["2018-Q1", "2020-Q1", "2021-Q1"]),
+        ("!=", "2019-Q1", ["2018-Q1", "2020-Q1", "2021-Q1"]),
+    ],
+)
+def test_apply_time_locally_operators(frame, op, value, expected):
+    out = _safety.apply_time_locally(frame, ((op, value),))
+
+    assert list(out["TIME_PERIOD"]) == expected
+
+
+def test_apply_time_locally_combines_constraints(frame):
+    out = _safety.apply_time_locally(
+        frame, ((">=", "2019-Q1"), ("<=", "2020-Q1"))
+    )
+
+    assert list(out["TIME_PERIOD"]) == ["2019-Q1", "2020-Q1"]
+
+
+def test_apply_time_locally_without_constraints(frame):
+    assert _safety.apply_time_locally(frame, ()) is frame
+
+
+def test_apply_time_locally_without_time_column():
+    df = pd.DataFrame({"OBS_VALUE": [1.0]})
+
+    assert _safety.apply_time_locally(df, ((">=", "2020"),)) is df
+
+
+def test_size_warning_flags_large_obs_count():
+    warning = _safety.size_warning(None, 5_000, row_limit=1_000)
+
+    assert warning is not None
+    assert "5,000 observations" in warning
+
+
+def test_size_warning_flags_large_series_count():
+    warning = _safety.size_warning(_safety.LARGE_SERIES_THRESHOLD + 1, None)
+
+    assert warning is not None
+    assert "series" in warning
+
+
+def test_size_warning_flags_unknown_size():
+    # BIS reports neither for some scopes; silence would read as "small".
+    warning = _safety.size_warning(None, None)
+
+    assert warning is not None
+    assert "unknown" in warning
+
+
+@pytest.mark.parametrize(
+    ("series_count", "obs_count"),
+    [(10, None), (None, 10), (10, 10), (0, 0)],
+)
+def test_size_warning_silent_when_small(series_count, obs_count):
+    assert _safety.size_warning(series_count, obs_count) is None
+
+
+def test_size_warning_prefers_obs_count_when_both_present():
+    # obs_count is the more direct signal, so it wins when available.
+    warning = _safety.size_warning(1, 9_999, row_limit=10)
+
+    assert "9,999 observations" in warning
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (errors.Invalid("nope"), True),
+        (errors.NotImplemented("nope"), True),
+        (errors.NotFound("nope"), False),
+        (errors.Unavailable("nope"), False),
+        (errors.InternalError("nope"), False),
+        (ValueError("nope"), False),
+    ],
+)
+def test_is_pushdown_failure(exc, expected):
+    assert _safety.is_pushdown_failure(exc) is expected

--- a/tests/toolkit/mcp/test_server.py
+++ b/tests/toolkit/mcp/test_server.py
@@ -1,0 +1,658 @@
+import numpy as np
+import pandas as pd
+import pytest
+from fastmcp.exceptions import ToolError
+
+from pysdmx import errors
+from pysdmx.model import Code, Dataflow
+from pysdmx.toolkit.mcp import _safety, _services, server
+
+
+class FakeComponent:
+    """Duck-typed stand-in for a pysdmx Component.
+
+    The server reads components through getattr, so a light fake keeps
+    these tests focused on server behaviour rather than on constructing
+    a full DSD.
+    """
+
+    def __init__(self, id, name=None, enumeration=None, required=True):
+        """Instantiate a fake component."""
+        self.id = id
+        self.name = name
+        self.enumeration = enumeration
+        self.required = required
+
+
+class FakeComponents:
+    """Duck-typed stand-in for a pysdmx Components collection."""
+
+    def __init__(self, dimensions=(), measures=(), attributes=()):
+        """Instantiate a fake components collection."""
+        self.dimensions = list(dimensions)
+        self.measures = list(measures)
+        self.attributes = list(attributes)
+
+    def __iter__(self):
+        """Iterate over every component, whatever its role."""
+        return iter(self.dimensions + self.measures + self.attributes)
+
+
+class FakeFlow:
+    """Duck-typed stand-in for a pysdmx Dataflow with availability."""
+
+    def __init__(
+        self,
+        name="Consolidated banking",
+        description=None,
+        components=None,
+        series_count=None,
+        obs_count=None,
+    ):
+        """Instantiate a fake dataflow."""
+        self.name = name
+        self.description = description
+        self.components = components
+        self.series_count = series_count
+        self.obs_count = obs_count
+
+
+class FakeConnector:
+    """Records calls so tests can assert what was actually sent."""
+
+    def __init__(self, flows=(), flow=None, data=None, raises=None):
+        """Instantiate a fake connector."""
+        self._flows = tuple(flows)
+        self._flow = flow
+        self._data = data
+        self._raises = raises
+        self.data_calls = []
+        self.dataflow_calls = []
+
+    def dataflows(self, search_term=None):
+        """Return the canned dataflows, or raise the canned error."""
+        if isinstance(self._raises, Exception):
+            raise self._raises
+        return self._flows
+
+    def dataflow(self, ref, filters=None):
+        """Return the canned dataflow, recording the call."""
+        self.dataflow_calls.append((ref, filters))
+        if isinstance(self._raises, Exception):
+            raise self._raises
+        return self._flow
+
+    def data(self, ref, filters=None, **kwargs):
+        """Return canned data, or delegate to a responder callable."""
+        self.data_calls.append((ref, filters, kwargs))
+        result = self._data
+        if callable(result):
+            return result(ref, filters, **kwargs)
+        return result
+
+
+@pytest.fixture
+def use_connector(monkeypatch):
+    """Install a fake connector for every tool call."""
+
+    def _install(connector):
+        monkeypatch.setattr(
+            _services, "connector", lambda resolved, **kw: connector
+        )
+        return connector
+
+    return _install
+
+
+# --------------------------------------------------------------------
+# list_services
+# --------------------------------------------------------------------
+
+
+def test_list_services_reports_the_pysdmx_endpoint():
+    result = server.list_services()
+
+    assert [s.name for s in result.services] == ["BIS"]
+    assert result.services[0].verified is True
+    assert result.custom_endpoints_supported is True
+    assert "base URL" in result.next_step
+
+
+# --------------------------------------------------------------------
+# search_dataflows
+# --------------------------------------------------------------------
+
+
+@pytest.fixture
+def flows():
+    return (
+        Dataflow(
+            "WS_CBS_PUB",
+            agency="BIS",
+            version="1.0",
+            name="Consolidated banking",
+        ),
+        Dataflow(
+            "WS_CBPOL",
+            agency="BIS",
+            version="1.0",
+            name="Central bank policy rates",
+        ),
+    )
+
+
+def test_search_dataflows_matches_locally(use_connector, flows):
+    use_connector(FakeConnector(flows=flows))
+
+    result = server.search_dataflows("banking")
+
+    assert result.match_count == 1
+    assert result.dataflows[0].ref == "BIS:WS_CBS_PUB(1.0)"
+    assert result.dataflows[0].matched_on == "name"
+    assert result.total_dataflows_on_service == 2
+    assert "inspect_dataflow" in result.next_step
+
+
+def test_search_dataflows_treats_words_as_alternatives(use_connector, flows):
+    # One call, many synonyms - the documented way to avoid repeated
+    # round trips for each candidate term.
+    use_connector(FakeConnector(flows=flows))
+
+    result = server.search_dataflows("banking policy")
+
+    assert result.match_count == 2
+    assert result.search_terms == ["banking", "policy"]
+
+
+def test_search_dataflows_empty_query_returns_everything(use_connector, flows):
+    use_connector(FakeConnector(flows=flows))
+
+    result = server.search_dataflows("")
+
+    assert result.match_count == 2
+    assert result.dataflows[0].matched_on is None
+
+
+def test_search_dataflows_no_match_suggests_recovery(use_connector, flows):
+    use_connector(FakeConnector(flows=flows))
+
+    result = server.search_dataflows("cryptocurrency")
+
+    assert result.match_count == 0
+    assert result.dataflows == []
+    assert "component or code labels" in result.next_step
+
+
+def test_search_dataflows_single_match_names_the_ref(use_connector, flows):
+    use_connector(FakeConnector(flows=flows))
+
+    result = server.search_dataflows("banking")
+
+    assert "BIS:WS_CBS_PUB(1.0)" in result.next_step
+
+
+def test_search_dataflows_applies_limit(use_connector, flows):
+    use_connector(FakeConnector(flows=flows))
+
+    result = server.search_dataflows("", limit=1)
+
+    assert result.match_count == 2
+    assert len(result.dataflows) == 1
+
+
+def test_search_dataflows_maps_errors(use_connector):
+    use_connector(FakeConnector(raises=errors.Unavailable("Service down")))
+
+    with pytest.raises(ToolError, match=r"\[unavailable\]"):
+        server.search_dataflows("banking")
+
+
+def test_search_dataflows_rejects_unknown_service():
+    with pytest.raises(ToolError, match=r"\[invalid_request\]"):
+        server.search_dataflows("banking", service="ECB")
+
+
+# --------------------------------------------------------------------
+# inspect_dataflow
+# --------------------------------------------------------------------
+
+
+@pytest.fixture
+def banking_components():
+    # 'CH' deliberately appears in three components, mirroring BIS
+    # consolidated banking, where it is a reporting country, a
+    # counterparty country and a bank type.
+    return FakeComponents(
+        dimensions=[
+            FakeComponent("FREQ", "Frequency", [Code("Q", name="Quarterly")]),
+            FakeComponent(
+                "L_REP_CTY",
+                "Reporting country",
+                [Code("CH", name="Switzerland"), Code("DE")],
+            ),
+            FakeComponent(
+                "CBS_BANK_TYPE", "CBS bank type", [Code("CH"), Code("4R")]
+            ),
+            FakeComponent(
+                "L_CP_COUNTRY", "Counterparty country", [Code("CH")]
+            ),
+        ],
+        measures=[FakeComponent("OBS_VALUE", "Observation value")],
+        attributes=[FakeComponent("OBS_STATUS", "Status", required=False)],
+    )
+
+
+def test_inspect_dataflow_groups_components(use_connector, banking_components):
+    use_connector(
+        FakeConnector(
+            flow=FakeFlow(components=banking_components, series_count=10)
+        )
+    )
+
+    result = server.inspect_dataflow("BIS:WS_CBS_PUB(1.0)")
+
+    assert [d.id for d in result.dimensions] == [
+        "FREQ",
+        "L_REP_CTY",
+        "CBS_BANK_TYPE",
+        "L_CP_COUNTRY",
+    ]
+    assert result.dimensions[0].role == "dimension"
+    assert result.measures[0].role == "measure"
+    assert result.attributes[0].role == "attribute"
+    assert result.attributes[0].required is False
+
+
+def test_inspect_dataflow_reports_availability_not_validity(
+    use_connector, banking_components
+):
+    use_connector(
+        FakeConnector(
+            flow=FakeFlow(components=banking_components, series_count=10)
+        )
+    )
+
+    result = server.inspect_dataflow("BIS:WS_CBS_PUB(1.0)")
+
+    assert "may still be valid in the full codelist" in (
+        result.availability_note
+    )
+
+
+def test_inspect_dataflow_echoes_the_filter(use_connector, banking_components):
+    conn = use_connector(
+        FakeConnector(
+            flow=FakeFlow(components=banking_components, series_count=10)
+        )
+    )
+    flt = "L_REP_CTY = 'CH'"
+
+    result = server.inspect_dataflow("BIS:WS_CBS_PUB(1.0)", filters=flt)
+
+    assert result.filter_applied == flt
+    assert conn.dataflow_calls == [("BIS:WS_CBS_PUB(1.0)", flt)]
+    assert "get_data with the same filter" in result.next_step
+
+
+def test_inspect_dataflow_finds_a_code_in_every_role(
+    use_connector, banking_components
+):
+    use_connector(
+        FakeConnector(
+            flow=FakeFlow(components=banking_components, series_count=10)
+        )
+    )
+
+    result = server.inspect_dataflow("BIS:WS_CBS_PUB(1.0)", find_code="ch")
+
+    assert [loc.component_id for loc in result.code_locations] == [
+        "L_REP_CTY",
+        "CBS_BANK_TYPE",
+        "L_CP_COUNTRY",
+    ]
+    assert result.code_locations[0].role_hint == "reporting country"
+    assert result.code_locations[0].code_name == "Switzerland"
+    assert "ambiguous" in result.next_step
+
+
+def test_inspect_dataflow_unambiguous_code(use_connector):
+    components = FakeComponents(
+        dimensions=[FakeComponent("FREQ", "Frequency", [Code("Q")])]
+    )
+    use_connector(
+        FakeConnector(flow=FakeFlow(components=components, series_count=1))
+    )
+
+    result = server.inspect_dataflow("BIS:X(1.0)", find_code="Q")
+
+    assert len(result.code_locations) == 1
+    assert "ambiguous" not in result.next_step
+
+
+def test_inspect_dataflow_code_not_found(use_connector, banking_components):
+    use_connector(
+        FakeConnector(
+            flow=FakeFlow(components=banking_components, series_count=1)
+        )
+    )
+
+    result = server.inspect_dataflow("BIS:X(1.0)", find_code="ZZ")
+
+    assert result.code_locations == []
+
+
+def test_inspect_dataflow_warns_when_large(use_connector, banking_components):
+    use_connector(
+        FakeConnector(
+            flow=FakeFlow(
+                components=banking_components,
+                series_count=_safety.LARGE_SERIES_THRESHOLD + 1,
+            )
+        )
+    )
+
+    result = server.inspect_dataflow("BIS:WS_CBS_PUB(1.0)")
+
+    assert result.size_warning is not None
+    assert "Add filters" in result.next_step
+
+
+def test_inspect_dataflow_survives_missing_obs_count(
+    use_connector, banking_components
+):
+    # BIS returns None for obs_count; depending on it would break
+    # against the only endpoint pysdmx ships.
+    use_connector(
+        FakeConnector(
+            flow=FakeFlow(components=banking_components, series_count=100)
+        )
+    )
+
+    result = server.inspect_dataflow("BIS:WS_CBS_PUB(1.0)")
+
+    assert result.obs_count is None
+    assert result.series_count == 100
+    assert result.size_warning is None
+
+
+def test_inspect_dataflow_without_components(use_connector):
+    use_connector(FakeConnector(flow=FakeFlow(components=None)))
+
+    result = server.inspect_dataflow("BIS:X(1.0)")
+
+    assert result.dimensions == []
+    assert result.measures == []
+    assert result.attributes == []
+    assert result.code_locations == []
+
+
+def test_inspect_dataflow_truncates_long_code_lists(use_connector):
+    codes = [Code(f"C{i}") for i in range(server._CODE_PREVIEW_LIMIT + 5)]
+    components = FakeComponents(
+        dimensions=[FakeComponent("BIG", "Big", codes)]
+    )
+    use_connector(
+        FakeConnector(flow=FakeFlow(components=components, series_count=1))
+    )
+
+    result = server.inspect_dataflow("BIS:X(1.0)")
+
+    assert result.dimensions[0].code_count == len(codes)
+    assert len(result.dimensions[0].codes) == server._CODE_PREVIEW_LIMIT
+    assert result.dimensions[0].codes_truncated is True
+
+
+def test_inspect_dataflow_maps_errors(use_connector):
+    use_connector(FakeConnector(raises=errors.NotFound("No such flow")))
+
+    with pytest.raises(ToolError, match=r"\[not_found\]"):
+        server.inspect_dataflow("BIS:NOPE(1.0)")
+
+
+# --------------------------------------------------------------------
+# get_data
+# --------------------------------------------------------------------
+
+
+@pytest.fixture
+def observations():
+    return pd.DataFrame(
+        {
+            "TIME_PERIOD": ["2018-Q1", "2019-Q1", "2020-Q1"],
+            "OBS_VALUE": [1.0, 2.0, 3.0],
+        }
+    )
+
+
+def test_get_data_returns_observations(use_connector, observations):
+    conn = use_connector(FakeConnector(data=observations))
+
+    result = server.get_data("BIS:X(1.0)", "FREQ = 'Q'")
+
+    assert result.row_count == 3
+    assert result.total_rows_available == 3
+    assert result.truncated is False
+    assert result.records[0]["OBS_VALUE"] == 1.0
+    assert result.filter_applied == "FREQ = 'Q'"
+    assert result.filter_fallback is None
+    assert "Complete" in result.next_step
+    assert conn.data_calls[0][1] == "FREQ = 'Q'"
+
+
+def test_get_data_truncates_and_says_so(use_connector):
+    df = pd.DataFrame({"OBS_VALUE": range(50)})
+    use_connector(FakeConnector(data=df))
+
+    result = server.get_data("BIS:X(1.0)", limit=10)
+
+    assert result.row_count == 10
+    assert result.total_rows_available == 50
+    assert result.truncated is True
+    assert "not a sample" in result.next_step
+
+
+def test_get_data_clamps_the_limit(use_connector):
+    df = pd.DataFrame({"OBS_VALUE": range(3)})
+    use_connector(FakeConnector(data=df))
+
+    result = server.get_data("BIS:X(1.0)", limit=10**9)
+
+    assert result.row_count == 3
+
+
+def test_get_data_flattens_an_index(use_connector, observations):
+    indexed = observations.set_index("TIME_PERIOD")
+    use_connector(FakeConnector(data=indexed))
+
+    result = server.get_data("BIS:X(1.0)")
+
+    assert "TIME_PERIOD" in result.columns
+    assert result.records[0]["TIME_PERIOD"] == "2018-Q1"
+
+
+def test_get_data_passes_columns_through(use_connector, observations):
+    conn = use_connector(FakeConnector(data=observations))
+
+    server.get_data("BIS:X(1.0)", columns=["OBS_VALUE"])
+
+    assert conn.data_calls[0][2]["columns"] == ["OBS_VALUE"]
+
+
+def test_get_data_omits_columns_when_not_requested(
+    use_connector, observations
+):
+    conn = use_connector(FakeConnector(data=observations))
+
+    server.get_data("BIS:X(1.0)")
+
+    assert "columns" not in conn.data_calls[0][2]
+
+
+def test_get_data_passes_labels_through(use_connector, observations):
+    conn = use_connector(FakeConnector(data=observations))
+
+    server.get_data("BIS:X(1.0)", labels="both")
+
+    assert conn.data_calls[0][2]["labels"] == "both"
+
+
+def test_get_data_serialises_awkward_values(use_connector):
+    df = pd.DataFrame(
+        {
+            "OBS_VALUE": [np.float64(1.5), np.nan],
+            "OBS_STATUS": pd.Categorical(["A", "B"]),
+        }
+    )
+    use_connector(FakeConnector(data=df))
+
+    result = server.get_data("BIS:X(1.0)")
+
+    assert result.records[0]["OBS_VALUE"] == 1.5
+    assert result.records[1]["OBS_VALUE"] is None
+    assert result.records[0]["OBS_STATUS"] == "A"
+
+
+# --------------------------------------------------------------------
+# get_data: time-filter fallback
+# --------------------------------------------------------------------
+
+
+def test_get_data_falls_back_when_pushdown_rejected(use_connector):
+    df = pd.DataFrame(
+        {
+            "TIME_PERIOD": ["2018-Q1", "2020-Q1", "2021-Q1"],
+            "OBS_VALUE": [1.0, 2.0, 3.0],
+        }
+    )
+    calls = []
+
+    def responder(ref, filters, **kwargs):
+        calls.append(filters)
+        if filters and "TIME_PERIOD" in filters:
+            raise errors.Invalid("Bad query", "Dates are not supported.")
+        return df
+
+    use_connector(FakeConnector(data=responder))
+
+    result = server.get_data(
+        "BIS:X(1.0)", "FREQ = 'Q' AND TIME_PERIOD >= '2020-Q1'"
+    )
+
+    assert calls == ["FREQ = 'Q' AND TIME_PERIOD >= '2020-Q1'", "FREQ = 'Q'"]
+    assert result.filter_applied == "FREQ = 'Q'"
+    assert result.filter_fallback is not None
+    assert "applied locally" in result.filter_fallback
+    assert result.row_count == 2
+    assert [r["TIME_PERIOD"] for r in result.records] == [
+        "2020-Q1",
+        "2021-Q1",
+    ]
+    assert "Time filtering happened locally" in result.next_step
+
+
+def test_get_data_fallback_with_a_time_only_filter(use_connector):
+    df = pd.DataFrame(
+        {"TIME_PERIOD": ["2018-Q1", "2020-Q1"], "OBS_VALUE": [1.0, 2.0]}
+    )
+    seen = []
+
+    def responder(ref, filters, **kwargs):
+        seen.append(filters)
+        if filters is not None:
+            raise errors.NotImplemented("Unsupported")
+        return df
+
+    use_connector(FakeConnector(data=responder))
+
+    result = server.get_data("BIS:X(1.0)", "TIME_PERIOD >= '2020-Q1'")
+
+    assert seen == ["TIME_PERIOD >= '2020-Q1'", None]
+    assert result.filter_applied is None
+    assert result.row_count == 1
+
+
+def test_get_data_does_not_fall_back_without_a_time_clause(use_connector):
+    def responder(ref, filters, **kwargs):
+        raise errors.Invalid("Bad query")
+
+    use_connector(FakeConnector(data=responder))
+
+    with pytest.raises(ToolError, match=r"\[invalid_request\]"):
+        server.get_data("BIS:X(1.0)", "FREQ = 'Q'")
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        errors.NotFound("Gone"),
+        errors.Unavailable("Down"),
+        errors.InternalError("Boom"),
+    ],
+)
+def test_get_data_does_not_fall_back_on_unrelated_errors(use_connector, exc):
+    # Dropping a clause cannot fix a wrong reference or an unreachable
+    # service; retrying would waste a round trip and obscure the error.
+    calls = []
+
+    def responder(ref, filters, **kwargs):
+        calls.append(filters)
+        raise exc
+
+    use_connector(FakeConnector(data=responder))
+
+    with pytest.raises(ToolError):
+        server.get_data("BIS:X(1.0)", "FREQ = 'Q' AND TIME_PERIOD >= '2020'")
+
+    assert len(calls) == 1
+
+
+def test_get_data_reports_a_failing_retry(use_connector):
+    def responder(ref, filters, **kwargs):
+        if filters and "TIME_PERIOD" in filters:
+            raise errors.Invalid("Dates unsupported")
+        raise errors.Unavailable("Service died")
+
+    use_connector(FakeConnector(data=responder))
+
+    with pytest.raises(ToolError, match=r"\[unavailable\]"):
+        server.get_data("BIS:X(1.0)", "FREQ = 'Q' AND TIME_PERIOD >= '2020'")
+
+
+def test_get_data_rejects_unknown_service():
+    with pytest.raises(ToolError, match=r"\[invalid_request\]"):
+        server.get_data("BIS:X(1.0)", service="not a url")
+
+
+# --------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, None), ("", None), ("   ", None), (" x ", "x"), (5, "5")],
+)
+def test_text_normalisation(value, expected):
+    assert server._text(value) == expected
+
+
+def test_scalar_passes_through_plain_values():
+    assert server._scalar("a") == "a"
+    assert server._scalar(None) is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected", "expected_type"),
+    [
+        (np.float64(1.5), 1.5, float),
+        (np.int64(3), 3, int),
+        (np.bool_(True), True, bool),
+    ],
+)
+def test_scalar_unwraps_numpy_values(value, expected, expected_type):
+    # numpy scalars are not JSON-serialisable; unwrapping them keeps the
+    # records payload valid regardless of the dtypes pysdmx applies.
+    result = server._scalar(value)
+
+    assert result == expected
+    assert type(result) is expected_type

--- a/tests/toolkit/mcp/test_server.py
+++ b/tests/toolkit/mcp/test_server.py
@@ -642,6 +642,15 @@ def test_scalar_passes_through_plain_values():
 
 
 @pytest.mark.parametrize(
+    "missing", [None, float("nan"), np.nan, np.float64("nan"), pd.NaT, pd.NA]
+)
+def test_scalar_normalises_every_missing_value(missing):
+    # NaN, NaT and pd.NA all mean "no observation" and none of them is
+    # valid JSON.
+    assert server._scalar(missing) is None
+
+
+@pytest.mark.parametrize(
     ("value", "expected", "expected_type"),
     [
         (np.float64(1.5), 1.5, float),

--- a/tests/toolkit/mcp/test_services.py
+++ b/tests/toolkit/mcp/test_services.py
@@ -1,0 +1,75 @@
+import pytest
+
+from pysdmx.api.dc import Endpoints
+from pysdmx.api.dc.pd import PandasConnector
+from pysdmx.errors import Invalid
+from pysdmx.toolkit.mcp import _services
+
+
+def test_known_services_reads_the_pysdmx_enum():
+    known = _services.known_services()
+
+    assert known == {m.name: m.value for m in Endpoints}
+    assert "BIS" in known
+
+
+def test_notes_for_known_service():
+    assert "series_count" in _services.notes_for("BIS")
+
+
+def test_notes_for_unknown_service():
+    assert "No capability notes" in _services.notes_for("NOPE")
+
+
+def test_resolve_defaults_to_the_single_endpoint():
+    resolved = _services.resolve(None)
+
+    assert resolved.name == "BIS"
+    assert resolved.base_url == Endpoints.BIS.value
+    assert resolved.known is True
+
+
+@pytest.mark.parametrize("supplied", ["BIS", "bis", " Bis "])
+def test_resolve_known_name_is_case_insensitive(supplied):
+    resolved = _services.resolve(supplied)
+
+    assert resolved.name == "BIS"
+    assert resolved.known is True
+
+
+@pytest.mark.parametrize(
+    ("supplied", "expected"),
+    [
+        ("https://example.org/api/v2", "https://example.org/api/v2"),
+        ("https://example.org/api/v2/", "https://example.org/api/v2"),
+        ("http://localhost:8080/sdmx", "http://localhost:8080/sdmx"),
+    ],
+)
+def test_resolve_accepts_custom_base_urls(supplied, expected):
+    # Endpoints has a single member, so a supplied URL is a first-class
+    # input rather than a fallback.
+    resolved = _services.resolve(supplied)
+
+    assert resolved.base_url == expected
+    assert resolved.known is False
+
+
+@pytest.mark.parametrize(
+    "supplied", ["", "not a url", "ftp://example.org", "https://", "ECB"]
+)
+def test_resolve_rejects_anything_else(supplied):
+    with pytest.raises(Invalid, match="Unknown service"):
+        _services.resolve(supplied)
+
+
+def test_resolve_error_lists_the_known_names():
+    with pytest.raises(Invalid) as exc:
+        _services.resolve("ECB")
+
+    assert "BIS" in exc.value.description
+
+
+def test_connector_targets_the_resolved_url():
+    resolved = _services.resolve("https://example.org/api/v2")
+
+    assert isinstance(_services.connector(resolved), PandasConnector)


### PR DESCRIPTION
## What this adds

An MCP ([Model Context Protocol](https://modelcontextprotocol.io)) server exposing
`pysdmx.api.dc.pd.PandasConnector` to AI assistants, under `pysdmx.toolkit.mcp`.

This relates to #561 ("AI Coding Assistant Instructions for data analysts"). That
issue asks for guidance aimed at analysts; this is one concrete form of it — the
behaviour described in `.agents/skills/data-discovery-and-retrieval/SKILL.md`
implemented as a server, so the rules are enforced by the tool rather than left for
an assistant to remember.

The same server is also published standalone as
[`sdmx-data-mcp`](https://pypi.org/project/sdmx-data-mcp/), which depends on
`pysdmx[data]` rather than living inside it:

```bash
pip install sdmx-data-mcp
claude mcp add sdmx -- sdmx-data-mcp
```

So this can live outside the library if you would prefer that, and I am happy to
close the PR on that basis. I am raising it here because enforcing the SKILL.md
rules in the tool seemed closer to what #561 is asking for than documentation
alone.

The distinguishing feature is that `get_data` returns observations. Existing SDMX
MCP servers navigate metadata and hand back a query URL, leaving the assistant with
a link rather than numbers.

## The four tools

Meant to be called in order:

| Tool | Purpose |
|---|---|
| `list_services` | Endpoints from `Endpoints`, plus any caller-supplied SDMX-REST v2 base URL |
| `search_dataflows` | One `dataflows()` call, then local term matching |
| `inspect_dataflow` | Components, availability-backed codes, size signals |
| `get_data` | Retrieves the observations |

## Design decisions worth reviewing

These are the points where I made a judgement call, and the ones most worth
pushing back on.

### The error hierarchy is preserved rather than flattened

`NotFound` and `Unavailable` imply opposite retry decisions, so each error maps to
a distinct kind with an explicit retriable flag. I marked `InternalError`
non-retriable, following the class docstring in `errors.py` ("clients should not
retry the query before investigating"), even though it maps to 5xx.

### `obs_count` is treated as optional

Against `BIS:WS_CBS_PUB(1.0)` it comes back `None` for both the full flow and
filtered subsets, while `series_count` is populated. Size checks therefore lead on
`series_count`; anything doing `if flow.obs_count > n` would raise `TypeError`
against the only endpoint `Endpoints` ships.

### Retrieval is capped

`L_MEASURE = 'S' AND L_REP_CTY = 'CH' AND FREQ = 'Q'` — three clauses, one country
— returns 478,965 rows. The default cap is 1,000 with a hard ceiling of 10,000, and
the response sets `truncated` and states that the rows are the first N in service
order rather than a sample.

### A code is located across every component carrying it

On consolidated banking, `CH` is available in `L_REP_CTY`, `L_CP_COUNTRY` and
`CBS_BANK_TYPE`, which shares the country codelist.
`inspect_dataflow(find_code=...)` reports all three with a role hint, so "in
Switzerland" cannot silently resolve to the wrong dimension.

### Time filters degrade rather than fail

`TIME_PERIOD` is pushed down first. If the service rejects it with `Invalid` or
`NotImplemented`, the clause is stripped, the narrower query retried, and the
cutoff applied in Pandas, with `filter_fallback` saying so. It deliberately does
not fall back on `NotFound`, `Unavailable` or `InternalError`, where dropping a
clause cannot help and would only obscure the real error. Pushdown does work
against BIS today; the fallback is covered by tests rather than by live behaviour.

### Availability is never reported as validity

Every inspection result carries a note that a code missing from availability may
still be valid in the full codelist.

## Packaging

- New `mcp` extra (`fastmcp>=3.0,<4.0`, gated to Python >= 3.10), added to `all`
- `__check_mcp_extra()` follows the existing `__extras_check.py` pattern
- New `mcp` pytest marker, registered in `pytest.ini` and auto-applied via
  `tests/conftest.py`
- Entry point: `python -m pysdmx.toolkit.mcp`, STDIO by default, `--transport http`
  for Streamable HTTP

## Verification

- `ruff format` and `ruff check` clean
- `mypy` clean across all 191 source files
- 5,256 tests pass; 100% statement and branch coverage repo-wide, with the new
  package at 100% on its own
- Sphinx docs build clean; API reference and how-to added to the toolkit toctrees

Most server tests inject a fake connector so every branch is reachable
deterministically. A separate end-to-end module drives the real `PandasConnector`
against `respx`-mocked responses, reusing the existing `bis_der.json` and
`data_v2.csv` samples, so drift in URL construction or SDMX-CSV parsing surfaces
there.

The API surface was re-read from v1.18.0 source and confirmed against the live BIS
service before the server was written.

### Behaviour against the live service

Driven from a client, `BIS:WS_CBPOL(1.0)` with
`FREQ = 'M' AND REF_AREA = 'CH' AND TIME_PERIOD >= '2020-01'` returns 79 rows with
`filter_fallback: null`, and the values reproduce the SNB rate path correctly
(−0.75 held to May 2022, peak of 1.75 from June 2023, 0.00 from June 2025).

Two behaviours showed up unprompted and are worth noting, since both are the
result of the design decisions above:

- A failing `inspect_dataflow` call returned `internal_error` with
  `retriable=false` and a `next_step` telling the caller not to repeat the
  identical request. The assistant changed approach rather than retrying.
- Asked for a daily KES series, the server returned `not_found` rather than an
  empty result, so the caller concluded the series does not exist instead of
  searching other date ranges for it.

---

*Developed with Claude Code. The design decisions above are mine and I am happy to
discuss any of them.*
