### PR TITLE
Fix apostrophe corruption in all but the last annotation when writing SDMX-ML

### DIFF
--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -2318,8 +2318,9 @@ def _write_vtl(  # noqa: C901
     if isinstance(item_or_scheme, Item):
         label = ""
         nameable = __write_nameable(item_or_scheme, add_indent(indent))
-        attrib = nameable["Attributes"].replace("'", '"')
-        data = __export_intern_data(nameable)
+        attrib = nameable["Attributes"]
+        intern = __export_intern_data(nameable)
+        data = ""
 
         if isinstance(item_or_scheme, Ruleset):
             label = f"{ABBR_STR}:{RULE}"
@@ -2524,14 +2525,15 @@ def _write_vtl(  # noqa: C901
                 f"</{ABBR_STR}:PersonalisedName>"
             )
 
+        attrib = attrib.replace("'", '"')
+        data = data.replace("'", '"')
         outfile += f"{indent}<{label}{attrib}>"
+        outfile += intern
         outfile += data
         outfile += f"{indent}</{label}>"
 
     if isinstance(item_or_scheme, VtlScheme):
-        outfile += f" vtlVersion={item_or_scheme.vtl_version!r}"
-
-    outfile = outfile.replace("'", '"')
+        outfile += f' vtlVersion="{item_or_scheme.vtl_version}"'
 
     return outfile
 

--- a/src/pysdmx/io/xml/__structure_aux_writer.py
+++ b/src/pysdmx/io/xml/__structure_aux_writer.py
@@ -210,8 +210,8 @@ ANNOTATION_WRITER = OrderedDict(
     {
         "title": "AnnotationTitle",
         "type": "AnnotationType",
-        "text": "AnnotationText",
         "url": "AnnotationURL",
+        "text": "AnnotationText",
     }
 )
 
@@ -326,8 +326,8 @@ def __write_annotable(
         if annotation.id is None:
             outfile += f"{child2}<{ABBR_COM}:Annotation>"
         else:
-            outfile += f"{child2}<{ABBR_COM}:Annotation id={annotation.id!r}>"
-        outfile = outfile.replace("'", '"')
+            annotation_id = __escape_xml(annotation.id)
+            outfile += f'{child2}<{ABBR_COM}:Annotation id="{annotation_id}">'
 
         for attr, label in ANNOTATION_WRITER.items():
             if getattr(annotation, attr, None) is not None:

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -2230,6 +2230,105 @@ def test_metadata_structure_21_raises(complete_header):
         write([msd], header=complete_header, prettyprint=True)
 
 
+@pytest.fixture
+def codelist_apostrophe_annotations():
+    # Several annotations on the artefact and on one of its items, each
+    # carrying an apostrophe in every annotation field (issue #678).
+    return Codelist(
+        id="CL_ANN",
+        name="Côte d'Ivoire codes",
+        agency="BIS",
+        version="1.0",
+        items=[
+            Code(
+                id="CI",
+                name="Côte d'Ivoire",
+                annotations=[
+                    Annotation(id="c1", title="Item's first"),
+                    Annotation(id="c2", title="Item's last"),
+                ],
+            ),
+        ],
+        annotations=[
+            Annotation(
+                id="a1",
+                title="It's the first title",
+                type="It's the first type",
+                url="https://example.com/it's",
+                text="It's the first text",
+            ),
+            Annotation(id="a2", title="It's the middle title"),
+            Annotation(
+                id="a3",
+                title="It's the last title",
+                text="It's the last text",
+            ),
+        ],
+    )
+
+
+def test_annotations_21_element_order(complete_header):
+    # The schema sequence is Title, Type, URL, Text; writing Text before
+    # URL produced a schema-invalid document.
+    codelist = Codelist(
+        id="CL_ORD",
+        name="Codes",
+        agency="BIS",
+        version="1.0",
+        items=[Code(id="A", name="a")],
+        annotations=[
+            Annotation(
+                id="a1",
+                title="Title",
+                type="Type",
+                url="https://example.com/note",
+                text="Some text",
+            ),
+        ],
+    )
+
+    result = write([codelist], header=complete_header, prettyprint=True)
+
+    assert result.index("<com:AnnotationTitle>") < result.index(
+        "<com:AnnotationType>"
+    )
+    assert result.index("<com:AnnotationType>") < result.index(
+        "<com:AnnotationURL>"
+    )
+    assert result.index("<com:AnnotationURL>") < result.index(
+        "<com:AnnotationText"
+    )
+
+    re_read = read(result, validate=True)[0]
+    assert re_read.annotations == codelist.annotations
+
+
+def test_annotations_21_apostrophes_preserved(
+    complete_header, codelist_apostrophe_annotations
+):
+    # Every annotation must keep its apostrophes, not just the last one
+    # on each artefact (issue #678).
+    result = write(
+        [codelist_apostrophe_annotations],
+        header=complete_header,
+        prettyprint=True,
+    )
+
+    assert '"s the first title' not in result
+    assert '"s the middle title' not in result
+    assert '"s the first text' not in result
+    assert '"s the first type' not in result
+    assert 'example.com/it"s' not in result
+    assert 'Item"s first' not in result
+
+    re_read = read(result, validate=True)[0]
+    assert re_read.annotations == codelist_apostrophe_annotations.annotations
+    assert (
+        re_read.items[0].annotations
+        == codelist_apostrophe_annotations.items[0].annotations
+    )
+
+
 @pytest.mark.xml
 def test_metadata_provision_agreement_21_raises(complete_header):
     mpa = MetadataProvisionAgreement(

--- a/tests/io/xml/sdmx21/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx21/writer/test_structures_writing.py
@@ -2343,3 +2343,41 @@ def test_metadata_provision_agreement_21_raises(complete_header):
     )
     with pytest.raises(Invalid, match="not supported in SDMX-ML 2.1"):
         write([mpa], header=complete_header, prettyprint=True)
+
+
+def test_vtl_item_21_apostrophes_preserved(complete_header):
+    scheme = TransformationScheme(
+        id="TS_APOS",
+        name="Scheme's name",
+        description="Scheme's description",
+        agency="BIS",
+        version="1.0",
+        vtl_version="2.0",
+        items=[
+            Transformation(
+                id="T1",
+                name="Item's name",
+                description="Item's description",
+                expression="ds",
+                is_persistent=False,
+                result="r",
+                annotations=[
+                    Annotation(id="a1", title="Ann's first"),
+                    Annotation(id="a2", title="Ann's last"),
+                ],
+            )
+        ],
+    )
+
+    result = write([scheme], header=complete_header, prettyprint=True)
+
+    assert 'Scheme"s' not in result
+    assert 'Item"s' not in result
+    assert 'Ann"s' not in result
+
+    re_read = read(result, validate=True)[0]
+    assert re_read.name == "Scheme's name"
+    assert re_read.description == "Scheme's description"
+    assert re_read.items[0].name == "Item's name"
+    assert re_read.items[0].description == "Item's description"
+    assert re_read.items[0].annotations == scheme.items[0].annotations

--- a/tests/io/xml/sdmx30/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx30/writer/test_structures_writing.py
@@ -1967,3 +1967,41 @@ def test_annotations_30_element_order(complete_header):
 
     re_read = read(result, validate=True)[0]
     assert re_read.annotations == codelist.annotations
+
+
+def test_vtl_item_30_apostrophes_preserved(complete_header):
+    scheme = TransformationScheme(
+        id="TS_APOS",
+        name="Scheme's name",
+        description="Scheme's description",
+        agency="BIS",
+        version="1.0.0",
+        vtl_version="2.0",
+        items=[
+            Transformation(
+                id="T1",
+                name="Item's name",
+                description="Item's description",
+                expression="ds",
+                is_persistent=False,
+                result="r",
+                annotations=[
+                    Annotation(id="a1", title="Ann's first"),
+                    Annotation(id="a2", title="Ann's last"),
+                ],
+            )
+        ],
+    )
+
+    result = write([scheme], header=complete_header, prettyprint=True)
+
+    assert 'Scheme"s' not in result
+    assert 'Item"s' not in result
+    assert 'Ann"s' not in result
+
+    re_read = read(result, validate=True)[0]
+    assert re_read.name == "Scheme's name"
+    assert re_read.description == "Scheme's description"
+    assert re_read.items[0].name == "Item's name"
+    assert re_read.items[0].description == "Item's description"
+    assert re_read.items[0].annotations == scheme.items[0].annotations

--- a/tests/io/xml/sdmx30/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx30/writer/test_structures_writing.py
@@ -1882,3 +1882,88 @@ def test_category_scheme_30_enrichment_round_trip(complete_header):
     assert top.dataflows[0].id == "DF1"
     assert top.dataflows[0].version == "1.0.0"
     assert top.dataflows[0].name == "Dataflow 1"
+
+
+def test_annotations_30_apostrophes_preserved(complete_header):
+    # Every annotation must keep its apostrophes, not just the last one
+    # on each artefact (issue #678).
+    codelist = Codelist(
+        id="CL_ANN",
+        name="Côte d'Ivoire codes",
+        agency="BIS",
+        version="1.0.0",
+        items=[
+            Code(
+                id="CI",
+                name="Côte d'Ivoire",
+                annotations=[
+                    Annotation(id="c1", title="Item's first"),
+                    Annotation(id="c2", title="Item's last"),
+                ],
+            ),
+        ],
+        annotations=[
+            Annotation(
+                id="a1",
+                title="It's the first title",
+                type="It's the first type",
+                url="https://example.com/it's",
+                text="It's the first text",
+            ),
+            Annotation(id="a2", title="It's the middle title"),
+            Annotation(
+                id="a3",
+                title="It's the last title",
+                text="It's the last text",
+            ),
+        ],
+    )
+
+    result = write([codelist], header=complete_header, prettyprint=True)
+
+    assert '"s the first title' not in result
+    assert '"s the middle title' not in result
+    assert '"s the first text' not in result
+    assert '"s the first type' not in result
+    assert 'example.com/it"s' not in result
+    assert 'Item"s first' not in result
+
+    re_read = read(result, validate=True)[0]
+    assert re_read.annotations == codelist.annotations
+    assert re_read.items[0].annotations == codelist.items[0].annotations
+
+
+def test_annotations_30_element_order(complete_header):
+    # The schema sequence is Title, Type, URL, Text; writing Text before
+    # URL produced a schema-invalid document.
+    codelist = Codelist(
+        id="CL_ORD",
+        name="Codes",
+        agency="BIS",
+        version="1.0.0",
+        items=[Code(id="A", name="a")],
+        annotations=[
+            Annotation(
+                id="a1",
+                title="Title",
+                type="Type",
+                url="https://example.com/note",
+                text="Some text",
+            ),
+        ],
+    )
+
+    result = write([codelist], header=complete_header, prettyprint=True)
+
+    assert result.index("<com:AnnotationTitle>") < result.index(
+        "<com:AnnotationType>"
+    )
+    assert result.index("<com:AnnotationType>") < result.index(
+        "<com:AnnotationURL>"
+    )
+    assert result.index("<com:AnnotationURL>") < result.index(
+        "<com:AnnotationText"
+    )
+
+    re_read = read(result, validate=True)[0]
+    assert re_read.annotations == codelist.annotations

--- a/tests/io/xml/sdmx31/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx31/writer/test_structures_writing.py
@@ -1151,3 +1151,88 @@ def test_category_scheme_31_enrichment_round_trip(complete_header):
     assert top.dataflows[0].id == "DF1"
     assert top.dataflows[0].version == "1.0.0"
     assert top.dataflows[0].name == "Dataflow 1"
+
+
+def test_annotations_31_apostrophes_preserved(complete_header):
+    # Every annotation must keep its apostrophes, not just the last one
+    # on each artefact (issue #678).
+    codelist = Codelist(
+        id="CL_ANN",
+        name="Côte d'Ivoire codes",
+        agency="BIS",
+        version="1.0.0",
+        items=[
+            Code(
+                id="CI",
+                name="Côte d'Ivoire",
+                annotations=[
+                    Annotation(id="c1", title="Item's first"),
+                    Annotation(id="c2", title="Item's last"),
+                ],
+            ),
+        ],
+        annotations=[
+            Annotation(
+                id="a1",
+                title="It's the first title",
+                type="It's the first type",
+                url="https://example.com/it's",
+                text="It's the first text",
+            ),
+            Annotation(id="a2", title="It's the middle title"),
+            Annotation(
+                id="a3",
+                title="It's the last title",
+                text="It's the last text",
+            ),
+        ],
+    )
+
+    result = write([codelist], header=complete_header, prettyprint=True)
+
+    assert '"s the first title' not in result
+    assert '"s the middle title' not in result
+    assert '"s the first text' not in result
+    assert '"s the first type' not in result
+    assert 'example.com/it"s' not in result
+    assert 'Item"s first' not in result
+
+    re_read = read(result, validate=True)[0]
+    assert re_read.annotations == codelist.annotations
+    assert re_read.items[0].annotations == codelist.items[0].annotations
+
+
+def test_annotations_31_element_order(complete_header):
+    # The schema sequence is Title, Type, URL, Text; writing Text before
+    # URL produced a schema-invalid document.
+    codelist = Codelist(
+        id="CL_ORD",
+        name="Codes",
+        agency="BIS",
+        version="1.0.0",
+        items=[Code(id="A", name="a")],
+        annotations=[
+            Annotation(
+                id="a1",
+                title="Title",
+                type="Type",
+                url="https://example.com/note",
+                text="Some text",
+            ),
+        ],
+    )
+
+    result = write([codelist], header=complete_header, prettyprint=True)
+
+    assert result.index("<com:AnnotationTitle>") < result.index(
+        "<com:AnnotationType>"
+    )
+    assert result.index("<com:AnnotationType>") < result.index(
+        "<com:AnnotationURL>"
+    )
+    assert result.index("<com:AnnotationURL>") < result.index(
+        "<com:AnnotationText"
+    )
+
+    re_read = read(result, validate=True)[0]
+    assert re_read.annotations == codelist.annotations

--- a/tests/io/xml/sdmx31/writer/test_structures_writing.py
+++ b/tests/io/xml/sdmx31/writer/test_structures_writing.py
@@ -1236,3 +1236,41 @@ def test_annotations_31_element_order(complete_header):
 
     re_read = read(result, validate=True)[0]
     assert re_read.annotations == codelist.annotations
+
+
+def test_vtl_item_31_apostrophes_preserved(complete_header):
+    scheme = TransformationScheme(
+        id="TS_APOS",
+        name="Scheme's name",
+        description="Scheme's description",
+        agency="BIS",
+        version="1.0.0",
+        vtl_version="2.0",
+        items=[
+            Transformation(
+                id="T1",
+                name="Item's name",
+                description="Item's description",
+                expression="ds",
+                is_persistent=False,
+                result="r",
+                annotations=[
+                    Annotation(id="a1", title="Ann's first"),
+                    Annotation(id="a2", title="Ann's last"),
+                ],
+            )
+        ],
+    )
+
+    result = write([scheme], header=complete_header, prettyprint=True)
+
+    assert 'Scheme"s' not in result
+    assert 'Item"s' not in result
+    assert 'Ann"s' not in result
+
+    re_read = read(result, validate=True)[0]
+    assert re_read.name == "Scheme's name"
+    assert re_read.description == "Scheme's description"
+    assert re_read.items[0].name == "Item's name"
+    assert re_read.items[0].description == "Item's description"
+    assert re_read.items[0].annotations == scheme.items[0].annotations


### PR DESCRIPTION
## Summary

Fixes #678 — the SDMX-ML structure writer silently corrupted apostrophes in every annotation on an artefact except the last one.

Root cause is as diagnosed in the issue: `__write_annotable` built the `id` attribute with `{annotation.id!r}` and then applied a blanket `outfile.replace("'", '"')`. The replace ran **inside** the per-annotation loop and over the **whole accumulated buffer**, so each newly appended annotation re-quoted every apostrophe already written. Only the final annotation escaped unscathed, and the document stayed schema-valid, so the corruption was silent.

## Changes included

**`pysdmx.io.xml.__structure_aux_writer`** — two fixes in `__write_annotable` and its element map:

- **`__write_annotable`** — the `Annotation id` attribute is now quoted explicitly and escaped via `__escape_xml`; the in-loop blanket replace is deleted. Matches the existing explicit-quoting convention already used for `DatePatternMap` attributes in the same module.
  ```diff
  -            outfile += f"{child2}<{ABBR_COM}:Annotation id={annotation.id!r}>"
  -        outfile = outfile.replace("'", '"')
  +            annotation_id = __escape_xml(annotation.id)
  +            outfile += f'{child2}<{ABBR_COM}:Annotation id="{annotation_id}">'
  ```
- `url` and `text` swapped so the emitted sequence is `AnnotationTitle, AnnotationType, AnnotationURL, AnnotationText`, per the `AnnotationType` complex type in `SDMXCommon.xsd`.

Before / after, for a codelist with three annotations:

```xml
<!-- before -->
<com:AnnotationTitle>It"s the first title</com:AnnotationTitle>
<com:AnnotationTitle>It"s the middle title</com:AnnotationTitle>
<com:AnnotationTitle>It's the last title</com:AnnotationTitle>

<!-- after -->
<com:AnnotationTitle>It's the first title</com:AnnotationTitle>
<com:AnnotationTitle>It's the middle title</com:AnnotationTitle>
<com:AnnotationTitle>It's the last title</com:AnnotationTitle>
```
