### PR TITLE
Fail cleanly on unsupported SDMX-ML 2.1 RegistryInterface content

### DIFF
--- a/src/pysdmx/io/input_processor.py
+++ b/src/pysdmx/io/input_processor.py
@@ -91,6 +91,13 @@ def __get_generic_metadata_flavour(flavour_check: str) -> Format:
 
 def __get_sdmx_ml_flavour(input_str: str) -> Tuple[str, Format]:
     flavour_check = input_str[:1000].lower()
+    # Root-element tokens are checked first: looser substrings such as
+    # ":structure" also match content of registry and error messages
+    # (e.g. <str:Structures> in a SubmitStructureRequest).
+    if ":registryinterface" in flavour_check:
+        return input_str, Format.REGISTRY_SDMX_ML_2_1
+    if ":error" in flavour_check:
+        return input_str, Format.ERROR_SDMX_ML_2_1
     if ":generictimeseriesdata" in flavour_check:
         return input_str, Format.DATA_SDMX_ML_2_1_GENTS
     # GenericMetadata must be checked before the ":generic" data check,
@@ -116,10 +123,6 @@ def __get_sdmx_ml_flavour(input_str: str) -> Tuple[str, Format]:
             Format.STRUCTURE_SDMX_ML_3_0,
             Format.STRUCTURE_SDMX_ML_3_1,
         )
-    if ":registryinterface" in flavour_check:
-        return input_str, Format.REGISTRY_SDMX_ML_2_1
-    if ":error" in flavour_check:
-        return input_str, Format.ERROR_SDMX_ML_2_1
     raise Invalid("Validation Error", "Cannot parse input as SDMX-ML.")
 
 

--- a/src/pysdmx/io/xml/sdmx21/reader/submission.py
+++ b/src/pysdmx/io/xml/sdmx21/reader/submission.py
@@ -2,10 +2,11 @@
 
 from typing import Any, Dict, Sequence
 
-from pysdmx.errors import Invalid
+from pysdmx.errors import Invalid, NotImplemented
 from pysdmx.io.xml.__parse_xml import parse_xml
 from pysdmx.io.xml.__tokens import (
     ACTION,
+    HEADER,
     MAINTAINABLE_OBJECT,
     REG_INTERFACE,
     STATUS,
@@ -15,6 +16,7 @@ from pysdmx.io.xml.__tokens import (
     SUBMITTED_STRUCTURE,
     URN,
 )
+from pysdmx.io.xml.utils import add_list
 from pysdmx.model.submission import SubmissionResult
 from pysdmx.util import parse_urn
 
@@ -33,7 +35,7 @@ def __handle_registry_interface(
     response = dict_info[REG_INTERFACE][SUBMIT_STRUCTURE_RESPONSE]
 
     result = []
-    for submission_result in response[SUBMISSION_RESULT]:
+    for submission_result in add_list(response[SUBMISSION_RESULT]):
         structure = submission_result[SUBMITTED_STRUCTURE]
         action = structure[ACTION]
         urn = structure[MAINTAINABLE_OBJECT][URN]
@@ -50,8 +52,29 @@ def read(input_str: str, validate: bool = True) -> Sequence[SubmissionResult]:
     Args:
         input_str: SDMX-ML data to read.
         validate: If True, the XML data will be validated against the XSD.
+
+    Raises:
+        Invalid: If the document is not an SDMX-ML 2.1 RegistryInterface
+            message.
+        NotImplemented: If the RegistryInterface message contains anything
+            other than a SubmitStructureResponse (e.g. a
+            SubmitStructureRequest or a QueryRegistrationResponse).
     """
     dict_info = parse_xml(input_str, validate=validate)
     if REG_INTERFACE not in dict_info:
         raise Invalid("This SDMX document is not an SDMX-ML 2.1 Submission.")
+    if SUBMIT_STRUCTURE_RESPONSE not in dict_info[REG_INTERFACE]:
+        # Keys with a colon (e.g. xsi:schemaLocation) and xmlns are
+        # attributes of the root element, not content: element names
+        # have their namespace prefixes stripped during parsing.
+        content = ", ".join(
+            key
+            for key in dict_info[REG_INTERFACE]
+            if key != HEADER and key != "xmlns" and ":" not in key
+        )
+        raise NotImplemented(
+            "Unsupported RegistryInterface content",
+            f"Only SubmitStructureResponse messages are supported. "
+            f"Found: {content}.",
+        )
     return __handle_registry_interface(dict_info)

--- a/tests/io/xml/sdmx21/reader/samples/error_with_structure_text.xml
+++ b/tests/io/xml/sdmx21/reader/samples/error_with_structure_text.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<message:Error
+        xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+        xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">
+    <message:ErrorMessage code="140">
+        <com:Text>Syntax error: cannot parse element str:Structures</com:Text>
+    </message:ErrorMessage>
+</message:Error>

--- a/tests/io/xml/sdmx21/reader/samples/registry_query_registration_response.xml
+++ b/tests/io/xml/sdmx21/reader/samples/registry_query_registration_response.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:RegistryInterface
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:xml="http://www.w3.org/XML/1998/namespace"
+        xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+        xmlns:reg="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/registry"
+        xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common">
+    <mes:Header>
+        <mes:ID>IREF618242</mes:ID>
+        <mes:Test>false</mes:Test>
+        <mes:Prepared>2026-08-31T07:37:05Z</mes:Prepared>
+        <mes:Sender id="ZZZ"/>
+        <mes:Receiver id="not_supplied"/>
+    </mes:Header>
+    <mes:QueryRegistrationResponse>
+        <reg:StatusMessage status="Success"/>
+        <reg:QueryResult timeSeriesMatch="false">
+            <reg:DataResult>
+                <reg:Registration lastUpdated="2026-08-31T07:26:45" indexReportingPeriod="false" indexDataSet="false" indexAttributes="false" id="DFE0F68D5BB59C20C0C5C95BD3B1DAF2" indexTimeSeries="false">
+                    <reg:ProvisionAgreement>
+                        <Ref package="registry" agencyID="IMF" id="AT_CGO" version="1.0" class="ProvisionAgreement"/>
+                    </reg:ProvisionAgreement>
+                    <reg:Datasource>
+                        <reg:SimpleDataSource>https://www.oenb.at/docroot/SDDSplus/SDDS_CGO.xml</reg:SimpleDataSource>
+                    </reg:Datasource>
+                </reg:Registration>
+            </reg:DataResult>
+        </reg:QueryResult>
+    </mes:QueryRegistrationResponse>
+</mes:RegistryInterface>

--- a/tests/io/xml/sdmx21/reader/samples/registry_submit_structure_request.xml
+++ b/tests/io/xml/sdmx21/reader/samples/registry_submit_structure_request.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mes:RegistryInterface xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xml="http://www.w3.org/XML/1998/namespace" xmlns:mes="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message" xmlns:str="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure" xmlns:com="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common" xsi:schemaLocation="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message https://registry.sdmx.org/schemas/v2_1/SDMXMessage.xsd">
+  <mes:Header>
+    <mes:ID>IREF422205</mes:ID>
+    <mes:Test>false</mes:Test>
+    <mes:Prepared>2021-02-04T12:37:05Z</mes:Prepared>
+    <mes:Sender id="REGISTRY1"/>
+    <mes:Receiver id="not_supplied"/>
+  </mes:Header>
+  <mes:SubmitStructureRequest action="Information">
+    <str:Structures>
+      <str:Dataflows>
+        <str:Dataflow urn="urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=ESTAT:HC02(2.0)" isExternalReference="false" agencyID="ESTAT" id="HC02" isFinal="false" version="2.0">
+          <com:Name xml:lang="en">HC02 - Population by Household Status and Educational Attainment</com:Name>
+          <str:Structure>
+            <Ref package="datastructure" agencyID="ESTAT" id="HC02" version="1.0" class="DataStructure"/>
+          </str:Structure>
+        </str:Dataflow>
+      </str:Dataflows>
+    </str:Structures>
+  </mes:SubmitStructureRequest>
+</mes:RegistryInterface>

--- a/tests/io/xml/sdmx21/reader/samples/submission_append_single.xml
+++ b/tests/io/xml/sdmx21/reader/samples/submission_append_single.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<message:RegistryInterface
+        xmlns:message="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+        xmlns:reg="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/registry">
+    <message:Header>
+        <message:ID>test</message:ID>
+        <message:Test>true</message:Test>
+        <message:Prepared>2023-11-08T12:40:53Z</message:Prepared>
+        <message:Sender id="Unknown" />
+        <message:Receiver id="Not_Supplied" />
+    </message:Header>
+    <message:SubmitStructureResponse>
+        <reg:SubmissionResult>
+            <reg:SubmittedStructure action="Append">
+                <reg:MaintainableObject>
+                    <URN>urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=BIS:BIS_DER(1.0)</URN>
+                </reg:MaintainableObject>
+            </reg:SubmittedStructure>
+            <reg:StatusMessage status="Success"></reg:StatusMessage>
+        </reg:SubmissionResult>
+    </message:SubmitStructureResponse>
+</message:RegistryInterface>

--- a/tests/io/xml/sdmx21/reader/test_reader.py
+++ b/tests/io/xml/sdmx21/reader/test_reader.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 import pysdmx
-from pysdmx.errors import Invalid
+from pysdmx.errors import Invalid, NotImplemented
 from pysdmx.io import read_sdmx
 from pysdmx.io.format import Format
 from pysdmx.io.input_processor import process_string_to_read
@@ -78,6 +78,34 @@ def item_scheme_path():
 @pytest.fixture
 def submission_path():
     return Path(__file__).parent / "samples" / "submission_append.xml"
+
+
+@pytest.fixture
+def submission_single_path():
+    return Path(__file__).parent / "samples" / "submission_append_single.xml"
+
+
+@pytest.fixture
+def submit_structure_request_path():
+    return (
+        Path(__file__).parent
+        / "samples"
+        / "registry_submit_structure_request.xml"
+    )
+
+
+@pytest.fixture
+def query_registration_response_path():
+    return (
+        Path(__file__).parent
+        / "samples"
+        / "registry_query_registration_response.xml"
+    )
+
+
+@pytest.fixture
+def error_structure_text_path():
+    return Path(__file__).parent / "samples" / "error_with_structure_text.xml"
 
 
 @pytest.fixture
@@ -417,6 +445,36 @@ def test_submission_result_read_sdmx(submission_path):
     assert result[1].short_urn == "Dataflow=BIS:WEBSTATS_DER_DATAFLOW(1.0)"
 
 
+def test_submission_result_single(submission_single_path):
+    result = read_sdmx(submission_single_path, validate=True).submission
+    assert len(result) == 1
+    assert result[0].action == "Append"
+    assert result[0].short_urn == "DataStructure=BIS:BIS_DER(1.0)"
+    assert result[0].status == "Success"
+
+
+def test_submit_structure_request_not_implemented(
+    submit_structure_request_path,
+):
+    input_str, read_format = process_string_to_read(
+        submit_structure_request_path
+    )
+    assert read_format == Format.REGISTRY_SDMX_ML_2_1
+    with pytest.raises(NotImplemented) as e:
+        read_sub(input_str, validate=True)
+    assert e.value.description == (
+        "Only SubmitStructureResponse messages are supported. "
+        "Found: SubmitStructureRequest."
+    )
+
+
+def test_query_registration_response_not_implemented(
+    query_registration_response_path,
+):
+    with pytest.raises(NotImplemented, match="QueryRegistrationResponse"):
+        read_sdmx(query_registration_response_path, validate=True)
+
+
 def test_error_304(error_304_path):
     input_str, read_format = process_string_to_read(error_304_path)
     assert read_format == Format.ERROR_SDMX_ML_2_1
@@ -430,6 +488,16 @@ def test_error_304(error_304_path):
     )
 
     assert e.value.description == reference_title
+
+
+def test_error_message_mentioning_structures(error_structure_text_path):
+    input_str, read_format = process_string_to_read(error_structure_text_path)
+    assert read_format == Format.ERROR_SDMX_ML_2_1
+    with pytest.raises(Invalid) as e:
+        read_error(input_str, validate=False)
+    assert e.value.description == (
+        "140: Syntax error: cannot parse element str:Structures"
+    )
 
 
 def test_error_message_with_different_mode(agency_scheme_path):


### PR DESCRIPTION
Fixes #681

## Changes

- `__get_sdmx_ml_flavour` now checks the `:registryinterface` and `:error` root-element tokens before the looser `:structure`/`:generic` substrings, so `RegistryInterface` and `Error` documents are routed to the right reader (previously a `RegistryInterface` with `<str:Structures>` near the top was misrouted and crashed with a bare `StopIteration`).
- The SDMX-ML 2.1 submission reader raises `NotImplemented` when a `RegistryInterface` message contains anything other than a `SubmitStructureResponse` (e.g. `SubmitStructureRequest`, `QueryRegistrationResponse`), instead of `KeyError`.
- Submission responses containing a single `SubmissionResult` are now parsed (previously `TypeError`, as xmltodict returns a dict instead of a list for a lone element).

New test samples include the wiki's verbatim `SubmitStructureRequest` transaction response and a live `QueryRegistrationResponse` from IMF SDMX Central.

## Verification

```python
from pysdmx.io import read_sdmx

read_sdmx(
    "tests/io/xml/sdmx21/reader/samples/registry_submit_structure_request.xml"
)
# Before: StopIteration (bare)
# After: NotImplemented: Unsupported RegistryInterface content:
#   Only SubmitStructureResponse messages are supported.
#   Found: SubmitStructureRequest.

read_sdmx(
    "tests/io/xml/sdmx21/reader/samples/submission_append_single.xml"
).submission
# Before: TypeError: string indices must be integers
# After: [SubmissionResult(action='Append',
#   short_urn='DataStructure=BIS:BIS_DER(1.0)', status='Success')]
```
